### PR TITLE
Make visitors and plugin return `CodamaResult<()>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,7 @@ version = "0.1.0"
 dependencies = [
  "cargo_toml",
  "codama-attributes",
+ "codama-errors",
  "codama-koroks",
  "codama-nodes",
  "codama-stores",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,8 +54,10 @@ dependencies = [
 name = "codama-korok-plugins"
 version = "0.1.0"
 dependencies = [
+ "codama-errors",
  "codama-korok-visitors",
  "codama-koroks",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,7 +57,6 @@ dependencies = [
  "codama-errors",
  "codama-korok-visitors",
  "codama-koroks",
- "syn",
 ]
 
 [[package]]

--- a/codama-korok-plugins/Cargo.toml
+++ b/codama-korok-plugins/Cargo.toml
@@ -7,4 +7,3 @@ edition = "2021"
 codama-errors = { path = "../codama-errors" }
 codama-koroks = { path = "../codama-koroks" }
 codama-korok-visitors = { path = "../codama-korok-visitors" }
-syn = { version = "2.0", features = ["extra-traits", "full"] }

--- a/codama-korok-plugins/Cargo.toml
+++ b/codama-korok-plugins/Cargo.toml
@@ -4,5 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+codama-errors = { path = "../codama-errors" }
 codama-koroks = { path = "../codama-koroks" }
 codama-korok-visitors = { path = "../codama-korok-visitors" }
+syn = { version = "2.0", features = ["extra-traits", "full"] }

--- a/codama-korok-plugins/src/default_plugin.rs
+++ b/codama-korok-plugins/src/default_plugin.rs
@@ -1,4 +1,5 @@
 use crate::KorokPlugin;
+use codama_errors::CodamaResult;
 use codama_korok_visitors::{
     ApplyCodamaTypeAttributesVisitor, CombineModulesVisitor, CombineTypesVisitor, ComposeVisitor,
     FilterItemsVisitor, KorokVisitable, SetAccountsVisitor, SetBorshTypesVisitor,
@@ -8,9 +9,14 @@ use codama_koroks::KorokTrait;
 
 pub struct DefaultPlugin;
 impl KorokPlugin for DefaultPlugin {
-    fn run(&self, visitable: &mut dyn KorokVisitable, next: &dyn Fn(&mut dyn KorokVisitable)) {
-        next(visitable);
-        visitable.accept(&mut get_default_visitor());
+    fn run(
+        &self,
+        visitable: &mut dyn KorokVisitable,
+        next: &dyn Fn(&mut dyn KorokVisitable) -> CodamaResult<()>,
+    ) -> CodamaResult<()> {
+        next(visitable)?;
+        visitable.accept(&mut get_default_visitor())?;
+        Ok(())
     }
 }
 

--- a/codama-korok-plugins/src/plugin.rs
+++ b/codama-korok-plugins/src/plugin.rs
@@ -1,7 +1,12 @@
+use codama_errors::CodamaResult;
 use codama_korok_visitors::KorokVisitable;
 
 pub trait KorokPlugin {
-    fn run(&self, visitable: &mut dyn KorokVisitable, next: &dyn Fn(&mut dyn KorokVisitable));
+    fn run(
+        &self,
+        visitable: &mut dyn KorokVisitable,
+        next: &dyn Fn(&mut dyn KorokVisitable) -> CodamaResult<()>,
+    ) -> CodamaResult<()>;
 }
 
 /// Reduce all plugins into a single function that runs them in sequence.
@@ -35,17 +40,17 @@ pub trait KorokPlugin {
 /// ```
 pub fn resolve_plugins<'a>(
     plugins: &'a [Box<dyn KorokPlugin + 'a>],
-) -> Box<dyn Fn(&mut dyn KorokVisitable) + 'a> {
+) -> Box<dyn Fn(&mut dyn KorokVisitable) -> CodamaResult<()> + 'a> {
     // We fold from the left to ensure that any code before the
     // `next` call is run before the previous plugin on the list.
     plugins.iter().fold(
         // Base case: a no-op `next` function.
-        Box::new(|_: &mut dyn KorokVisitable| {}) as Box<dyn Fn(&mut dyn KorokVisitable)>,
+        Box::new(|_: &mut dyn KorokVisitable| Ok(()))
+            as Box<dyn Fn(&mut dyn KorokVisitable) -> CodamaResult<()>>,
         // Wrap each plugin with a closure that calls the next plugin in the chain.
         |next, plugin| {
-            Box::new(move |visitable: &mut dyn KorokVisitable| {
-                plugin.run(visitable, &next);
-            }) as Box<dyn Fn(&mut dyn KorokVisitable)>
+            Box::new(move |visitable: &mut dyn KorokVisitable| plugin.run(visitable, &next))
+                as Box<dyn Fn(&mut dyn KorokVisitable) -> CodamaResult<()>>
         },
     )
 }
@@ -69,27 +74,34 @@ mod tests {
         }
     }
     impl KorokPlugin for LoggingPluging {
-        fn run(&self, visitable: &mut dyn KorokVisitable, next: &dyn Fn(&mut dyn KorokVisitable)) {
+        fn run(
+            &self,
+            visitable: &mut dyn KorokVisitable,
+            next: &dyn Fn(&mut dyn KorokVisitable) -> CodamaResult<()>,
+        ) -> CodamaResult<()> {
             self.logs
                 .borrow_mut()
                 .push(format!("Plugin {} - before", self.id));
-            next(visitable);
+            next(visitable)?;
             self.logs
                 .borrow_mut()
                 .push(format!("Plugin {} - after", self.id));
+            Ok(())
         }
     }
 
     struct MockVisitable;
     impl KorokVisitable for MockVisitable {
-        fn accept(&mut self, _visitor: &mut dyn KorokVisitor) {}
+        fn accept(&mut self, _visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+            Ok(())
+        }
         fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
             Vec::new()
         }
     }
 
     #[test]
-    fn test_resolve_plugins() {
+    fn test_resolve_plugins() -> CodamaResult<()> {
         let logs = Arc::new(RefCell::new(Vec::new()));
         let plugins: Vec<Box<dyn KorokPlugin>> = vec![
             Box::new(LoggingPluging::new("A", logs.clone())),
@@ -97,7 +109,7 @@ mod tests {
         ];
 
         let run_plugins = resolve_plugins(&plugins);
-        run_plugins(&mut MockVisitable);
+        run_plugins(&mut MockVisitable)?;
 
         assert_eq!(
             logs.borrow().as_slice(),
@@ -108,5 +120,6 @@ mod tests {
                 "Plugin B - after",
             ]
         );
+        Ok(())
     }
 }

--- a/codama-korok-plugins/src/plugin.rs
+++ b/codama-korok-plugins/src/plugin.rs
@@ -14,15 +14,17 @@ pub trait KorokPlugin {
 /// For instance, imagine we have a list of plugins [A, B, C] implemented as:
 ///
 /// ```rust
+/// use codama_errors::CodamaResult;
 /// use codama_korok_plugins::KorokPlugin;
 /// use codama_korok_visitors::KorokVisitable;
 ///
 /// struct LoggingPluging;
 /// impl KorokPlugin for LoggingPluging {
-///     fn run(&self, visitable: &mut dyn KorokVisitable, next: &dyn Fn(&mut dyn KorokVisitable)) {
+///     fn run(&self, visitable: &mut dyn KorokVisitable, next: &dyn Fn(&mut dyn KorokVisitable) -> CodamaResult<()>) -> CodamaResult<()> {
 ///         println!("Plugin X - before");
-///         next(visitable);
+///         next(visitable)?;
 ///         println!("Plugin X - after");
+///         Ok(())
 ///     }
 /// }
 /// ```

--- a/codama-korok-plugins/src/plugin.rs
+++ b/codama-korok-plugins/src/plugin.rs
@@ -94,7 +94,7 @@ mod tests {
 
     struct MockVisitable;
     impl KorokVisitable for MockVisitable {
-        fn accept(&mut self, _visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+        fn accept(&mut self, _visitor: &mut dyn KorokVisitor) -> CodamaResult<()> {
             Ok(())
         }
         fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {

--- a/codama-korok-visitors/Cargo.toml
+++ b/codama-korok-visitors/Cargo.toml
@@ -11,6 +11,7 @@ codama-stores = { path = "../codama-stores" }
 [dependencies]
 cargo_toml = "0.20"
 codama-attributes = { path = "../codama-attributes" }
+codama-errors = { path = "../codama-errors" }
 codama-nodes = { path = "../codama-nodes" }
 codama-koroks = { path = "../codama-koroks" }
 codama-syn-helpers = { path = "../codama-syn-helpers" }

--- a/codama-korok-visitors/src/apply_codama_type_attributes_visitor.rs
+++ b/codama-korok-visitors/src/apply_codama_type_attributes_visitor.rs
@@ -19,55 +19,62 @@ impl ApplyCodamaTypeAttributesVisitor {
 }
 
 impl KorokVisitor for ApplyCodamaTypeAttributesVisitor {
-    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) {
-        self.visit_children(korok);
+    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) -> syn::Result<()> {
+        self.visit_children(korok)?;
+        Ok(())
     }
 
-    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) {
-        self.visit_children(korok);
-        apply_codama_attributes(korok.into());
+    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) -> syn::Result<()> {
+        self.visit_children(korok)?;
+        apply_codama_attributes(korok.into())
     }
 
-    fn visit_file_module(&mut self, korok: &mut codama_koroks::FileModuleKorok) {
-        self.visit_children(korok);
-        apply_codama_attributes(korok.into());
+    fn visit_file_module(&mut self, korok: &mut codama_koroks::FileModuleKorok) -> syn::Result<()> {
+        self.visit_children(korok)?;
+        apply_codama_attributes(korok.into())
     }
 
-    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) {
-        self.visit_children(korok);
-        apply_codama_attributes(korok.into());
+    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) -> syn::Result<()> {
+        self.visit_children(korok)?;
+        apply_codama_attributes(korok.into())
     }
 
-    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) {
-        self.visit_children(korok);
-        apply_codama_attributes(korok.into());
+    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) -> syn::Result<()> {
+        self.visit_children(korok)?;
+        apply_codama_attributes(korok.into())
     }
 
-    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) {
-        self.visit_children(korok);
-        apply_codama_attributes(korok.into());
+    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) -> syn::Result<()> {
+        self.visit_children(korok)?;
+        apply_codama_attributes(korok.into())
     }
 
-    fn visit_unsupported_item(&mut self, korok: &mut codama_koroks::UnsupportedItemKorok) {
-        self.visit_children(korok);
-        apply_codama_attributes(korok.into());
+    fn visit_unsupported_item(
+        &mut self,
+        korok: &mut codama_koroks::UnsupportedItemKorok,
+    ) -> syn::Result<()> {
+        self.visit_children(korok)?;
+        apply_codama_attributes(korok.into())
     }
 
-    fn visit_enum_variant(&mut self, korok: &mut codama_koroks::EnumVariantKorok) {
-        self.visit_children(korok);
-        apply_codama_attributes(korok.into());
+    fn visit_enum_variant(
+        &mut self,
+        korok: &mut codama_koroks::EnumVariantKorok,
+    ) -> syn::Result<()> {
+        self.visit_children(korok)?;
+        apply_codama_attributes(korok.into())
     }
 
-    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) {
-        self.visit_children(korok);
-        apply_codama_attributes(korok.into());
+    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) -> syn::Result<()> {
+        self.visit_children(korok)?;
+        apply_codama_attributes(korok.into())
     }
 }
 
 /// Apply codama attributes to the node from the bottom up.
-fn apply_codama_attributes(mut korok: KorokMut) {
+fn apply_codama_attributes(mut korok: KorokMut) -> syn::Result<()> {
     let Some(attributes) = korok.attributes() else {
-        return;
+        return Ok(());
     };
 
     let node = attributes
@@ -81,6 +88,7 @@ fn apply_codama_attributes(mut korok: KorokMut) {
         });
 
     korok.set_node(node);
+    Ok(())
 }
 
 fn apply_codama_attribute(

--- a/codama-korok-visitors/src/apply_codama_type_attributes_visitor.rs
+++ b/codama-korok-visitors/src/apply_codama_type_attributes_visitor.rs
@@ -3,6 +3,7 @@ use codama_attributes::{
     Attribute, CodamaAttribute, CodamaDirective, EncodingDirective, FixedSizeDirective,
     SizePrefixDirective, TypeDirective,
 };
+use codama_errors::CodamaResult;
 use codama_koroks::{KorokMut, KorokTrait};
 use codama_nodes::{
     FixedSizeTypeNode, NestedTypeLeaf, NestedTypeNode, NestedTypeNodeTrait, Node,
@@ -19,32 +20,35 @@ impl ApplyCodamaTypeAttributesVisitor {
 }
 
 impl KorokVisitor for ApplyCodamaTypeAttributesVisitor {
-    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) -> syn::Result<()> {
+    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) -> CodamaResult<()> {
         self.visit_children(korok)?;
         Ok(())
     }
 
-    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) -> syn::Result<()> {
+    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) -> CodamaResult<()> {
         self.visit_children(korok)?;
         apply_codama_attributes(korok.into())
     }
 
-    fn visit_file_module(&mut self, korok: &mut codama_koroks::FileModuleKorok) -> syn::Result<()> {
+    fn visit_file_module(
+        &mut self,
+        korok: &mut codama_koroks::FileModuleKorok,
+    ) -> CodamaResult<()> {
         self.visit_children(korok)?;
         apply_codama_attributes(korok.into())
     }
 
-    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) -> syn::Result<()> {
+    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) -> CodamaResult<()> {
         self.visit_children(korok)?;
         apply_codama_attributes(korok.into())
     }
 
-    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) -> syn::Result<()> {
+    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) -> CodamaResult<()> {
         self.visit_children(korok)?;
         apply_codama_attributes(korok.into())
     }
 
-    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) -> syn::Result<()> {
+    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) -> CodamaResult<()> {
         self.visit_children(korok)?;
         apply_codama_attributes(korok.into())
     }
@@ -52,7 +56,7 @@ impl KorokVisitor for ApplyCodamaTypeAttributesVisitor {
     fn visit_unsupported_item(
         &mut self,
         korok: &mut codama_koroks::UnsupportedItemKorok,
-    ) -> syn::Result<()> {
+    ) -> CodamaResult<()> {
         self.visit_children(korok)?;
         apply_codama_attributes(korok.into())
     }
@@ -60,19 +64,19 @@ impl KorokVisitor for ApplyCodamaTypeAttributesVisitor {
     fn visit_enum_variant(
         &mut self,
         korok: &mut codama_koroks::EnumVariantKorok,
-    ) -> syn::Result<()> {
+    ) -> CodamaResult<()> {
         self.visit_children(korok)?;
         apply_codama_attributes(korok.into())
     }
 
-    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) -> syn::Result<()> {
+    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) -> CodamaResult<()> {
         self.visit_children(korok)?;
         apply_codama_attributes(korok.into())
     }
 }
 
 /// Apply codama attributes to the node from the bottom up.
-fn apply_codama_attributes(mut korok: KorokMut) -> syn::Result<()> {
+fn apply_codama_attributes(mut korok: KorokMut) -> CodamaResult<()> {
     let Some(attributes) = korok.attributes() else {
         return Ok(());
     };

--- a/codama-korok-visitors/src/combine_modules_visitor.rs
+++ b/codama-korok-visitors/src/combine_modules_visitor.rs
@@ -12,24 +12,28 @@ impl CombineModulesVisitor {
 }
 
 impl KorokVisitor for CombineModulesVisitor {
-    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) {
-        self.visit_children(korok);
+    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) -> syn::Result<()> {
+        self.visit_children(korok)?;
         korok.node = combine_koroks(&korok.node, &korok.crates);
+        Ok(())
     }
 
-    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) {
-        self.visit_children(korok);
+    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) -> syn::Result<()> {
+        self.visit_children(korok)?;
         korok.node = combine_koroks(&korok.node, &korok.items);
+        Ok(())
     }
 
-    fn visit_file_module(&mut self, korok: &mut codama_koroks::FileModuleKorok) {
-        self.visit_children(korok);
+    fn visit_file_module(&mut self, korok: &mut codama_koroks::FileModuleKorok) -> syn::Result<()> {
+        self.visit_children(korok)?;
         korok.node = combine_koroks(&korok.node, &korok.items);
+        Ok(())
     }
 
-    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) {
-        self.visit_children(korok);
+    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) -> syn::Result<()> {
+        self.visit_children(korok)?;
         korok.node = combine_koroks(&korok.node, &korok.items);
+        Ok(())
     }
 }
 

--- a/codama-korok-visitors/src/combine_modules_visitor.rs
+++ b/codama-korok-visitors/src/combine_modules_visitor.rs
@@ -1,4 +1,5 @@
 use crate::KorokVisitor;
+use codama_errors::CodamaResult;
 use codama_koroks::KorokTrait;
 use codama_nodes::{Node, ProgramNode, RootNode};
 
@@ -12,25 +13,28 @@ impl CombineModulesVisitor {
 }
 
 impl KorokVisitor for CombineModulesVisitor {
-    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) -> syn::Result<()> {
+    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) -> CodamaResult<()> {
         self.visit_children(korok)?;
         korok.node = combine_koroks(&korok.node, &korok.crates);
         Ok(())
     }
 
-    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) -> syn::Result<()> {
+    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) -> CodamaResult<()> {
         self.visit_children(korok)?;
         korok.node = combine_koroks(&korok.node, &korok.items);
         Ok(())
     }
 
-    fn visit_file_module(&mut self, korok: &mut codama_koroks::FileModuleKorok) -> syn::Result<()> {
+    fn visit_file_module(
+        &mut self,
+        korok: &mut codama_koroks::FileModuleKorok,
+    ) -> CodamaResult<()> {
         self.visit_children(korok)?;
         korok.node = combine_koroks(&korok.node, &korok.items);
         Ok(())
     }
 
-    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) -> syn::Result<()> {
+    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) -> CodamaResult<()> {
         self.visit_children(korok)?;
         korok.node = combine_koroks(&korok.node, &korok.items);
         Ok(())

--- a/codama-korok-visitors/src/combine_types_visitor.rs
+++ b/codama-korok-visitors/src/combine_types_visitor.rs
@@ -1,4 +1,5 @@
 use crate::KorokVisitor;
+use codama_errors::CodamaResult;
 use codama_nodes::{
     DefinedTypeNode, EnumEmptyVariantTypeNode, EnumStructVariantTypeNode, EnumTupleVariantTypeNode,
     EnumTypeNode, EnumVariantTypeNode, Node, RegisteredTypeNode, StructTypeNode, TupleTypeNode,
@@ -18,7 +19,7 @@ impl CombineTypesVisitor {
 }
 
 impl KorokVisitor for CombineTypesVisitor {
-    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) -> syn::Result<()> {
+    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) -> CodamaResult<()> {
         self.visit_children(korok)?;
         if korok.node.is_some() && !self.r#override {
             return Ok(());
@@ -35,7 +36,7 @@ impl KorokVisitor for CombineTypesVisitor {
         Ok(())
     }
 
-    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) -> syn::Result<()> {
+    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) -> CodamaResult<()> {
         self.visit_children(korok)?;
         if korok.node.is_some() && !self.r#override {
             return Ok(());
@@ -71,7 +72,7 @@ impl KorokVisitor for CombineTypesVisitor {
     fn visit_enum_variant(
         &mut self,
         korok: &mut codama_koroks::EnumVariantKorok,
-    ) -> syn::Result<()> {
+    ) -> CodamaResult<()> {
         self.visit_children(korok)?;
         if korok.node.is_some() && !self.r#override {
             return Ok(());
@@ -113,7 +114,7 @@ impl KorokVisitor for CombineTypesVisitor {
         Ok(())
     }
 
-    fn visit_fields(&mut self, korok: &mut codama_koroks::FieldsKorok) -> syn::Result<()> {
+    fn visit_fields(&mut self, korok: &mut codama_koroks::FieldsKorok) -> CodamaResult<()> {
         self.visit_children(korok)?;
         if korok.node.is_some() && !self.r#override {
             return Ok(());

--- a/codama-korok-visitors/src/combine_types_visitor.rs
+++ b/codama-korok-visitors/src/combine_types_visitor.rs
@@ -18,10 +18,10 @@ impl CombineTypesVisitor {
 }
 
 impl KorokVisitor for CombineTypesVisitor {
-    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) {
-        self.visit_children(korok);
+    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) -> syn::Result<()> {
+        self.visit_children(korok)?;
         if korok.node.is_some() && !self.r#override {
-            return;
+            return Ok(());
         }
 
         let name = korok.ast.ident.to_string();
@@ -31,18 +31,19 @@ impl KorokVisitor for CombineTypesVisitor {
             }
             Ok(type_node) => Some(DefinedTypeNode::new(name, type_node).into()),
             Err(_) => None,
-        }
+        };
+        Ok(())
     }
 
-    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) {
-        self.visit_children(korok);
+    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) -> syn::Result<()> {
+        self.visit_children(korok)?;
         if korok.node.is_some() && !self.r#override {
-            return;
+            return Ok(());
         }
 
         // Ensure all variants have nodes.
         if !korok.variants.iter().all(|field| field.node.is_some()) {
-            return;
+            return Ok(());
         }
 
         let enum_name = korok.ast.ident.to_string();
@@ -64,12 +65,16 @@ impl KorokVisitor for CombineTypesVisitor {
             .collect::<Vec<_>>();
 
         korok.node = Some(DefinedTypeNode::new(enum_name, EnumTypeNode::new(variants)).into());
+        Ok(())
     }
 
-    fn visit_enum_variant(&mut self, korok: &mut codama_koroks::EnumVariantKorok) {
-        self.visit_children(korok);
+    fn visit_enum_variant(
+        &mut self,
+        korok: &mut codama_koroks::EnumVariantKorok,
+    ) -> syn::Result<()> {
+        self.visit_children(korok)?;
         if korok.node.is_some() && !self.r#override {
-            return;
+            return Ok(());
         }
 
         let variant_name = korok.ast.ident.to_string();
@@ -104,18 +109,19 @@ impl KorokVisitor for CombineTypesVisitor {
                 .into(),
             ),
             _ => None,
-        }
+        };
+        Ok(())
     }
 
-    fn visit_fields(&mut self, korok: &mut codama_koroks::FieldsKorok) {
-        self.visit_children(korok);
+    fn visit_fields(&mut self, korok: &mut codama_koroks::FieldsKorok) -> syn::Result<()> {
+        self.visit_children(korok)?;
         if korok.node.is_some() && !self.r#override {
-            return;
+            return Ok(());
         }
 
         // Ensure all fields have nodes.
         if !korok.all.iter().all(|field| field.node.is_some()) {
-            return;
+            return Ok(());
         }
 
         korok.node = match &korok.ast {
@@ -142,5 +148,6 @@ impl KorokVisitor for CombineTypesVisitor {
             }
             syn::Fields::Unit => None,
         };
+        Ok(())
     }
 }

--- a/codama-korok-visitors/src/compose_visitor.rs
+++ b/codama-korok-visitors/src/compose_visitor.rs
@@ -1,4 +1,4 @@
-use codama_errors::IteratorCombineErrors;
+use codama_errors::{CodamaResult, IteratorCombineErrors};
 
 use crate::KorokVisitor;
 
@@ -21,7 +21,7 @@ impl<'a> ComposeVisitor<'a> {
 }
 
 impl KorokVisitor for ComposeVisitor<'_> {
-    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) -> syn::Result<()> {
+    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) -> CodamaResult<()> {
         self.visitors
             .iter_mut()
             .map(|v| v.visit_root(korok))
@@ -29,7 +29,7 @@ impl KorokVisitor for ComposeVisitor<'_> {
         Ok(())
     }
 
-    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) -> syn::Result<()> {
+    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) -> CodamaResult<()> {
         self.visitors
             .iter_mut()
             .map(|v| v.visit_crate(korok))
@@ -37,7 +37,7 @@ impl KorokVisitor for ComposeVisitor<'_> {
         Ok(())
     }
 
-    fn visit_item(&mut self, korok: &mut codama_koroks::ItemKorok) -> syn::Result<()> {
+    fn visit_item(&mut self, korok: &mut codama_koroks::ItemKorok) -> CodamaResult<()> {
         self.visitors
             .iter_mut()
             .map(|v| v.visit_item(korok))
@@ -45,7 +45,10 @@ impl KorokVisitor for ComposeVisitor<'_> {
         Ok(())
     }
 
-    fn visit_file_module(&mut self, korok: &mut codama_koroks::FileModuleKorok) -> syn::Result<()> {
+    fn visit_file_module(
+        &mut self,
+        korok: &mut codama_koroks::FileModuleKorok,
+    ) -> CodamaResult<()> {
         self.visitors
             .iter_mut()
             .map(|v| v.visit_file_module(korok))
@@ -53,7 +56,7 @@ impl KorokVisitor for ComposeVisitor<'_> {
         Ok(())
     }
 
-    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) -> syn::Result<()> {
+    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) -> CodamaResult<()> {
         self.visitors
             .iter_mut()
             .map(|v| v.visit_module(korok))
@@ -61,7 +64,7 @@ impl KorokVisitor for ComposeVisitor<'_> {
         Ok(())
     }
 
-    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) -> syn::Result<()> {
+    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) -> CodamaResult<()> {
         self.visitors
             .iter_mut()
             .map(|v| v.visit_struct(korok))
@@ -69,7 +72,7 @@ impl KorokVisitor for ComposeVisitor<'_> {
         Ok(())
     }
 
-    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) -> syn::Result<()> {
+    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) -> CodamaResult<()> {
         self.visitors
             .iter_mut()
             .map(|v| v.visit_enum(korok))
@@ -80,7 +83,7 @@ impl KorokVisitor for ComposeVisitor<'_> {
     fn visit_enum_variant(
         &mut self,
         korok: &mut codama_koroks::EnumVariantKorok,
-    ) -> syn::Result<()> {
+    ) -> CodamaResult<()> {
         self.visitors
             .iter_mut()
             .map(|v| v.visit_enum_variant(korok))
@@ -91,7 +94,7 @@ impl KorokVisitor for ComposeVisitor<'_> {
     fn visit_unsupported_item(
         &mut self,
         korok: &mut codama_koroks::UnsupportedItemKorok,
-    ) -> syn::Result<()> {
+    ) -> CodamaResult<()> {
         self.visitors
             .iter_mut()
             .map(|v| v.visit_unsupported_item(korok))
@@ -99,7 +102,7 @@ impl KorokVisitor for ComposeVisitor<'_> {
         Ok(())
     }
 
-    fn visit_fields(&mut self, korok: &mut codama_koroks::FieldsKorok) -> syn::Result<()> {
+    fn visit_fields(&mut self, korok: &mut codama_koroks::FieldsKorok) -> CodamaResult<()> {
         self.visitors
             .iter_mut()
             .map(|v| v.visit_fields(korok))
@@ -107,7 +110,7 @@ impl KorokVisitor for ComposeVisitor<'_> {
         Ok(())
     }
 
-    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) -> syn::Result<()> {
+    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) -> CodamaResult<()> {
         self.visitors
             .iter_mut()
             .map(|v| v.visit_field(korok))

--- a/codama-korok-visitors/src/compose_visitor.rs
+++ b/codama-korok-visitors/src/compose_visitor.rs
@@ -1,3 +1,5 @@
+use codama_errors::IteratorCombineErrors;
+
 use crate::KorokVisitor;
 
 /// Compose multiple visitors into one.
@@ -19,69 +21,97 @@ impl<'a> ComposeVisitor<'a> {
 }
 
 impl KorokVisitor for ComposeVisitor<'_> {
-    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) {
-        for visitor in &mut self.visitors {
-            visitor.visit_root(korok);
-        }
+    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) -> syn::Result<()> {
+        self.visitors
+            .iter_mut()
+            .map(|v| v.visit_root(korok))
+            .collect_and_combine_errors()?;
+        Ok(())
     }
 
-    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) {
-        for visitor in &mut self.visitors {
-            visitor.visit_crate(korok);
-        }
+    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) -> syn::Result<()> {
+        self.visitors
+            .iter_mut()
+            .map(|v| v.visit_crate(korok))
+            .collect_and_combine_errors()?;
+        Ok(())
     }
 
-    fn visit_item(&mut self, korok: &mut codama_koroks::ItemKorok) {
-        for visitor in &mut self.visitors {
-            visitor.visit_item(korok);
-        }
+    fn visit_item(&mut self, korok: &mut codama_koroks::ItemKorok) -> syn::Result<()> {
+        self.visitors
+            .iter_mut()
+            .map(|v| v.visit_item(korok))
+            .collect_and_combine_errors()?;
+        Ok(())
     }
 
-    fn visit_file_module(&mut self, korok: &mut codama_koroks::FileModuleKorok) {
-        for visitor in &mut self.visitors {
-            visitor.visit_file_module(korok);
-        }
+    fn visit_file_module(&mut self, korok: &mut codama_koroks::FileModuleKorok) -> syn::Result<()> {
+        self.visitors
+            .iter_mut()
+            .map(|v| v.visit_file_module(korok))
+            .collect_and_combine_errors()?;
+        Ok(())
     }
 
-    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) {
-        for visitor in &mut self.visitors {
-            visitor.visit_module(korok);
-        }
+    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) -> syn::Result<()> {
+        self.visitors
+            .iter_mut()
+            .map(|v| v.visit_module(korok))
+            .collect_and_combine_errors()?;
+        Ok(())
     }
 
-    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) {
-        for visitor in &mut self.visitors {
-            visitor.visit_struct(korok);
-        }
+    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) -> syn::Result<()> {
+        self.visitors
+            .iter_mut()
+            .map(|v| v.visit_struct(korok))
+            .collect_and_combine_errors()?;
+        Ok(())
     }
 
-    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) {
-        for visitor in &mut self.visitors {
-            visitor.visit_enum(korok);
-        }
+    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) -> syn::Result<()> {
+        self.visitors
+            .iter_mut()
+            .map(|v| v.visit_enum(korok))
+            .collect_and_combine_errors()?;
+        Ok(())
     }
 
-    fn visit_enum_variant(&mut self, korok: &mut codama_koroks::EnumVariantKorok) {
-        for visitor in &mut self.visitors {
-            visitor.visit_enum_variant(korok);
-        }
+    fn visit_enum_variant(
+        &mut self,
+        korok: &mut codama_koroks::EnumVariantKorok,
+    ) -> syn::Result<()> {
+        self.visitors
+            .iter_mut()
+            .map(|v| v.visit_enum_variant(korok))
+            .collect_and_combine_errors()?;
+        Ok(())
     }
 
-    fn visit_unsupported_item(&mut self, korok: &mut codama_koroks::UnsupportedItemKorok) {
-        for visitor in &mut self.visitors {
-            visitor.visit_unsupported_item(korok);
-        }
+    fn visit_unsupported_item(
+        &mut self,
+        korok: &mut codama_koroks::UnsupportedItemKorok,
+    ) -> syn::Result<()> {
+        self.visitors
+            .iter_mut()
+            .map(|v| v.visit_unsupported_item(korok))
+            .collect_and_combine_errors()?;
+        Ok(())
     }
 
-    fn visit_fields(&mut self, korok: &mut codama_koroks::FieldsKorok) {
-        for visitor in &mut self.visitors {
-            visitor.visit_fields(korok);
-        }
+    fn visit_fields(&mut self, korok: &mut codama_koroks::FieldsKorok) -> syn::Result<()> {
+        self.visitors
+            .iter_mut()
+            .map(|v| v.visit_fields(korok))
+            .collect_and_combine_errors()?;
+        Ok(())
     }
 
-    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) {
-        for visitor in &mut self.visitors {
-            visitor.visit_field(korok);
-        }
+    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) -> syn::Result<()> {
+        self.visitors
+            .iter_mut()
+            .map(|v| v.visit_field(korok))
+            .collect_and_combine_errors()?;
+        Ok(())
     }
 }

--- a/codama-korok-visitors/src/filter_items_visitor.rs
+++ b/codama-korok-visitors/src/filter_items_visitor.rs
@@ -1,4 +1,5 @@
 use crate::KorokVisitor;
+use codama_errors::CodamaResult;
 use codama_koroks::ItemKorok;
 
 pub struct FilterItemsVisitor<'a, F>
@@ -25,7 +26,7 @@ impl<F> KorokVisitor for FilterItemsVisitor<'_, F>
 where
     F: Fn(&ItemKorok) -> bool,
 {
-    fn visit_item(&mut self, korok: &mut codama_koroks::ItemKorok) -> syn::Result<()> {
+    fn visit_item(&mut self, korok: &mut codama_koroks::ItemKorok) -> CodamaResult<()> {
         if (self.filter)(korok) {
             self.visitor.visit_item(korok)
         } else {

--- a/codama-korok-visitors/src/filter_items_visitor.rs
+++ b/codama-korok-visitors/src/filter_items_visitor.rs
@@ -25,11 +25,11 @@ impl<F> KorokVisitor for FilterItemsVisitor<'_, F>
 where
     F: Fn(&ItemKorok) -> bool,
 {
-    fn visit_item(&mut self, korok: &mut codama_koroks::ItemKorok) {
+    fn visit_item(&mut self, korok: &mut codama_koroks::ItemKorok) -> syn::Result<()> {
         if (self.filter)(korok) {
-            self.visitor.visit_item(korok);
+            self.visitor.visit_item(korok)
         } else {
-            self.visit_children(korok);
+            self.visit_children(korok)
         }
     }
 }

--- a/codama-korok-visitors/src/set_accounts_visitor.rs
+++ b/codama-korok-visitors/src/set_accounts_visitor.rs
@@ -1,4 +1,5 @@
 use crate::KorokVisitor;
+use codama_errors::CodamaResult;
 use codama_nodes::{AccountNode, NestedTypeNode, Node, StructTypeNode};
 
 #[derive(Default)]
@@ -11,7 +12,7 @@ impl SetAccountsVisitor {
 }
 
 impl KorokVisitor for SetAccountsVisitor {
-    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) -> syn::Result<()> {
+    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) -> CodamaResult<()> {
         self.visit_children(korok)?;
 
         // Ensure the struct has the `CodamaAccount` attribute.
@@ -48,7 +49,7 @@ impl KorokVisitor for SetAccountsVisitor {
         Ok(())
     }
 
-    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) -> syn::Result<()> {
+    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) -> CodamaResult<()> {
         self.visit_children(korok)?;
 
         // Ensure the struct has the `CodamaAccount` attribute.

--- a/codama-korok-visitors/src/set_accounts_visitor.rs
+++ b/codama-korok-visitors/src/set_accounts_visitor.rs
@@ -11,25 +11,25 @@ impl SetAccountsVisitor {
 }
 
 impl KorokVisitor for SetAccountsVisitor {
-    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) {
-        self.visit_children(korok);
+    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) -> syn::Result<()> {
+        self.visit_children(korok)?;
 
         // Ensure the struct has the `CodamaAccount` attribute.
         if !korok.attributes.has_codama_derive("CodamaAccount") {
-            return;
+            return Ok(());
         };
 
         // Ensure the korok is already typed.
         let Some(Node::DefinedType(defined_type)) = &korok.node else {
             // TODO: Throw error?
-            return;
+            return Ok(());
         };
 
         // Ensure the data type is a struct.
         let Ok(data) = NestedTypeNode::<StructTypeNode>::try_from(defined_type.r#type.clone())
         else {
             // TODO: Throw error?
-            return;
+            return Ok(());
         };
 
         // Transform the defined type into an account node.
@@ -44,17 +44,20 @@ impl KorokVisitor for SetAccountsVisitor {
             }
             .into(),
         );
+
+        Ok(())
     }
 
-    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) {
-        self.visit_children(korok);
+    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) -> syn::Result<()> {
+        self.visit_children(korok)?;
 
         // Ensure the struct has the `CodamaAccount` attribute.
         if !korok.attributes.has_codama_derive("CodamaAccount") {
-            return;
+            return Ok(());
         };
 
         // TODO: Throw error?
-        korok.node = None
+        korok.node = None;
+        Ok(())
     }
 }

--- a/codama-korok-visitors/src/set_borsh_types_visitor.rs
+++ b/codama-korok-visitors/src/set_borsh_types_visitor.rs
@@ -1,4 +1,5 @@
 use crate::KorokVisitor;
+use codama_errors::CodamaResult;
 use codama_nodes::{
     ArrayTypeNode, BooleanTypeNode, FixedCountNode, MapTypeNode, NumberFormat::*, NumberTypeNode,
     PrefixedCountNode, PublicKeyTypeNode, SetTypeNode, SizePrefixTypeNode, StringTypeNode,
@@ -16,7 +17,7 @@ impl SetBorshTypesVisitor {
 }
 
 impl KorokVisitor for SetBorshTypesVisitor {
-    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) -> syn::Result<()> {
+    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) -> CodamaResult<()> {
         if korok.node.is_some() {
             return Ok(());
         }

--- a/codama-korok-visitors/src/set_borsh_types_visitor.rs
+++ b/codama-korok-visitors/src/set_borsh_types_visitor.rs
@@ -16,13 +16,14 @@ impl SetBorshTypesVisitor {
 }
 
 impl KorokVisitor for SetBorshTypesVisitor {
-    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) {
+    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) -> syn::Result<()> {
         if korok.node.is_some() {
-            return;
+            return Ok(());
         }
         if let Some(node) = self.get_type_node(&korok.ast.ty) {
             korok.set_type_node(node);
         }
+        Ok(())
     }
 }
 

--- a/codama-korok-visitors/src/set_link_types_visitor.rs
+++ b/codama-korok-visitors/src/set_link_types_visitor.rs
@@ -12,12 +12,13 @@ impl SetLinkTypesVisitor {
 }
 
 impl KorokVisitor for SetLinkTypesVisitor {
-    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) {
+    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) -> syn::Result<()> {
         if korok.node.is_some() {
-            return;
+            return Ok(());
         }
         if let syn::Type::Path(tp) = &korok.ast.ty {
             korok.set_type_node(DefinedTypeLinkNode::new(tp.path.last_str()).into())
         }
+        Ok(())
     }
 }

--- a/codama-korok-visitors/src/set_link_types_visitor.rs
+++ b/codama-korok-visitors/src/set_link_types_visitor.rs
@@ -1,4 +1,5 @@
 use crate::KorokVisitor;
+use codama_errors::CodamaResult;
 use codama_nodes::DefinedTypeLinkNode;
 use codama_syn_helpers::extensions::*;
 
@@ -12,7 +13,7 @@ impl SetLinkTypesVisitor {
 }
 
 impl KorokVisitor for SetLinkTypesVisitor {
-    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) -> syn::Result<()> {
+    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) -> CodamaResult<()> {
         if korok.node.is_some() {
             return Ok(());
         }

--- a/codama-korok-visitors/src/set_program_metadata_visitor.rs
+++ b/codama-korok-visitors/src/set_program_metadata_visitor.rs
@@ -18,8 +18,8 @@ impl SetProgramMetadataVisitor {
 }
 
 impl KorokVisitor for SetProgramMetadataVisitor {
-    fn visit_crate(&mut self, korok: &mut CrateKorok) {
-        self.visit_children(korok);
+    fn visit_crate(&mut self, korok: &mut CrateKorok) -> syn::Result<()> {
+        self.visit_children(korok)?;
 
         // Get a mutable reference to the program to update its metadata.
         let program = match &mut korok.node {
@@ -37,7 +37,7 @@ impl KorokVisitor for SetProgramMetadataVisitor {
                 }
             }
             // Don't update the node if it is set to anything else.
-            _ => return,
+            _ => return Ok(()),
         };
 
         // Update the program name using the Cargo.toml package name.
@@ -77,11 +77,13 @@ impl KorokVisitor for SetProgramMetadataVisitor {
                 program.public_key = public_key.into()
             }
         }
+
+        Ok(())
     }
 
-    fn visit_unsupported_item(&mut self, korok: &mut UnsupportedItemKorok) {
+    fn visit_unsupported_item(&mut self, korok: &mut UnsupportedItemKorok) -> syn::Result<()> {
         let syn::Item::Macro(syn::ItemMacro { mac, .. }) = korok.ast else {
-            return;
+            return Ok(());
         };
 
         if let ("" | "solana_program", "declare_id") =
@@ -89,6 +91,8 @@ impl KorokVisitor for SetProgramMetadataVisitor {
         {
             self.identified_public_key = Some(mac.tokens.to_string().replace("\"", ""));
         };
+
+        Ok(())
     }
 }
 

--- a/codama-korok-visitors/src/set_program_metadata_visitor.rs
+++ b/codama-korok-visitors/src/set_program_metadata_visitor.rs
@@ -1,4 +1,5 @@
 use cargo_toml::{Inheritable, Manifest, Package, Value};
+use codama_errors::CodamaResult;
 use codama_koroks::{CrateKorok, UnsupportedItemKorok};
 use codama_nodes::{Node, ProgramNode};
 use codama_syn_helpers::extensions::*;
@@ -18,7 +19,7 @@ impl SetProgramMetadataVisitor {
 }
 
 impl KorokVisitor for SetProgramMetadataVisitor {
-    fn visit_crate(&mut self, korok: &mut CrateKorok) -> syn::Result<()> {
+    fn visit_crate(&mut self, korok: &mut CrateKorok) -> CodamaResult<()> {
         self.visit_children(korok)?;
 
         // Get a mutable reference to the program to update its metadata.
@@ -81,7 +82,7 @@ impl KorokVisitor for SetProgramMetadataVisitor {
         Ok(())
     }
 
-    fn visit_unsupported_item(&mut self, korok: &mut UnsupportedItemKorok) -> syn::Result<()> {
+    fn visit_unsupported_item(&mut self, korok: &mut UnsupportedItemKorok) -> CodamaResult<()> {
         let syn::Item::Macro(syn::ItemMacro { mac, .. }) = korok.ast else {
             return Ok(());
         };

--- a/codama-korok-visitors/src/uniform_visitor.rs
+++ b/codama-korok-visitors/src/uniform_visitor.rs
@@ -3,57 +3,63 @@ use codama_koroks::KorokMut;
 
 /// Use the same callback function on all koroks visited.
 pub struct UniformVisitor {
-    pub callback: fn(korok: KorokMut, visitor: &mut Self),
+    pub callback: fn(korok: KorokMut, visitor: &mut Self) -> syn::Result<()>,
 }
 
 impl UniformVisitor {
-    pub fn new(callback: fn(korok: KorokMut, visitor: &mut Self)) -> Self {
+    pub fn new(callback: fn(korok: KorokMut, visitor: &mut Self) -> syn::Result<()>) -> Self {
         Self { callback }
     }
 }
 
 impl KorokVisitor for UniformVisitor {
-    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) {
-        (self.callback)(korok.into(), self);
+    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) -> syn::Result<()> {
+        (self.callback)(korok.into(), self)
     }
 
-    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) {
-        (self.callback)(korok.into(), self);
+    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) -> syn::Result<()> {
+        (self.callback)(korok.into(), self)
     }
 
-    fn visit_item(&mut self, korok: &mut codama_koroks::ItemKorok) {
-        (self.callback)(korok.into(), self);
+    fn visit_item(&mut self, korok: &mut codama_koroks::ItemKorok) -> syn::Result<()> {
+        (self.callback)(korok.into(), self)
     }
 
-    fn visit_file_module(&mut self, korok: &mut codama_koroks::FileModuleKorok) {
-        (self.callback)(korok.into(), self);
+    fn visit_file_module(&mut self, korok: &mut codama_koroks::FileModuleKorok) -> syn::Result<()> {
+        (self.callback)(korok.into(), self)
     }
 
-    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) {
-        (self.callback)(korok.into(), self);
+    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) -> syn::Result<()> {
+        (self.callback)(korok.into(), self)
     }
 
-    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) {
-        (self.callback)(korok.into(), self);
+    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) -> syn::Result<()> {
+        (self.callback)(korok.into(), self)
     }
 
-    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) {
-        (self.callback)(korok.into(), self);
+    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) -> syn::Result<()> {
+        (self.callback)(korok.into(), self)
     }
 
-    fn visit_enum_variant(&mut self, korok: &mut codama_koroks::EnumVariantKorok) {
-        (self.callback)(korok.into(), self);
+    fn visit_enum_variant(
+        &mut self,
+        korok: &mut codama_koroks::EnumVariantKorok,
+    ) -> syn::Result<()> {
+        (self.callback)(korok.into(), self)
     }
 
-    fn visit_unsupported_item(&mut self, korok: &mut codama_koroks::UnsupportedItemKorok) {
-        (self.callback)(korok.into(), self);
+    fn visit_unsupported_item(
+        &mut self,
+        korok: &mut codama_koroks::UnsupportedItemKorok,
+    ) -> syn::Result<()> {
+        (self.callback)(korok.into(), self)
     }
 
-    fn visit_fields(&mut self, korok: &mut codama_koroks::FieldsKorok) {
-        (self.callback)(korok.into(), self);
+    fn visit_fields(&mut self, korok: &mut codama_koroks::FieldsKorok) -> syn::Result<()> {
+        (self.callback)(korok.into(), self)
     }
 
-    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) {
-        (self.callback)(korok.into(), self);
+    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) -> syn::Result<()> {
+        (self.callback)(korok.into(), self)
     }
 }

--- a/codama-korok-visitors/src/uniform_visitor.rs
+++ b/codama-korok-visitors/src/uniform_visitor.rs
@@ -1,65 +1,69 @@
 use crate::KorokVisitor;
+use codama_errors::CodamaResult;
 use codama_koroks::KorokMut;
 
 /// Use the same callback function on all koroks visited.
 pub struct UniformVisitor {
-    pub callback: fn(korok: KorokMut, visitor: &mut Self) -> syn::Result<()>,
+    pub callback: fn(korok: KorokMut, visitor: &mut Self) -> CodamaResult<()>,
 }
 
 impl UniformVisitor {
-    pub fn new(callback: fn(korok: KorokMut, visitor: &mut Self) -> syn::Result<()>) -> Self {
+    pub fn new(callback: fn(korok: KorokMut, visitor: &mut Self) -> CodamaResult<()>) -> Self {
         Self { callback }
     }
 }
 
 impl KorokVisitor for UniformVisitor {
-    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) -> syn::Result<()> {
+    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) -> CodamaResult<()> {
         (self.callback)(korok.into(), self)
     }
 
-    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) -> syn::Result<()> {
+    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) -> CodamaResult<()> {
         (self.callback)(korok.into(), self)
     }
 
-    fn visit_item(&mut self, korok: &mut codama_koroks::ItemKorok) -> syn::Result<()> {
+    fn visit_item(&mut self, korok: &mut codama_koroks::ItemKorok) -> CodamaResult<()> {
         (self.callback)(korok.into(), self)
     }
 
-    fn visit_file_module(&mut self, korok: &mut codama_koroks::FileModuleKorok) -> syn::Result<()> {
+    fn visit_file_module(
+        &mut self,
+        korok: &mut codama_koroks::FileModuleKorok,
+    ) -> CodamaResult<()> {
         (self.callback)(korok.into(), self)
     }
 
-    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) -> syn::Result<()> {
+    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) -> CodamaResult<()> {
         (self.callback)(korok.into(), self)
     }
 
-    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) -> syn::Result<()> {
+    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) -> CodamaResult<()> {
         (self.callback)(korok.into(), self)
     }
 
-    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) -> syn::Result<()> {
+    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) -> CodamaResult<()> {
         (self.callback)(korok.into(), self)
     }
 
     fn visit_enum_variant(
         &mut self,
         korok: &mut codama_koroks::EnumVariantKorok,
-    ) -> syn::Result<()> {
+    ) -> CodamaResult<()> {
         (self.callback)(korok.into(), self)
     }
 
     fn visit_unsupported_item(
         &mut self,
         korok: &mut codama_koroks::UnsupportedItemKorok,
-    ) -> syn::Result<()> {
+    ) -> CodamaResult<()> {
         (self.callback)(korok.into(), self)
     }
 
-    fn visit_fields(&mut self, korok: &mut codama_koroks::FieldsKorok) -> syn::Result<()> {
+    fn visit_fields(&mut self, korok: &mut codama_koroks::FieldsKorok) -> CodamaResult<()> {
         (self.callback)(korok.into(), self)
     }
 
-    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) -> syn::Result<()> {
+    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) -> CodamaResult<()> {
         (self.callback)(korok.into(), self)
     }
 }

--- a/codama-korok-visitors/src/visitable.rs
+++ b/codama-korok-visitors/src/visitable.rs
@@ -1,12 +1,13 @@
 use crate::visitor::KorokVisitor;
+use codama_errors::CodamaResult;
 
 pub trait KorokVisitable {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()>;
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> CodamaResult<()>;
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable>;
 }
 
 impl KorokVisitable for codama_koroks::KorokMut<'_, '_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> CodamaResult<()> {
         match self {
             Self::Crate(k) => k.accept(visitor),
             Self::Enum(k) => k.accept(visitor),
@@ -40,7 +41,7 @@ impl KorokVisitable for codama_koroks::KorokMut<'_, '_> {
 }
 
 impl KorokVisitable for codama_koroks::RootKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> CodamaResult<()> {
         visitor.visit_root(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
@@ -52,7 +53,7 @@ impl KorokVisitable for codama_koroks::RootKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::CrateKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> CodamaResult<()> {
         visitor.visit_crate(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
@@ -64,7 +65,7 @@ impl KorokVisitable for codama_koroks::CrateKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::ItemKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> CodamaResult<()> {
         visitor.visit_item(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
@@ -79,7 +80,7 @@ impl KorokVisitable for codama_koroks::ItemKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::FileModuleKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> CodamaResult<()> {
         visitor.visit_file_module(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
@@ -91,7 +92,7 @@ impl KorokVisitable for codama_koroks::FileModuleKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::ModuleKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> CodamaResult<()> {
         visitor.visit_module(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
@@ -103,7 +104,7 @@ impl KorokVisitable for codama_koroks::ModuleKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::StructKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> CodamaResult<()> {
         visitor.visit_struct(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
@@ -112,7 +113,7 @@ impl KorokVisitable for codama_koroks::StructKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::FieldsKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> CodamaResult<()> {
         visitor.visit_fields(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
@@ -124,7 +125,7 @@ impl KorokVisitable for codama_koroks::FieldsKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::FieldKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> CodamaResult<()> {
         visitor.visit_field(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
@@ -133,7 +134,7 @@ impl KorokVisitable for codama_koroks::FieldKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::EnumKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> CodamaResult<()> {
         visitor.visit_enum(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
@@ -145,7 +146,7 @@ impl KorokVisitable for codama_koroks::EnumKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::EnumVariantKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> CodamaResult<()> {
         visitor.visit_enum_variant(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
@@ -154,7 +155,7 @@ impl KorokVisitable for codama_koroks::EnumVariantKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::UnsupportedItemKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> CodamaResult<()> {
         visitor.visit_unsupported_item(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {

--- a/codama-korok-visitors/src/visitable.rs
+++ b/codama-korok-visitors/src/visitable.rs
@@ -1,12 +1,12 @@
 use crate::visitor::KorokVisitor;
 
 pub trait KorokVisitable {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor);
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()>;
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable>;
 }
 
 impl KorokVisitable for codama_koroks::KorokMut<'_, '_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) {
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
         match self {
             Self::Crate(k) => k.accept(visitor),
             Self::Enum(k) => k.accept(visitor),
@@ -40,8 +40,8 @@ impl KorokVisitable for codama_koroks::KorokMut<'_, '_> {
 }
 
 impl KorokVisitable for codama_koroks::RootKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) {
-        visitor.visit_root(self);
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+        visitor.visit_root(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
         self.crates
@@ -52,8 +52,8 @@ impl KorokVisitable for codama_koroks::RootKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::CrateKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) {
-        visitor.visit_crate(self);
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+        visitor.visit_crate(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
         self.items
@@ -64,8 +64,8 @@ impl KorokVisitable for codama_koroks::CrateKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::ItemKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) {
-        visitor.visit_item(self);
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+        visitor.visit_item(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
         match self {
@@ -79,8 +79,8 @@ impl KorokVisitable for codama_koroks::ItemKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::FileModuleKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) {
-        visitor.visit_file_module(self);
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+        visitor.visit_file_module(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
         self.items
@@ -91,8 +91,8 @@ impl KorokVisitable for codama_koroks::FileModuleKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::ModuleKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) {
-        visitor.visit_module(self);
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+        visitor.visit_module(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
         self.items
@@ -103,8 +103,8 @@ impl KorokVisitable for codama_koroks::ModuleKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::StructKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) {
-        visitor.visit_struct(self);
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+        visitor.visit_struct(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
         vec![&mut self.fields as &mut dyn KorokVisitable]
@@ -112,8 +112,8 @@ impl KorokVisitable for codama_koroks::StructKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::FieldsKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) {
-        visitor.visit_fields(self);
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+        visitor.visit_fields(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
         self.all
@@ -124,8 +124,8 @@ impl KorokVisitable for codama_koroks::FieldsKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::FieldKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) {
-        visitor.visit_field(self);
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+        visitor.visit_field(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
         Vec::new()
@@ -133,8 +133,8 @@ impl KorokVisitable for codama_koroks::FieldKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::EnumKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) {
-        visitor.visit_enum(self);
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+        visitor.visit_enum(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
         self.variants
@@ -145,8 +145,8 @@ impl KorokVisitable for codama_koroks::EnumKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::EnumVariantKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) {
-        visitor.visit_enum_variant(self);
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+        visitor.visit_enum_variant(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
         vec![&mut self.fields as &mut dyn KorokVisitable]
@@ -154,8 +154,8 @@ impl KorokVisitable for codama_koroks::EnumVariantKorok<'_> {
 }
 
 impl KorokVisitable for codama_koroks::UnsupportedItemKorok<'_> {
-    fn accept(&mut self, visitor: &mut dyn KorokVisitor) {
-        visitor.visit_unsupported_item(self);
+    fn accept(&mut self, visitor: &mut dyn KorokVisitor) -> syn::Result<()> {
+        visitor.visit_unsupported_item(self)
     }
     fn get_children(&mut self) -> Vec<&mut dyn KorokVisitable> {
         Vec::new()

--- a/codama-korok-visitors/src/visitor.rs
+++ b/codama-korok-visitors/src/visitor.rs
@@ -1,8 +1,8 @@
 use crate::KorokVisitable;
-use codama_errors::IteratorCombineErrors;
+use codama_errors::{CodamaResult, IteratorCombineErrors};
 
 pub trait KorokVisitor {
-    fn visit_children(&mut self, korok: &mut dyn KorokVisitable) -> syn::Result<()>
+    fn visit_children(&mut self, korok: &mut dyn KorokVisitable) -> CodamaResult<()>
     where
         Self: Sized,
     {
@@ -14,7 +14,7 @@ pub trait KorokVisitor {
         Ok(())
     }
 
-    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) -> syn::Result<()> {
+    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) -> CodamaResult<()> {
         korok
             .crates
             .iter_mut()
@@ -23,7 +23,7 @@ pub trait KorokVisitor {
         Ok(())
     }
 
-    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) -> syn::Result<()> {
+    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) -> CodamaResult<()> {
         korok
             .items
             .iter_mut()
@@ -32,7 +32,7 @@ pub trait KorokVisitor {
         Ok(())
     }
 
-    fn visit_item(&mut self, korok: &mut codama_koroks::ItemKorok) -> syn::Result<()> {
+    fn visit_item(&mut self, korok: &mut codama_koroks::ItemKorok) -> CodamaResult<()> {
         match korok {
             codama_koroks::ItemKorok::FileModule(korok) => self.visit_file_module(korok),
             codama_koroks::ItemKorok::Module(korok) => self.visit_module(korok),
@@ -42,7 +42,10 @@ pub trait KorokVisitor {
         }
     }
 
-    fn visit_file_module(&mut self, korok: &mut codama_koroks::FileModuleKorok) -> syn::Result<()> {
+    fn visit_file_module(
+        &mut self,
+        korok: &mut codama_koroks::FileModuleKorok,
+    ) -> CodamaResult<()> {
         korok
             .items
             .iter_mut()
@@ -51,7 +54,7 @@ pub trait KorokVisitor {
         Ok(())
     }
 
-    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) -> syn::Result<()> {
+    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) -> CodamaResult<()> {
         korok
             .items
             .iter_mut()
@@ -60,11 +63,11 @@ pub trait KorokVisitor {
         Ok(())
     }
 
-    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) -> syn::Result<()> {
+    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) -> CodamaResult<()> {
         self.visit_fields(&mut korok.fields)
     }
 
-    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) -> syn::Result<()> {
+    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) -> CodamaResult<()> {
         korok
             .variants
             .iter_mut()
@@ -76,18 +79,18 @@ pub trait KorokVisitor {
     fn visit_enum_variant(
         &mut self,
         korok: &mut codama_koroks::EnumVariantKorok,
-    ) -> syn::Result<()> {
+    ) -> CodamaResult<()> {
         self.visit_fields(&mut korok.fields)
     }
 
     fn visit_unsupported_item(
         &mut self,
         _korok: &mut codama_koroks::UnsupportedItemKorok,
-    ) -> syn::Result<()> {
+    ) -> CodamaResult<()> {
         Ok(())
     }
 
-    fn visit_fields(&mut self, korok: &mut codama_koroks::FieldsKorok) -> syn::Result<()> {
+    fn visit_fields(&mut self, korok: &mut codama_koroks::FieldsKorok) -> CodamaResult<()> {
         korok
             .all
             .iter_mut()
@@ -96,7 +99,7 @@ pub trait KorokVisitor {
         Ok(())
     }
 
-    fn visit_field(&mut self, _korok: &mut codama_koroks::FieldKorok) -> syn::Result<()> {
+    fn visit_field(&mut self, _korok: &mut codama_koroks::FieldKorok) -> CodamaResult<()> {
         Ok(())
     }
 }

--- a/codama-korok-visitors/src/visitor.rs
+++ b/codama-korok-visitors/src/visitor.rs
@@ -1,28 +1,38 @@
 use crate::KorokVisitable;
+use codama_errors::IteratorCombineErrors;
 
 pub trait KorokVisitor {
-    fn visit_children(&mut self, korok: &mut dyn KorokVisitable)
+    fn visit_children(&mut self, korok: &mut dyn KorokVisitable) -> syn::Result<()>
     where
         Self: Sized,
     {
-        for child in korok.get_children() {
-            child.accept(self);
-        }
+        korok
+            .get_children()
+            .into_iter()
+            .map(|child| child.accept(self))
+            .collect_and_combine_errors()?;
+        Ok(())
     }
 
-    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) {
-        for crate_korok in &mut korok.crates {
-            self.visit_crate(crate_korok);
-        }
+    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) -> syn::Result<()> {
+        korok
+            .crates
+            .iter_mut()
+            .map(|crate_korok| self.visit_crate(crate_korok))
+            .collect_and_combine_errors()?;
+        Ok(())
     }
 
-    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) {
-        for item_korok in &mut korok.items {
-            self.visit_item(item_korok);
-        }
+    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) -> syn::Result<()> {
+        korok
+            .items
+            .iter_mut()
+            .map(|item_korok| self.visit_item(item_korok))
+            .collect_and_combine_errors()?;
+        Ok(())
     }
 
-    fn visit_item(&mut self, korok: &mut codama_koroks::ItemKorok) {
+    fn visit_item(&mut self, korok: &mut codama_koroks::ItemKorok) -> syn::Result<()> {
         match korok {
             codama_koroks::ItemKorok::FileModule(korok) => self.visit_file_module(korok),
             codama_koroks::ItemKorok::Module(korok) => self.visit_module(korok),
@@ -32,43 +42,61 @@ pub trait KorokVisitor {
         }
     }
 
-    fn visit_file_module(&mut self, korok: &mut codama_koroks::FileModuleKorok) {
-        for item_korok in &mut korok.items {
-            self.visit_item(item_korok);
-        }
+    fn visit_file_module(&mut self, korok: &mut codama_koroks::FileModuleKorok) -> syn::Result<()> {
+        korok
+            .items
+            .iter_mut()
+            .map(|item_korok| self.visit_item(item_korok))
+            .collect_and_combine_errors()?;
+        Ok(())
     }
 
-    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) {
-        for item_korok in &mut korok.items {
-            self.visit_item(item_korok);
-        }
+    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) -> syn::Result<()> {
+        korok
+            .items
+            .iter_mut()
+            .map(|item_korok| self.visit_item(item_korok))
+            .collect_and_combine_errors()?;
+        Ok(())
     }
 
-    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) {
-        self.visit_fields(&mut korok.fields);
+    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) -> syn::Result<()> {
+        self.visit_fields(&mut korok.fields)
     }
 
-    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) {
-        for variant_korok in &mut korok.variants {
-            self.visit_enum_variant(variant_korok);
-        }
+    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) -> syn::Result<()> {
+        korok
+            .variants
+            .iter_mut()
+            .map(|variant_korok| self.visit_enum_variant(variant_korok))
+            .collect_and_combine_errors()?;
+        Ok(())
     }
 
-    fn visit_enum_variant(&mut self, korok: &mut codama_koroks::EnumVariantKorok) {
-        self.visit_fields(&mut korok.fields);
+    fn visit_enum_variant(
+        &mut self,
+        korok: &mut codama_koroks::EnumVariantKorok,
+    ) -> syn::Result<()> {
+        self.visit_fields(&mut korok.fields)
     }
 
-    fn visit_unsupported_item(&mut self, _korok: &mut codama_koroks::UnsupportedItemKorok) {
-        //
+    fn visit_unsupported_item(
+        &mut self,
+        _korok: &mut codama_koroks::UnsupportedItemKorok,
+    ) -> syn::Result<()> {
+        Ok(())
     }
 
-    fn visit_fields(&mut self, korok: &mut codama_koroks::FieldsKorok) {
-        for field_korok in &mut korok.all {
-            self.visit_field(field_korok);
-        }
+    fn visit_fields(&mut self, korok: &mut codama_koroks::FieldsKorok) -> syn::Result<()> {
+        korok
+            .all
+            .iter_mut()
+            .map(|field_korok| self.visit_field(field_korok))
+            .collect_and_combine_errors()?;
+        Ok(())
     }
 
-    fn visit_field(&mut self, _korok: &mut codama_koroks::FieldKorok) {
-        //
+    fn visit_field(&mut self, _korok: &mut codama_koroks::FieldKorok) -> syn::Result<()> {
+        Ok(())
     }
 }

--- a/codama-korok-visitors/tests/apply_codama_type_attributes_visitor/encoding_directive.rs
+++ b/codama-korok-visitors/tests/apply_codama_type_attributes_visitor/encoding_directive.rs
@@ -1,3 +1,4 @@
+use codama_errors::CodamaResult;
 use codama_korok_visitors::{
     ApplyCodamaTypeAttributesVisitor, KorokVisitable, SetBorshTypesVisitor,
 };
@@ -7,13 +8,13 @@ use codama_nodes::{
 };
 
 #[test]
-fn it_updates_the_encoding_of_string_type_nodes() -> syn::Result<()> {
+fn it_updates_the_encoding_of_string_type_nodes() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(type = string)]
         #[codama(encoding = base16)]
         String
     };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
@@ -22,12 +23,12 @@ fn it_updates_the_encoding_of_string_type_nodes() -> syn::Result<()> {
 }
 
 #[test]
-fn it_updates_the_encoding_of_nested_string_type_nodes() -> syn::Result<()> {
+fn it_updates_the_encoding_of_nested_string_type_nodes() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(encoding = base16)]
         String
     };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
     korok.accept(&mut SetBorshTypesVisitor::new())?;
 
     assert_eq!(
@@ -43,13 +44,13 @@ fn it_updates_the_encoding_of_nested_string_type_nodes() -> syn::Result<()> {
 }
 
 #[test]
-fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() -> syn::Result<()> {
+fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(type = string)]
         #[codama(encoding = base16)]
         field: String
     };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
@@ -61,12 +62,12 @@ fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() -> syn::Result<()> {
 }
 
 #[test]
-fn it_keeps_the_nested_type_wrapped_in_a_struct_field_type_node() -> syn::Result<()> {
+fn it_keeps_the_nested_type_wrapped_in_a_struct_field_type_node() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(encoding = base16)]
         field: String
     };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
     korok.accept(&mut SetBorshTypesVisitor::new())?;
 
     assert_eq!(

--- a/codama-korok-visitors/tests/apply_codama_type_attributes_visitor/encoding_directive.rs
+++ b/codama-korok-visitors/tests/apply_codama_type_attributes_visitor/encoding_directive.rs
@@ -7,7 +7,7 @@ use codama_nodes::{
 };
 
 #[test]
-fn it_updates_the_encoding_of_string_type_nodes() {
+fn it_updates_the_encoding_of_string_type_nodes() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(type = string)]
         #[codama(encoding = base16)]
@@ -16,32 +16,34 @@ fn it_updates_the_encoding_of_string_type_nodes() {
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new());
+    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
     assert_eq!(korok.node, Some(StringTypeNode::base16().into()));
+    Ok(())
 }
 
 #[test]
-fn it_updates_the_encoding_of_nested_string_type_nodes() {
+fn it_updates_the_encoding_of_nested_string_type_nodes() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(encoding = base16)]
         String
     };
     let mut korok = FieldKorok::parse(&ast).unwrap();
-    korok.accept(&mut SetBorshTypesVisitor::new());
+    korok.accept(&mut SetBorshTypesVisitor::new())?;
 
     assert_eq!(
         korok.node,
         Some(SizePrefixTypeNode::new(StringTypeNode::utf8(), NumberTypeNode::le(U32)).into())
     );
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new());
+    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(SizePrefixTypeNode::new(StringTypeNode::base16(), NumberTypeNode::le(U32)).into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() {
+fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(type = string)]
         #[codama(encoding = base16)]
@@ -50,21 +52,22 @@ fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() {
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new());
+    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(StructFieldTypeNode::new("field", StringTypeNode::base16()).into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_keeps_the_nested_type_wrapped_in_a_struct_field_type_node() {
+fn it_keeps_the_nested_type_wrapped_in_a_struct_field_type_node() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(encoding = base16)]
         field: String
     };
     let mut korok = FieldKorok::parse(&ast).unwrap();
-    korok.accept(&mut SetBorshTypesVisitor::new());
+    korok.accept(&mut SetBorshTypesVisitor::new())?;
 
     assert_eq!(
         korok.node,
@@ -76,7 +79,7 @@ fn it_keeps_the_nested_type_wrapped_in_a_struct_field_type_node() {
             .into()
         )
     );
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new());
+    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(
@@ -87,4 +90,5 @@ fn it_keeps_the_nested_type_wrapped_in_a_struct_field_type_node() {
             .into()
         )
     );
+    Ok(())
 }

--- a/codama-korok-visitors/tests/apply_codama_type_attributes_visitor/fixed_size_directive.rs
+++ b/codama-korok-visitors/tests/apply_codama_type_attributes_visitor/fixed_size_directive.rs
@@ -7,7 +7,7 @@ use codama_nodes::{
 };
 
 #[test]
-fn it_wraps_any_type_into_a_fixed_size_type_node() {
+fn it_wraps_any_type_into_a_fixed_size_type_node() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(fixed_size = 8)]
         u32
@@ -15,16 +15,17 @@ fn it_wraps_any_type_into_a_fixed_size_type_node() {
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut SetBorshTypesVisitor::new());
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new());
+    korok.accept(&mut SetBorshTypesVisitor::new())?;
+    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(FixedSizeTypeNode::new(NumberTypeNode::le(U32), 8).into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_wraps_any_overridden_type_into_a_fixed_size_type_node() {
+fn it_wraps_any_overridden_type_into_a_fixed_size_type_node() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(type = string)]
         #[codama(fixed_size = 42)]
@@ -33,15 +34,16 @@ fn it_wraps_any_overridden_type_into_a_fixed_size_type_node() {
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new());
+    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(FixedSizeTypeNode::new(StringTypeNode::utf8(), 42).into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_replaces_the_size_of_existing_fixed_size_type_nodes() {
+fn it_replaces_the_size_of_existing_fixed_size_type_nodes() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(type = string)]
         #[codama(fixed_size = 111)]
@@ -51,15 +53,16 @@ fn it_replaces_the_size_of_existing_fixed_size_type_nodes() {
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new());
+    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(FixedSizeTypeNode::new(StringTypeNode::utf8(), 222).into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_replaces_size_prefixed_type_nodes() {
+fn it_replaces_size_prefixed_type_nodes() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(fixed_size = 42)]
         String
@@ -67,16 +70,17 @@ fn it_replaces_size_prefixed_type_nodes() {
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut SetBorshTypesVisitor::new());
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new());
+    korok.accept(&mut SetBorshTypesVisitor::new())?;
+    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(FixedSizeTypeNode::new(StringTypeNode::utf8(), 42).into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() {
+fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(fixed_size = 8)]
         field: u32
@@ -84,8 +88,8 @@ fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() {
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut SetBorshTypesVisitor::new());
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new());
+    korok.accept(&mut SetBorshTypesVisitor::new())?;
+    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(
@@ -93,4 +97,5 @@ fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() {
                 .into()
         )
     );
+    Ok(())
 }

--- a/codama-korok-visitors/tests/apply_codama_type_attributes_visitor/fixed_size_directive.rs
+++ b/codama-korok-visitors/tests/apply_codama_type_attributes_visitor/fixed_size_directive.rs
@@ -1,3 +1,4 @@
+use codama_errors::CodamaResult;
 use codama_korok_visitors::{
     ApplyCodamaTypeAttributesVisitor, KorokVisitable, SetBorshTypesVisitor,
 };
@@ -7,12 +8,12 @@ use codama_nodes::{
 };
 
 #[test]
-fn it_wraps_any_type_into_a_fixed_size_type_node() -> syn::Result<()> {
+fn it_wraps_any_type_into_a_fixed_size_type_node() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(fixed_size = 8)]
         u32
     };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut SetBorshTypesVisitor::new())?;
@@ -25,13 +26,13 @@ fn it_wraps_any_type_into_a_fixed_size_type_node() -> syn::Result<()> {
 }
 
 #[test]
-fn it_wraps_any_overridden_type_into_a_fixed_size_type_node() -> syn::Result<()> {
+fn it_wraps_any_overridden_type_into_a_fixed_size_type_node() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(type = string)]
         #[codama(fixed_size = 42)]
         String
     };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
@@ -43,14 +44,14 @@ fn it_wraps_any_overridden_type_into_a_fixed_size_type_node() -> syn::Result<()>
 }
 
 #[test]
-fn it_replaces_the_size_of_existing_fixed_size_type_nodes() -> syn::Result<()> {
+fn it_replaces_the_size_of_existing_fixed_size_type_nodes() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(type = string)]
         #[codama(fixed_size = 111)]
         #[codama(fixed_size = 222)]
         String
     };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
@@ -62,12 +63,12 @@ fn it_replaces_the_size_of_existing_fixed_size_type_nodes() -> syn::Result<()> {
 }
 
 #[test]
-fn it_replaces_size_prefixed_type_nodes() -> syn::Result<()> {
+fn it_replaces_size_prefixed_type_nodes() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(fixed_size = 42)]
         String
     };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut SetBorshTypesVisitor::new())?;
@@ -80,12 +81,12 @@ fn it_replaces_size_prefixed_type_nodes() -> syn::Result<()> {
 }
 
 #[test]
-fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() -> syn::Result<()> {
+fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(fixed_size = 8)]
         field: u32
     };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut SetBorshTypesVisitor::new())?;

--- a/codama-korok-visitors/tests/apply_codama_type_attributes_visitor/size_prefix_directive.rs
+++ b/codama-korok-visitors/tests/apply_codama_type_attributes_visitor/size_prefix_directive.rs
@@ -1,3 +1,4 @@
+use codama_errors::CodamaResult;
 use codama_korok_visitors::{
     ApplyCodamaTypeAttributesVisitor, KorokVisitable, SetBorshTypesVisitor,
 };
@@ -9,12 +10,12 @@ use codama_nodes::{
 };
 
 #[test]
-fn it_wraps_any_type_into_a_size_prefix_type_node() -> syn::Result<()> {
+fn it_wraps_any_type_into_a_size_prefix_type_node() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(size_prefix = number(u8))]
         u32
     };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut SetBorshTypesVisitor::new())?;
@@ -27,12 +28,12 @@ fn it_wraps_any_type_into_a_size_prefix_type_node() -> syn::Result<()> {
 }
 
 #[test]
-fn it_accepts_nested_number_type_nodes_as_size_prefixes() -> syn::Result<()> {
+fn it_accepts_nested_number_type_nodes_as_size_prefixes() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(size_prefix = fixed_size(number(u8), 42))]
         u32
     };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut SetBorshTypesVisitor::new())?;
@@ -51,13 +52,13 @@ fn it_accepts_nested_number_type_nodes_as_size_prefixes() -> syn::Result<()> {
 }
 
 #[test]
-fn it_wraps_any_overridden_type_into_a_size_prefix_type_node() -> syn::Result<()> {
+fn it_wraps_any_overridden_type_into_a_size_prefix_type_node() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(type = string)]
         #[codama(size_prefix = number(u8))]
         String
     };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
@@ -69,14 +70,14 @@ fn it_wraps_any_overridden_type_into_a_size_prefix_type_node() -> syn::Result<()
 }
 
 #[test]
-fn it_replaces_the_size_of_existing_size_prefix_type_nodes() -> syn::Result<()> {
+fn it_replaces_the_size_of_existing_size_prefix_type_nodes() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(type = string)]
         #[codama(size_prefix = number(u8))]
         #[codama(size_prefix = number(u16))]
         String
     };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
@@ -88,14 +89,14 @@ fn it_replaces_the_size_of_existing_size_prefix_type_nodes() -> syn::Result<()> 
 }
 
 #[test]
-fn it_replaces_fixed_size_type_nodes() -> syn::Result<()> {
+fn it_replaces_fixed_size_type_nodes() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(type = string)]
         #[codama(fixed_size = 42)]
         #[codama(size_prefix = number(u8))]
         String
     };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
@@ -107,12 +108,12 @@ fn it_replaces_fixed_size_type_nodes() -> syn::Result<()> {
 }
 
 #[test]
-fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() -> syn::Result<()> {
+fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(size_prefix = number(u8))]
         field: u32
     };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut SetBorshTypesVisitor::new())?;

--- a/codama-korok-visitors/tests/apply_codama_type_attributes_visitor/size_prefix_directive.rs
+++ b/codama-korok-visitors/tests/apply_codama_type_attributes_visitor/size_prefix_directive.rs
@@ -9,7 +9,7 @@ use codama_nodes::{
 };
 
 #[test]
-fn it_wraps_any_type_into_a_size_prefix_type_node() {
+fn it_wraps_any_type_into_a_size_prefix_type_node() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(size_prefix = number(u8))]
         u32
@@ -17,16 +17,17 @@ fn it_wraps_any_type_into_a_size_prefix_type_node() {
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut SetBorshTypesVisitor::new());
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new());
+    korok.accept(&mut SetBorshTypesVisitor::new())?;
+    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(SizePrefixTypeNode::new(NumberTypeNode::le(U32), NumberTypeNode::le(U8)).into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_accepts_nested_number_type_nodes_as_size_prefixes() {
+fn it_accepts_nested_number_type_nodes_as_size_prefixes() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(size_prefix = fixed_size(number(u8), 42))]
         u32
@@ -34,8 +35,8 @@ fn it_accepts_nested_number_type_nodes_as_size_prefixes() {
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut SetBorshTypesVisitor::new());
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new());
+    korok.accept(&mut SetBorshTypesVisitor::new())?;
+    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(
@@ -46,10 +47,11 @@ fn it_accepts_nested_number_type_nodes_as_size_prefixes() {
             .into()
         )
     );
+    Ok(())
 }
 
 #[test]
-fn it_wraps_any_overridden_type_into_a_size_prefix_type_node() {
+fn it_wraps_any_overridden_type_into_a_size_prefix_type_node() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(type = string)]
         #[codama(size_prefix = number(u8))]
@@ -58,15 +60,16 @@ fn it_wraps_any_overridden_type_into_a_size_prefix_type_node() {
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new());
+    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(SizePrefixTypeNode::new(StringTypeNode::utf8(), NumberTypeNode::le(U8)).into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_replaces_the_size_of_existing_size_prefix_type_nodes() {
+fn it_replaces_the_size_of_existing_size_prefix_type_nodes() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(type = string)]
         #[codama(size_prefix = number(u8))]
@@ -76,15 +79,16 @@ fn it_replaces_the_size_of_existing_size_prefix_type_nodes() {
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new());
+    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(SizePrefixTypeNode::new(StringTypeNode::utf8(), NumberTypeNode::le(U16)).into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_replaces_fixed_size_type_nodes() {
+fn it_replaces_fixed_size_type_nodes() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(type = string)]
         #[codama(fixed_size = 42)]
@@ -94,15 +98,16 @@ fn it_replaces_fixed_size_type_nodes() {
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new());
+    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(SizePrefixTypeNode::new(StringTypeNode::utf8(), NumberTypeNode::le(U8)).into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() {
+fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(size_prefix = number(u8))]
         field: u32
@@ -110,8 +115,8 @@ fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() {
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut SetBorshTypesVisitor::new());
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new());
+    korok.accept(&mut SetBorshTypesVisitor::new())?;
+    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(
@@ -122,4 +127,5 @@ fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() {
             .into()
         )
     );
+    Ok(())
 }

--- a/codama-korok-visitors/tests/apply_codama_type_attributes_visitor/type_directive.rs
+++ b/codama-korok-visitors/tests/apply_codama_type_attributes_visitor/type_directive.rs
@@ -3,7 +3,7 @@ use codama_koroks::{FieldKorok, StructKorok};
 use codama_nodes::{BooleanTypeNode, StructFieldTypeNode};
 
 #[test]
-fn it_set_the_node_on_the_korok() {
+fn it_set_the_node_on_the_korok() -> syn::Result<()> {
     let ast: syn::ItemStruct = syn::parse_quote! {
         #[codama(type = boolean)]
         pub struct Membership;
@@ -11,12 +11,13 @@ fn it_set_the_node_on_the_korok() {
     let mut korok = StructKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new());
+    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
     assert_eq!(korok.node, Some(BooleanTypeNode::default().into()));
+    Ok(())
 }
 
 #[test]
-fn it_wraps_the_node_in_a_struct_field_for_named_field_koroks() {
+fn it_wraps_the_node_in_a_struct_field_for_named_field_koroks() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(type = boolean)]
         pub is_valid: u8
@@ -24,9 +25,10 @@ fn it_wraps_the_node_in_a_struct_field_for_named_field_koroks() {
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new());
+    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(StructFieldTypeNode::new("isValid", BooleanTypeNode::default()).into())
     );
+    Ok(())
 }

--- a/codama-korok-visitors/tests/apply_codama_type_attributes_visitor/type_directive.rs
+++ b/codama-korok-visitors/tests/apply_codama_type_attributes_visitor/type_directive.rs
@@ -1,14 +1,15 @@
+use codama_errors::CodamaResult;
 use codama_korok_visitors::{ApplyCodamaTypeAttributesVisitor, KorokVisitable};
 use codama_koroks::{FieldKorok, StructKorok};
 use codama_nodes::{BooleanTypeNode, StructFieldTypeNode};
 
 #[test]
-fn it_set_the_node_on_the_korok() -> syn::Result<()> {
+fn it_set_the_node_on_the_korok() -> CodamaResult<()> {
     let ast: syn::ItemStruct = syn::parse_quote! {
         #[codama(type = boolean)]
         pub struct Membership;
     };
-    let mut korok = StructKorok::parse(&ast).unwrap();
+    let mut korok = StructKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
@@ -17,12 +18,12 @@ fn it_set_the_node_on_the_korok() -> syn::Result<()> {
 }
 
 #[test]
-fn it_wraps_the_node_in_a_struct_field_for_named_field_koroks() -> syn::Result<()> {
+fn it_wraps_the_node_in_a_struct_field_for_named_field_koroks() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! {
         #[codama(type = boolean)]
         pub is_valid: u8
     };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;

--- a/codama-korok-visitors/tests/combine_modules_visitor/utils.rs
+++ b/codama-korok-visitors/tests/combine_modules_visitor/utils.rs
@@ -77,7 +77,9 @@ pub fn combine_modules<'a>(input: CombineModulesInput) -> Option<Node> {
     };
 
     module_korok.node = input.initial_node;
-    module_korok.accept(&mut CombineModulesVisitor::new());
+    module_korok
+        .accept(&mut CombineModulesVisitor::new())
+        .unwrap();
     module_korok.node
 }
 

--- a/codama-korok-visitors/tests/combine_types_visitor/enum_korok.rs
+++ b/codama-korok-visitors/tests/combine_types_visitor/enum_korok.rs
@@ -1,3 +1,4 @@
+use codama_errors::CodamaResult;
 use codama_korok_visitors::{CombineTypesVisitor, KorokVisitable};
 use codama_koroks::EnumKorok;
 use codama_nodes::{
@@ -7,7 +8,7 @@ use codama_nodes::{
 };
 
 #[test]
-fn it_creates_a_defined_type_enum_from_variants() -> syn::Result<()> {
+fn it_creates_a_defined_type_enum_from_variants() -> CodamaResult<()> {
     let ast: syn::ItemEnum = syn::parse_quote! {
         enum Message {
             Quit,
@@ -15,7 +16,7 @@ fn it_creates_a_defined_type_enum_from_variants() -> syn::Result<()> {
             Write(String),
         }
     };
-    let mut korok = EnumKorok::parse(&ast).unwrap();
+    let mut korok = EnumKorok::parse(&ast)?;
     let variant_quit = EnumEmptyVariantTypeNode::new("quit");
     let variant_move = EnumStructVariantTypeNode::new(
         "move",
@@ -52,9 +53,9 @@ fn it_creates_a_defined_type_enum_from_variants() -> syn::Result<()> {
 }
 
 #[test]
-fn it_does_not_override_existing_nodes_by_default() -> syn::Result<()> {
+fn it_does_not_override_existing_nodes_by_default() -> CodamaResult<()> {
     let ast: syn::ItemEnum = syn::parse_quote! { enum Direction { Left } };
-    let mut korok = EnumKorok::parse(&ast).unwrap();
+    let mut korok = EnumKorok::parse(&ast)?;
     korok.variants[0].node = Some(EnumEmptyVariantTypeNode::new("left").into());
 
     let original_node = Some(Node::from(DefinedTypeNode::new(

--- a/codama-korok-visitors/tests/combine_types_visitor/enum_korok.rs
+++ b/codama-korok-visitors/tests/combine_types_visitor/enum_korok.rs
@@ -7,7 +7,7 @@ use codama_nodes::{
 };
 
 #[test]
-fn it_creates_a_defined_type_enum_from_variants() {
+fn it_creates_a_defined_type_enum_from_variants() -> syn::Result<()> {
     let ast: syn::ItemEnum = syn::parse_quote! {
         enum Message {
             Quit,
@@ -33,7 +33,7 @@ fn it_creates_a_defined_type_enum_from_variants() {
     korok.variants[2].node = Some(variant_write.clone().into());
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut CombineTypesVisitor::new());
+    korok.accept(&mut CombineTypesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(
@@ -48,10 +48,11 @@ fn it_creates_a_defined_type_enum_from_variants() {
             .into()
         )
     );
+    Ok(())
 }
 
 #[test]
-fn it_does_not_override_existing_nodes_by_default() {
+fn it_does_not_override_existing_nodes_by_default() -> syn::Result<()> {
     let ast: syn::ItemEnum = syn::parse_quote! { enum Direction { Left } };
     let mut korok = EnumKorok::parse(&ast).unwrap();
     korok.variants[0].node = Some(EnumEmptyVariantTypeNode::new("left").into());
@@ -61,6 +62,7 @@ fn it_does_not_override_existing_nodes_by_default() {
         EnumTypeNode::new(vec![EnumEmptyVariantTypeNode::new("right").into()]),
     )));
     korok.node = original_node.clone();
-    korok.accept(&mut CombineTypesVisitor::new());
+    korok.accept(&mut CombineTypesVisitor::new())?;
     assert_eq!(korok.node, original_node);
+    Ok(())
 }

--- a/codama-korok-visitors/tests/combine_types_visitor/enum_variant_korok.rs
+++ b/codama-korok-visitors/tests/combine_types_visitor/enum_variant_korok.rs
@@ -1,3 +1,4 @@
+use codama_errors::CodamaResult;
 use codama_korok_visitors::{CombineTypesVisitor, KorokVisitable};
 use codama_koroks::EnumVariantKorok;
 use codama_nodes::{
@@ -6,9 +7,9 @@ use codama_nodes::{
 };
 
 #[test]
-fn it_creates_enum_empty_variants() -> syn::Result<()> {
+fn it_creates_enum_empty_variants() -> CodamaResult<()> {
     let ast: syn::Variant = syn::parse_quote! { Foo };
-    let mut korok = EnumVariantKorok::parse(&ast).unwrap();
+    let mut korok = EnumVariantKorok::parse(&ast)?;
     korok.fields.node = None;
 
     assert_eq!(korok.node, None);
@@ -21,9 +22,9 @@ fn it_creates_enum_empty_variants() -> syn::Result<()> {
 }
 
 #[test]
-fn it_creates_enum_struct_variants() -> syn::Result<()> {
+fn it_creates_enum_struct_variants() -> CodamaResult<()> {
     let ast: syn::Variant = syn::parse_quote! { Foo { x: i32, y: i32 } };
-    let mut korok = EnumVariantKorok::parse(&ast).unwrap();
+    let mut korok = EnumVariantKorok::parse(&ast)?;
     korok.fields.node = Some(
         StructTypeNode::new(vec![
             StructFieldTypeNode::new("x", NumberTypeNode::le(I32)),
@@ -51,9 +52,9 @@ fn it_creates_enum_struct_variants() -> syn::Result<()> {
 }
 
 #[test]
-fn it_creates_enum_tuple_variants() -> syn::Result<()> {
+fn it_creates_enum_tuple_variants() -> CodamaResult<()> {
     let ast: syn::Variant = syn::parse_quote! { Foo (u64, String) };
-    let mut korok = EnumVariantKorok::parse(&ast).unwrap();
+    let mut korok = EnumVariantKorok::parse(&ast)?;
     korok.fields.node = Some(
         TupleTypeNode::new(vec![
             NumberTypeNode::le(U64).into(),
@@ -81,9 +82,9 @@ fn it_creates_enum_tuple_variants() -> syn::Result<()> {
 }
 
 #[test]
-fn it_keeps_track_of_the_variant_discriminant() -> syn::Result<()> {
+fn it_keeps_track_of_the_variant_discriminant() -> CodamaResult<()> {
     let ast: syn::Variant = syn::parse_quote! { Foo = 42 };
-    let mut korok = EnumVariantKorok::parse(&ast).unwrap();
+    let mut korok = EnumVariantKorok::parse(&ast)?;
     korok.fields.node = None;
 
     assert_eq!(korok.node, None);
@@ -102,9 +103,9 @@ fn it_keeps_track_of_the_variant_discriminant() -> syn::Result<()> {
 }
 
 #[test]
-fn it_does_not_override_existing_nodes_by_default() -> syn::Result<()> {
+fn it_does_not_override_existing_nodes_by_default() -> CodamaResult<()> {
     let ast: syn::Variant = syn::parse_quote! { Foo };
-    let mut korok = EnumVariantKorok::parse(&ast).unwrap();
+    let mut korok = EnumVariantKorok::parse(&ast)?;
     korok.fields.node = None;
 
     korok.node = Some(EnumEmptyVariantTypeNode::new("bar").into());

--- a/codama-korok-visitors/tests/combine_types_visitor/enum_variant_korok.rs
+++ b/codama-korok-visitors/tests/combine_types_visitor/enum_variant_korok.rs
@@ -6,21 +6,22 @@ use codama_nodes::{
 };
 
 #[test]
-fn it_creates_enum_empty_variants() {
+fn it_creates_enum_empty_variants() -> syn::Result<()> {
     let ast: syn::Variant = syn::parse_quote! { Foo };
     let mut korok = EnumVariantKorok::parse(&ast).unwrap();
     korok.fields.node = None;
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut CombineTypesVisitor::new());
+    korok.accept(&mut CombineTypesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(EnumEmptyVariantTypeNode::new("foo").into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_creates_enum_struct_variants() {
+fn it_creates_enum_struct_variants() -> syn::Result<()> {
     let ast: syn::Variant = syn::parse_quote! { Foo { x: i32, y: i32 } };
     let mut korok = EnumVariantKorok::parse(&ast).unwrap();
     korok.fields.node = Some(
@@ -32,7 +33,7 @@ fn it_creates_enum_struct_variants() {
     );
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut CombineTypesVisitor::new());
+    korok.accept(&mut CombineTypesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(
@@ -46,10 +47,11 @@ fn it_creates_enum_struct_variants() {
             .into()
         )
     );
+    Ok(())
 }
 
 #[test]
-fn it_creates_enum_tuple_variants() {
+fn it_creates_enum_tuple_variants() -> syn::Result<()> {
     let ast: syn::Variant = syn::parse_quote! { Foo (u64, String) };
     let mut korok = EnumVariantKorok::parse(&ast).unwrap();
     korok.fields.node = Some(
@@ -61,7 +63,7 @@ fn it_creates_enum_tuple_variants() {
     );
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut CombineTypesVisitor::new());
+    korok.accept(&mut CombineTypesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(
@@ -75,16 +77,17 @@ fn it_creates_enum_tuple_variants() {
             .into()
         )
     );
+    Ok(())
 }
 
 #[test]
-fn it_keeps_track_of_the_variant_discriminant() {
+fn it_keeps_track_of_the_variant_discriminant() -> syn::Result<()> {
     let ast: syn::Variant = syn::parse_quote! { Foo = 42 };
     let mut korok = EnumVariantKorok::parse(&ast).unwrap();
     korok.fields.node = None;
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut CombineTypesVisitor::new());
+    korok.accept(&mut CombineTypesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(
@@ -95,18 +98,20 @@ fn it_keeps_track_of_the_variant_discriminant() {
             .into()
         )
     );
+    Ok(())
 }
 
 #[test]
-fn it_does_not_override_existing_nodes_by_default() {
+fn it_does_not_override_existing_nodes_by_default() -> syn::Result<()> {
     let ast: syn::Variant = syn::parse_quote! { Foo };
     let mut korok = EnumVariantKorok::parse(&ast).unwrap();
     korok.fields.node = None;
 
     korok.node = Some(EnumEmptyVariantTypeNode::new("bar").into());
-    korok.accept(&mut CombineTypesVisitor::new());
+    korok.accept(&mut CombineTypesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(EnumEmptyVariantTypeNode::new("bar").into())
     );
+    Ok(())
 }

--- a/codama-korok-visitors/tests/combine_types_visitor/fields_korok.rs
+++ b/codama-korok-visitors/tests/combine_types_visitor/fields_korok.rs
@@ -3,14 +3,14 @@ use codama_koroks::FieldsKorok;
 use codama_nodes::{NumberTypeNode, StructFieldTypeNode, StructTypeNode, TupleTypeNode, I32, U64};
 
 #[test]
-fn it_create_a_struct_type_node_from_struct_field_type_nodes() {
+fn it_create_a_struct_type_node_from_struct_field_type_nodes() -> syn::Result<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo { x: i32, y: i32 } };
     let mut korok = FieldsKorok::parse(&ast.fields).unwrap();
     korok.all[0].node = Some(StructFieldTypeNode::new("x", NumberTypeNode::le(I32)).into());
     korok.all[1].node = Some(StructFieldTypeNode::new("y", NumberTypeNode::le(I32)).into());
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut CombineTypesVisitor::new());
+    korok.accept(&mut CombineTypesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(
@@ -21,17 +21,18 @@ fn it_create_a_struct_type_node_from_struct_field_type_nodes() {
             .into()
         )
     );
+    Ok(())
 }
 
 #[test]
-fn it_create_a_tuple_type_node_from_multiple_type_nodes() {
+fn it_create_a_tuple_type_node_from_multiple_type_nodes() -> syn::Result<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo (i32, u64); };
     let mut korok = FieldsKorok::parse(&ast.fields).unwrap();
     korok.all[0].node = Some(NumberTypeNode::le(I32).into());
     korok.all[1].node = Some(NumberTypeNode::le(U64).into());
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut CombineTypesVisitor::new());
+    korok.accept(&mut CombineTypesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(
@@ -42,53 +43,58 @@ fn it_create_a_tuple_type_node_from_multiple_type_nodes() {
             .into()
         )
     );
+    Ok(())
 }
 
 #[test]
-fn it_create_a_tuple_type_node_from_single_type_nodes() {
+fn it_create_a_tuple_type_node_from_single_type_nodes() -> syn::Result<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo (i32); };
     let mut korok = FieldsKorok::parse(&ast.fields).unwrap();
     korok.all[0].node = Some(NumberTypeNode::le(I32).into());
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut CombineTypesVisitor::new());
+    korok.accept(&mut CombineTypesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(TupleTypeNode::new(vec![NumberTypeNode::le(I32).into()]).into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_sets_node_to_none_from_empty_fields() {
+fn it_sets_node_to_none_from_empty_fields() -> syn::Result<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo; };
     let mut korok = FieldsKorok::parse(&ast.fields).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut CombineTypesVisitor::new());
+    korok.accept(&mut CombineTypesVisitor::new())?;
     assert_eq!(korok.node, None);
+    Ok(())
 }
 
 #[test]
-fn it_does_not_override_existing_nodes_by_default() {
+fn it_does_not_override_existing_nodes_by_default() -> syn::Result<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo (i32); };
     let mut korok = FieldsKorok::parse(&ast.fields).unwrap();
     korok.all[0].node = Some(NumberTypeNode::le(I32).into());
     korok.node = Some(NumberTypeNode::le(U64).into());
 
-    korok.accept(&mut CombineTypesVisitor::new());
+    korok.accept(&mut CombineTypesVisitor::new())?;
     assert_eq!(korok.node, Some(NumberTypeNode::le(U64).into()));
+    Ok(())
 }
 
 #[test]
-fn it_can_override_existing_nodes() {
+fn it_can_override_existing_nodes() -> syn::Result<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo (i32); };
     let mut korok = FieldsKorok::parse(&ast.fields).unwrap();
     korok.all[0].node = Some(NumberTypeNode::le(I32).into());
     korok.node = Some(NumberTypeNode::le(U64).into());
 
-    korok.accept(&mut CombineTypesVisitor { r#override: true });
+    korok.accept(&mut CombineTypesVisitor { r#override: true })?;
     assert_eq!(
         korok.node,
         Some(TupleTypeNode::new(vec![NumberTypeNode::le(I32).into()]).into())
     );
+    Ok(())
 }

--- a/codama-korok-visitors/tests/combine_types_visitor/fields_korok.rs
+++ b/codama-korok-visitors/tests/combine_types_visitor/fields_korok.rs
@@ -1,11 +1,12 @@
+use codama_errors::CodamaResult;
 use codama_korok_visitors::{CombineTypesVisitor, KorokVisitable};
 use codama_koroks::FieldsKorok;
 use codama_nodes::{NumberTypeNode, StructFieldTypeNode, StructTypeNode, TupleTypeNode, I32, U64};
 
 #[test]
-fn it_create_a_struct_type_node_from_struct_field_type_nodes() -> syn::Result<()> {
+fn it_create_a_struct_type_node_from_struct_field_type_nodes() -> CodamaResult<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo { x: i32, y: i32 } };
-    let mut korok = FieldsKorok::parse(&ast.fields).unwrap();
+    let mut korok = FieldsKorok::parse(&ast.fields)?;
     korok.all[0].node = Some(StructFieldTypeNode::new("x", NumberTypeNode::le(I32)).into());
     korok.all[1].node = Some(StructFieldTypeNode::new("y", NumberTypeNode::le(I32)).into());
 
@@ -25,9 +26,9 @@ fn it_create_a_struct_type_node_from_struct_field_type_nodes() -> syn::Result<()
 }
 
 #[test]
-fn it_create_a_tuple_type_node_from_multiple_type_nodes() -> syn::Result<()> {
+fn it_create_a_tuple_type_node_from_multiple_type_nodes() -> CodamaResult<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo (i32, u64); };
-    let mut korok = FieldsKorok::parse(&ast.fields).unwrap();
+    let mut korok = FieldsKorok::parse(&ast.fields)?;
     korok.all[0].node = Some(NumberTypeNode::le(I32).into());
     korok.all[1].node = Some(NumberTypeNode::le(U64).into());
 
@@ -47,9 +48,9 @@ fn it_create_a_tuple_type_node_from_multiple_type_nodes() -> syn::Result<()> {
 }
 
 #[test]
-fn it_create_a_tuple_type_node_from_single_type_nodes() -> syn::Result<()> {
+fn it_create_a_tuple_type_node_from_single_type_nodes() -> CodamaResult<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo (i32); };
-    let mut korok = FieldsKorok::parse(&ast.fields).unwrap();
+    let mut korok = FieldsKorok::parse(&ast.fields)?;
     korok.all[0].node = Some(NumberTypeNode::le(I32).into());
 
     assert_eq!(korok.node, None);
@@ -62,9 +63,9 @@ fn it_create_a_tuple_type_node_from_single_type_nodes() -> syn::Result<()> {
 }
 
 #[test]
-fn it_sets_node_to_none_from_empty_fields() -> syn::Result<()> {
+fn it_sets_node_to_none_from_empty_fields() -> CodamaResult<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo; };
-    let mut korok = FieldsKorok::parse(&ast.fields).unwrap();
+    let mut korok = FieldsKorok::parse(&ast.fields)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut CombineTypesVisitor::new())?;
@@ -73,9 +74,9 @@ fn it_sets_node_to_none_from_empty_fields() -> syn::Result<()> {
 }
 
 #[test]
-fn it_does_not_override_existing_nodes_by_default() -> syn::Result<()> {
+fn it_does_not_override_existing_nodes_by_default() -> CodamaResult<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo (i32); };
-    let mut korok = FieldsKorok::parse(&ast.fields).unwrap();
+    let mut korok = FieldsKorok::parse(&ast.fields)?;
     korok.all[0].node = Some(NumberTypeNode::le(I32).into());
     korok.node = Some(NumberTypeNode::le(U64).into());
 
@@ -85,9 +86,9 @@ fn it_does_not_override_existing_nodes_by_default() -> syn::Result<()> {
 }
 
 #[test]
-fn it_can_override_existing_nodes() -> syn::Result<()> {
+fn it_can_override_existing_nodes() -> CodamaResult<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo (i32); };
-    let mut korok = FieldsKorok::parse(&ast.fields).unwrap();
+    let mut korok = FieldsKorok::parse(&ast.fields)?;
     korok.all[0].node = Some(NumberTypeNode::le(I32).into());
     korok.node = Some(NumberTypeNode::le(U64).into());
 

--- a/codama-korok-visitors/tests/combine_types_visitor/struct_korok.rs
+++ b/codama-korok-visitors/tests/combine_types_visitor/struct_korok.rs
@@ -1,3 +1,4 @@
+use codama_errors::CodamaResult;
 use codama_korok_visitors::{CombineTypesVisitor, KorokVisitable};
 use codama_koroks::StructKorok;
 use codama_nodes::{
@@ -6,14 +7,14 @@ use codama_nodes::{
 };
 
 #[test]
-fn it_creates_a_defined_type_struct_from_nammed_fields() -> syn::Result<()> {
+fn it_creates_a_defined_type_struct_from_nammed_fields() -> CodamaResult<()> {
     let ast: syn::ItemStruct = syn::parse_quote! {
         struct Person {
             age: u8,
             name: String,
         }
     };
-    let mut korok = StructKorok::parse(&ast).unwrap();
+    let mut korok = StructKorok::parse(&ast)?;
     let struct_node = StructTypeNode::new(vec![
         StructFieldTypeNode::new("age", NumberTypeNode::le(U8)),
         StructFieldTypeNode::new("name", StringTypeNode::utf8()),
@@ -30,11 +31,11 @@ fn it_creates_a_defined_type_struct_from_nammed_fields() -> syn::Result<()> {
 }
 
 #[test]
-fn it_creates_a_defined_type_tuple_from_unnammed_fields() -> syn::Result<()> {
+fn it_creates_a_defined_type_tuple_from_unnammed_fields() -> CodamaResult<()> {
     let ast: syn::ItemStruct = syn::parse_quote! {
         struct Coordinates(u32, u32);
     };
-    let mut korok = StructKorok::parse(&ast).unwrap();
+    let mut korok = StructKorok::parse(&ast)?;
     let tuple_node = TupleTypeNode::new(vec![
         NumberTypeNode::le(U32).into(),
         NumberTypeNode::le(U32).into(),
@@ -51,11 +52,11 @@ fn it_creates_a_defined_type_tuple_from_unnammed_fields() -> syn::Result<()> {
 }
 
 #[test]
-fn it_creates_a_defined_type_from_single_unnammed_fields() -> syn::Result<()> {
+fn it_creates_a_defined_type_from_single_unnammed_fields() -> CodamaResult<()> {
     let ast: syn::ItemStruct = syn::parse_quote! {
         struct Slot(u64);
     };
-    let mut korok = StructKorok::parse(&ast).unwrap();
+    let mut korok = StructKorok::parse(&ast)?;
     korok.fields.node = Some(TupleTypeNode::new(vec![NumberTypeNode::le(U64).into()]).into());
 
     assert_eq!(korok.node, None);
@@ -68,11 +69,11 @@ fn it_creates_a_defined_type_from_single_unnammed_fields() -> syn::Result<()> {
 }
 
 #[test]
-fn it_does_not_override_existing_nodes_by_default() -> syn::Result<()> {
+fn it_does_not_override_existing_nodes_by_default() -> CodamaResult<()> {
     let ast: syn::ItemStruct = syn::parse_quote! {
         struct Overriden(u32, u32);
     };
-    let mut korok = StructKorok::parse(&ast).unwrap();
+    let mut korok = StructKorok::parse(&ast)?;
     korok.fields.node = Some(
         TupleTypeNode::new(vec![
             NumberTypeNode::le(U32).into(),

--- a/codama-korok-visitors/tests/combine_types_visitor/struct_korok.rs
+++ b/codama-korok-visitors/tests/combine_types_visitor/struct_korok.rs
@@ -6,7 +6,7 @@ use codama_nodes::{
 };
 
 #[test]
-fn it_creates_a_defined_type_struct_from_nammed_fields() {
+fn it_creates_a_defined_type_struct_from_nammed_fields() -> syn::Result<()> {
     let ast: syn::ItemStruct = syn::parse_quote! {
         struct Person {
             age: u8,
@@ -21,15 +21,16 @@ fn it_creates_a_defined_type_struct_from_nammed_fields() {
     korok.fields.node = Some(struct_node.clone().into());
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut CombineTypesVisitor::new());
+    korok.accept(&mut CombineTypesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(DefinedTypeNode::new("person", struct_node).into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_creates_a_defined_type_tuple_from_unnammed_fields() {
+fn it_creates_a_defined_type_tuple_from_unnammed_fields() -> syn::Result<()> {
     let ast: syn::ItemStruct = syn::parse_quote! {
         struct Coordinates(u32, u32);
     };
@@ -41,15 +42,16 @@ fn it_creates_a_defined_type_tuple_from_unnammed_fields() {
     korok.fields.node = Some(tuple_node.clone().into());
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut CombineTypesVisitor::new());
+    korok.accept(&mut CombineTypesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(DefinedTypeNode::new("coordinates", tuple_node).into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_creates_a_defined_type_from_single_unnammed_fields() {
+fn it_creates_a_defined_type_from_single_unnammed_fields() -> syn::Result<()> {
     let ast: syn::ItemStruct = syn::parse_quote! {
         struct Slot(u64);
     };
@@ -57,15 +59,16 @@ fn it_creates_a_defined_type_from_single_unnammed_fields() {
     korok.fields.node = Some(TupleTypeNode::new(vec![NumberTypeNode::le(U64).into()]).into());
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut CombineTypesVisitor::new());
+    korok.accept(&mut CombineTypesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(DefinedTypeNode::new("slot", NumberTypeNode::le(U64)).into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_does_not_override_existing_nodes_by_default() {
+fn it_does_not_override_existing_nodes_by_default() -> syn::Result<()> {
     let ast: syn::ItemStruct = syn::parse_quote! {
         struct Overriden(u32, u32);
     };
@@ -83,6 +86,7 @@ fn it_does_not_override_existing_nodes_by_default() {
         StringTypeNode::utf8(),
     )));
     korok.node = original_node.clone();
-    korok.accept(&mut CombineTypesVisitor::new());
+    korok.accept(&mut CombineTypesVisitor::new())?;
     assert_eq!(korok.node, original_node);
+    Ok(())
 }

--- a/codama-korok-visitors/tests/compose_visitor.rs
+++ b/codama-korok-visitors/tests/compose_visitor.rs
@@ -3,32 +3,36 @@ use codama_koroks::{FieldKorok, KorokTrait, StructKorok};
 use codama_nodes::PublicKeyTypeNode;
 
 #[test]
-fn it_returns_a_single_visitor_from_multiple_visitors() {
+fn it_returns_a_single_visitor_from_multiple_visitors() -> syn::Result<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo(u32); };
     let mut korok = StructKorok::parse(&ast).unwrap();
 
     struct ResetStructAndFieldKoroksVisitor;
     impl KorokVisitor for ResetStructAndFieldKoroksVisitor {
-        fn visit_struct(&mut self, korok: &mut StructKorok) {
-            self.visit_children(korok);
+        fn visit_struct(&mut self, korok: &mut StructKorok) -> syn::Result<()> {
+            self.visit_children(korok)?;
             korok.node = None;
+            Ok(())
         }
-        fn visit_field(&mut self, korok: &mut FieldKorok) {
-            self.visit_children(korok);
+        fn visit_field(&mut self, korok: &mut FieldKorok) -> syn::Result<()> {
+            self.visit_children(korok)?;
             korok.node = None;
+            Ok(())
         }
     }
 
     korok.accept(
         &mut ComposeVisitor::new()
             .add(UniformVisitor::new(|mut k, visitor| {
-                visitor.visit_children(&mut k);
-                k.set_node(Some(PublicKeyTypeNode::new().into()))
+                visitor.visit_children(&mut k)?;
+                k.set_node(Some(PublicKeyTypeNode::new().into()));
+                Ok(())
             }))
             .add(ResetStructAndFieldKoroksVisitor {}),
-    );
+    )?;
 
     assert_eq!(korok.node, None);
     assert_eq!(korok.fields.node, Some(PublicKeyTypeNode::new().into()));
     assert_eq!(korok.fields.all[0].node, None);
+    Ok(())
 }

--- a/codama-korok-visitors/tests/compose_visitor.rs
+++ b/codama-korok-visitors/tests/compose_visitor.rs
@@ -1,20 +1,21 @@
+use codama_errors::CodamaResult;
 use codama_korok_visitors::{ComposeVisitor, KorokVisitable, KorokVisitor, UniformVisitor};
 use codama_koroks::{FieldKorok, KorokTrait, StructKorok};
 use codama_nodes::PublicKeyTypeNode;
 
 #[test]
-fn it_returns_a_single_visitor_from_multiple_visitors() -> syn::Result<()> {
+fn it_returns_a_single_visitor_from_multiple_visitors() -> CodamaResult<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo(u32); };
-    let mut korok = StructKorok::parse(&ast).unwrap();
+    let mut korok = StructKorok::parse(&ast)?;
 
     struct ResetStructAndFieldKoroksVisitor;
     impl KorokVisitor for ResetStructAndFieldKoroksVisitor {
-        fn visit_struct(&mut self, korok: &mut StructKorok) -> syn::Result<()> {
+        fn visit_struct(&mut self, korok: &mut StructKorok) -> CodamaResult<()> {
             self.visit_children(korok)?;
             korok.node = None;
             Ok(())
         }
-        fn visit_field(&mut self, korok: &mut FieldKorok) -> syn::Result<()> {
+        fn visit_field(&mut self, korok: &mut FieldKorok) -> CodamaResult<()> {
             self.visit_children(korok)?;
             korok.node = None;
             Ok(())

--- a/codama-korok-visitors/tests/filter_items_visitor.rs
+++ b/codama-korok-visitors/tests/filter_items_visitor.rs
@@ -3,7 +3,7 @@ use codama_koroks::{ItemKorok, KorokTrait};
 use codama_nodes::PublicKeyTypeNode;
 
 #[test]
-fn it_only_starts_the_child_visitor_on_filtered_items() {
+fn it_only_starts_the_child_visitor_on_filtered_items() -> syn::Result<()> {
     let ast: syn::Item = syn::parse_quote! {
         mod parent {
             mod foo {
@@ -22,10 +22,11 @@ fn it_only_starts_the_child_visitor_on_filtered_items() {
             _ => false,
         },
         UniformVisitor::new(|mut k, visitor| {
-            visitor.visit_children(&mut k);
-            k.set_node(Some(PublicKeyTypeNode::new().into()))
+            visitor.visit_children(&mut k)?;
+            k.set_node(Some(PublicKeyTypeNode::new().into()));
+            Ok(())
         }),
-    ));
+    ))?;
 
     let ItemKorok::Module(module) = &korok else {
         panic!("Expected parent module");
@@ -58,4 +59,5 @@ fn it_only_starts_the_child_visitor_on_filtered_items() {
     assert_eq!(bar_struct.node, None);
     assert_eq!(bar_struct.fields.node, None);
     assert_eq!(bar_struct.fields.all[0].node, None);
+    Ok(())
 }

--- a/codama-korok-visitors/tests/filter_items_visitor.rs
+++ b/codama-korok-visitors/tests/filter_items_visitor.rs
@@ -1,9 +1,10 @@
+use codama_errors::CodamaResult;
 use codama_korok_visitors::{FilterItemsVisitor, KorokVisitable, KorokVisitor, UniformVisitor};
 use codama_koroks::{ItemKorok, KorokTrait};
 use codama_nodes::PublicKeyTypeNode;
 
 #[test]
-fn it_only_starts_the_child_visitor_on_filtered_items() -> syn::Result<()> {
+fn it_only_starts_the_child_visitor_on_filtered_items() -> CodamaResult<()> {
     let ast: syn::Item = syn::parse_quote! {
         mod parent {
             mod foo {
@@ -14,7 +15,7 @@ fn it_only_starts_the_child_visitor_on_filtered_items() -> syn::Result<()> {
             }
         }
     };
-    let mut korok = ItemKorok::parse(&ast, &[], &mut 0).unwrap();
+    let mut korok = ItemKorok::parse(&ast, &[], &mut 0)?;
 
     korok.accept(&mut FilterItemsVisitor::new(
         |item| match item {

--- a/codama-korok-visitors/tests/set_accounts_visitor.rs
+++ b/codama-korok-visitors/tests/set_accounts_visitor.rs
@@ -8,7 +8,7 @@ use codama_nodes::{
 };
 
 #[test]
-fn it_transforms_defined_type_nodes_into_account_nodes() {
+fn it_transforms_defined_type_nodes_into_account_nodes() -> syn::Result<()> {
     let ast: syn::ItemStruct = syn::parse_quote! {
         #[derive(CodamaAccount)]
         struct Token {
@@ -20,9 +20,9 @@ fn it_transforms_defined_type_nodes_into_account_nodes() {
     let mut korok = StructKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut SetBorshTypesVisitor::new());
-    korok.accept(&mut CombineTypesVisitor::new());
-    korok.accept(&mut SetAccountsVisitor::new());
+    korok.accept(&mut SetBorshTypesVisitor::new())?;
+    korok.accept(&mut CombineTypesVisitor::new())?;
+    korok.accept(&mut SetAccountsVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(
@@ -37,10 +37,11 @@ fn it_transforms_defined_type_nodes_into_account_nodes() {
             .into()
         )
     );
+    Ok(())
 }
 
 #[test]
-fn it_ignores_enums() {
+fn it_ignores_enums() -> syn::Result<()> {
     let ast: syn::ItemEnum = syn::parse_quote! {
         #[derive(CodamaAccount)]
         enum Membership {
@@ -51,8 +52,9 @@ fn it_ignores_enums() {
     let mut korok = EnumKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut SetBorshTypesVisitor::new());
-    korok.accept(&mut CombineTypesVisitor::new());
-    korok.accept(&mut SetAccountsVisitor::new());
+    korok.accept(&mut SetBorshTypesVisitor::new())?;
+    korok.accept(&mut CombineTypesVisitor::new())?;
+    korok.accept(&mut SetAccountsVisitor::new())?;
     assert_eq!(korok.node, None);
+    Ok(())
 }

--- a/codama-korok-visitors/tests/set_accounts_visitor.rs
+++ b/codama-korok-visitors/tests/set_accounts_visitor.rs
@@ -1,3 +1,4 @@
+use codama_errors::CodamaResult;
 use codama_korok_visitors::{
     CombineTypesVisitor, KorokVisitable, SetAccountsVisitor, SetBorshTypesVisitor,
 };
@@ -8,7 +9,7 @@ use codama_nodes::{
 };
 
 #[test]
-fn it_transforms_defined_type_nodes_into_account_nodes() -> syn::Result<()> {
+fn it_transforms_defined_type_nodes_into_account_nodes() -> CodamaResult<()> {
     let ast: syn::ItemStruct = syn::parse_quote! {
         #[derive(CodamaAccount)]
         struct Token {
@@ -17,7 +18,7 @@ fn it_transforms_defined_type_nodes_into_account_nodes() -> syn::Result<()> {
             amount: u64,
         }
     };
-    let mut korok = StructKorok::parse(&ast).unwrap();
+    let mut korok = StructKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut SetBorshTypesVisitor::new())?;
@@ -41,7 +42,7 @@ fn it_transforms_defined_type_nodes_into_account_nodes() -> syn::Result<()> {
 }
 
 #[test]
-fn it_ignores_enums() -> syn::Result<()> {
+fn it_ignores_enums() -> CodamaResult<()> {
     let ast: syn::ItemEnum = syn::parse_quote! {
         #[derive(CodamaAccount)]
         enum Membership {
@@ -49,7 +50,7 @@ fn it_ignores_enums() -> syn::Result<()> {
             Premium,
         }
     };
-    let mut korok = EnumKorok::parse(&ast).unwrap();
+    let mut korok = EnumKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut SetBorshTypesVisitor::new())?;

--- a/codama-korok-visitors/tests/set_borsh_types_visitor/field_korok.rs
+++ b/codama-korok-visitors/tests/set_borsh_types_visitor/field_korok.rs
@@ -3,24 +3,26 @@ use codama_koroks::FieldKorok;
 use codama_nodes::{NumberTypeNode, StructFieldTypeNode, U64};
 
 #[test]
-fn it_create_a_struct_field_type_node_when_nammed() {
+fn it_create_a_struct_field_type_node_when_nammed() -> syn::Result<()> {
     let ast = syn::parse_quote! { foo: u64 };
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut SetBorshTypesVisitor::new());
+    korok.accept(&mut SetBorshTypesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(StructFieldTypeNode::new("foo", NumberTypeNode::le(U64)).into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_forwards_the_type_when_unnamed() {
+fn it_forwards_the_type_when_unnamed() -> syn::Result<()> {
     let ast = syn::parse_quote! { u64 };
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut SetBorshTypesVisitor::new());
+    korok.accept(&mut SetBorshTypesVisitor::new())?;
     assert_eq!(korok.node, Some(NumberTypeNode::le(U64).into()));
+    Ok(())
 }

--- a/codama-korok-visitors/tests/set_borsh_types_visitor/field_korok.rs
+++ b/codama-korok-visitors/tests/set_borsh_types_visitor/field_korok.rs
@@ -1,11 +1,12 @@
+use codama_errors::CodamaResult;
 use codama_korok_visitors::{KorokVisitable, SetBorshTypesVisitor};
 use codama_koroks::FieldKorok;
 use codama_nodes::{NumberTypeNode, StructFieldTypeNode, U64};
 
 #[test]
-fn it_create_a_struct_field_type_node_when_nammed() -> syn::Result<()> {
+fn it_create_a_struct_field_type_node_when_nammed() -> CodamaResult<()> {
     let ast = syn::parse_quote! { foo: u64 };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut SetBorshTypesVisitor::new())?;
@@ -17,9 +18,9 @@ fn it_create_a_struct_field_type_node_when_nammed() -> syn::Result<()> {
 }
 
 #[test]
-fn it_forwards_the_type_when_unnamed() -> syn::Result<()> {
+fn it_forwards_the_type_when_unnamed() -> CodamaResult<()> {
     let ast = syn::parse_quote! { u64 };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut SetBorshTypesVisitor::new())?;

--- a/codama-korok-visitors/tests/set_borsh_types_visitor/no_override.rs
+++ b/codama-korok-visitors/tests/set_borsh_types_visitor/no_override.rs
@@ -3,10 +3,11 @@ use codama_koroks::FieldKorok;
 use codama_nodes::BooleanTypeNode;
 
 #[test]
-fn it_does_not_override_existing_nodes() {
+fn it_does_not_override_existing_nodes() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! { u32 };
     let mut korok = FieldKorok::parse(&ast).unwrap();
     korok.node = Some(BooleanTypeNode::default().into());
-    korok.accept(&mut SetBorshTypesVisitor::new());
+    korok.accept(&mut SetBorshTypesVisitor::new())?;
     assert_eq!(korok.node, Some(BooleanTypeNode::default().into()));
+    Ok(())
 }

--- a/codama-korok-visitors/tests/set_borsh_types_visitor/no_override.rs
+++ b/codama-korok-visitors/tests/set_borsh_types_visitor/no_override.rs
@@ -1,11 +1,12 @@
+use codama_errors::CodamaResult;
 use codama_korok_visitors::{KorokVisitable, SetBorshTypesVisitor};
 use codama_koroks::FieldKorok;
 use codama_nodes::BooleanTypeNode;
 
 #[test]
-fn it_does_not_override_existing_nodes() -> syn::Result<()> {
+fn it_does_not_override_existing_nodes() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! { u32 };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
     korok.node = Some(BooleanTypeNode::default().into());
     korok.accept(&mut SetBorshTypesVisitor::new())?;
     assert_eq!(korok.node, Some(BooleanTypeNode::default().into()));

--- a/codama-korok-visitors/tests/set_borsh_types_visitor/utils.rs
+++ b/codama-korok-visitors/tests/set_borsh_types_visitor/utils.rs
@@ -8,8 +8,8 @@ use quote::quote;
 pub fn get_node(tt: TokenStream, node_getter: fn(RootKorok) -> Option<Node>) -> Option<Node> {
     let store = RootStore::hydrate(tt).unwrap();
     let mut korok = RootKorok::parse(&store).unwrap();
-    korok.accept(&mut SetBorshTypesVisitor::new());
-    korok.accept(&mut CombineTypesVisitor::new());
+    korok.accept(&mut SetBorshTypesVisitor::new()).unwrap();
+    korok.accept(&mut CombineTypesVisitor::new()).unwrap();
     node_getter(korok)
 }
 

--- a/codama-korok-visitors/tests/set_link_types_visitor.rs
+++ b/codama-korok-visitors/tests/set_link_types_visitor.rs
@@ -3,57 +3,61 @@ use codama_koroks::{FieldKorok, StructKorok};
 use codama_nodes::{DefinedTypeLinkNode, NumberFormat::U32, NumberTypeNode, StructFieldTypeNode};
 
 #[test]
-fn it_sets_link_nodes_using_the_type_path() {
+fn it_sets_link_nodes_using_the_type_path() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! { Membership };
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut SetLinkTypesVisitor::new());
+    korok.accept(&mut SetLinkTypesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(DefinedTypeLinkNode::new("membership").into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_ignores_the_path_prefix() {
+fn it_ignores_the_path_prefix() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! { some::prefix::Membership };
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
-    korok.accept(&mut SetLinkTypesVisitor::new());
+    korok.accept(&mut SetLinkTypesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(DefinedTypeLinkNode::new("membership").into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_ignores_non_path_types() {
+fn it_ignores_non_path_types() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! { [u32; 8] };
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
-    korok.accept(&mut SetLinkTypesVisitor::new());
+    korok.accept(&mut SetLinkTypesVisitor::new())?;
     assert_eq!(korok.node, None);
+    Ok(())
 }
 
 #[test]
-fn it_ignores_types_that_already_have_nodes() {
+fn it_ignores_types_that_already_have_nodes() -> syn::Result<()> {
     let ast: syn::Field = syn::parse_quote! { u32 };
     let mut korok = FieldKorok::parse(&ast).unwrap();
     korok.node = Some(NumberTypeNode::le(U32).into());
 
-    korok.accept(&mut SetLinkTypesVisitor::new());
+    korok.accept(&mut SetLinkTypesVisitor::new())?;
     korok.node = Some(NumberTypeNode::le(U32).into());
+    Ok(())
 }
 
 #[test]
-fn it_works_in_any_parent_koroks() {
+fn it_works_in_any_parent_koroks() -> syn::Result<()> {
     let ast: syn::ItemStruct = syn::parse_quote! {
         pub struct Person(String, u8, Membership);
     };
     let mut korok = StructKorok::parse(&ast).unwrap();
 
-    korok.accept(&mut SetLinkTypesVisitor::new());
+    korok.accept(&mut SetLinkTypesVisitor::new())?;
     let fields = korok.fields.all;
     assert_eq!(
         fields[0].node,
@@ -64,30 +68,33 @@ fn it_works_in_any_parent_koroks() {
         fields[2].node,
         Some(DefinedTypeLinkNode::new("membership").into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_create_a_struct_field_type_node_when_nammed() {
+fn it_create_a_struct_field_type_node_when_nammed() -> syn::Result<()> {
     let ast = syn::parse_quote! { foo: Membership };
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut SetLinkTypesVisitor::new());
+    korok.accept(&mut SetLinkTypesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(StructFieldTypeNode::new("foo", DefinedTypeLinkNode::new("membership")).into())
     );
+    Ok(())
 }
 
 #[test]
-fn it_forwards_the_type_when_unnamed() {
+fn it_forwards_the_type_when_unnamed() -> syn::Result<()> {
     let ast = syn::parse_quote! { Membership };
     let mut korok = FieldKorok::parse(&ast).unwrap();
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut SetLinkTypesVisitor::new());
+    korok.accept(&mut SetLinkTypesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(DefinedTypeLinkNode::new("membership").into())
     );
+    Ok(())
 }

--- a/codama-korok-visitors/tests/set_link_types_visitor.rs
+++ b/codama-korok-visitors/tests/set_link_types_visitor.rs
@@ -1,11 +1,12 @@
+use codama_errors::CodamaResult;
 use codama_korok_visitors::{KorokVisitable, SetLinkTypesVisitor};
 use codama_koroks::{FieldKorok, StructKorok};
 use codama_nodes::{DefinedTypeLinkNode, NumberFormat::U32, NumberTypeNode, StructFieldTypeNode};
 
 #[test]
-fn it_sets_link_nodes_using_the_type_path() -> syn::Result<()> {
+fn it_sets_link_nodes_using_the_type_path() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! { Membership };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut SetLinkTypesVisitor::new())?;
@@ -17,9 +18,9 @@ fn it_sets_link_nodes_using_the_type_path() -> syn::Result<()> {
 }
 
 #[test]
-fn it_ignores_the_path_prefix() -> syn::Result<()> {
+fn it_ignores_the_path_prefix() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! { some::prefix::Membership };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     korok.accept(&mut SetLinkTypesVisitor::new())?;
     assert_eq!(
@@ -30,9 +31,9 @@ fn it_ignores_the_path_prefix() -> syn::Result<()> {
 }
 
 #[test]
-fn it_ignores_non_path_types() -> syn::Result<()> {
+fn it_ignores_non_path_types() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! { [u32; 8] };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     korok.accept(&mut SetLinkTypesVisitor::new())?;
     assert_eq!(korok.node, None);
@@ -40,9 +41,9 @@ fn it_ignores_non_path_types() -> syn::Result<()> {
 }
 
 #[test]
-fn it_ignores_types_that_already_have_nodes() -> syn::Result<()> {
+fn it_ignores_types_that_already_have_nodes() -> CodamaResult<()> {
     let ast: syn::Field = syn::parse_quote! { u32 };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
     korok.node = Some(NumberTypeNode::le(U32).into());
 
     korok.accept(&mut SetLinkTypesVisitor::new())?;
@@ -51,11 +52,11 @@ fn it_ignores_types_that_already_have_nodes() -> syn::Result<()> {
 }
 
 #[test]
-fn it_works_in_any_parent_koroks() -> syn::Result<()> {
+fn it_works_in_any_parent_koroks() -> CodamaResult<()> {
     let ast: syn::ItemStruct = syn::parse_quote! {
         pub struct Person(String, u8, Membership);
     };
-    let mut korok = StructKorok::parse(&ast).unwrap();
+    let mut korok = StructKorok::parse(&ast)?;
 
     korok.accept(&mut SetLinkTypesVisitor::new())?;
     let fields = korok.fields.all;
@@ -72,9 +73,9 @@ fn it_works_in_any_parent_koroks() -> syn::Result<()> {
 }
 
 #[test]
-fn it_create_a_struct_field_type_node_when_nammed() -> syn::Result<()> {
+fn it_create_a_struct_field_type_node_when_nammed() -> CodamaResult<()> {
     let ast = syn::parse_quote! { foo: Membership };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut SetLinkTypesVisitor::new())?;
@@ -86,9 +87,9 @@ fn it_create_a_struct_field_type_node_when_nammed() -> syn::Result<()> {
 }
 
 #[test]
-fn it_forwards_the_type_when_unnamed() -> syn::Result<()> {
+fn it_forwards_the_type_when_unnamed() -> CodamaResult<()> {
     let ast = syn::parse_quote! { Membership };
-    let mut korok = FieldKorok::parse(&ast).unwrap();
+    let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
     korok.accept(&mut SetLinkTypesVisitor::new())?;

--- a/codama-korok-visitors/tests/set_program_metadata_visitor/mod.rs
+++ b/codama-korok-visitors/tests/set_program_metadata_visitor/mod.rs
@@ -5,13 +5,13 @@ use codama_stores::CrateStore;
 use quote::quote;
 
 #[test]
-fn it_gets_program_metadata_from_the_manifest() {
+fn it_gets_program_metadata_from_the_manifest() -> syn::Result<()> {
     let mut store = CrateStore::hydrate(quote! {}).unwrap();
     let manifest = cargo_toml::Manifest::from_path(get_path("full_metadata.toml")).unwrap();
     store.manifest = Some(manifest);
 
     let mut korok = CrateKorok::parse(&store).unwrap();
-    korok.accept(&mut SetProgramMetadataVisitor::new());
+    korok.accept(&mut SetProgramMetadataVisitor::new())?;
 
     let Some(Node::Program(program)) = korok.node else {
         panic!("Expected program node");
@@ -23,16 +23,17 @@ fn it_gets_program_metadata_from_the_manifest() {
         program.public_key,
         "MyProgramAddress1111111111111111111111111"
     );
+    Ok(())
 }
 
 #[test]
-fn it_gets_program_ids_from_the_declare_id_macro() {
+fn it_gets_program_ids_from_the_declare_id_macro() -> syn::Result<()> {
     let store = CrateStore::hydrate(quote! {
         solana_program::declare_id!("MyProgramAddress1111111111111111111111111");
     })
     .unwrap();
     let mut korok = CrateKorok::parse(&store).unwrap();
-    korok.accept(&mut SetProgramMetadataVisitor::new());
+    korok.accept(&mut SetProgramMetadataVisitor::new())?;
 
     let Some(Node::Program(program)) = korok.node else {
         panic!("Expected program node");
@@ -41,10 +42,11 @@ fn it_gets_program_ids_from_the_declare_id_macro() {
         program.public_key,
         "MyProgramAddress1111111111111111111111111"
     );
+    Ok(())
 }
 
 #[test]
-fn it_prioritises_the_program_id_from_the_manifest() {
+fn it_prioritises_the_program_id_from_the_manifest() -> syn::Result<()> {
     let mut store = CrateStore::hydrate(quote! {
         solana_program::declare_id!("MyMacroProgramAddress1111111111111111111111111");
     })
@@ -53,7 +55,7 @@ fn it_prioritises_the_program_id_from_the_manifest() {
     store.manifest = Some(manifest);
 
     let mut korok = CrateKorok::parse(&store).unwrap();
-    korok.accept(&mut SetProgramMetadataVisitor::new());
+    korok.accept(&mut SetProgramMetadataVisitor::new())?;
 
     assert_eq!(
         korok.node,
@@ -67,10 +69,11 @@ fn it_prioritises_the_program_id_from_the_manifest() {
             .into()
         )
     );
+    Ok(())
 }
 
 #[test]
-fn it_updates_existing_program_nodes() {
+fn it_updates_existing_program_nodes() -> syn::Result<()> {
     let store = CrateStore::hydrate(quote! {
         solana_program::declare_id!("MyProgramAddress1111111111111111111111111");
     })
@@ -78,7 +81,7 @@ fn it_updates_existing_program_nodes() {
 
     let mut korok = CrateKorok::parse(&store).unwrap();
     korok.node = Some(ProgramNode::default().into());
-    korok.accept(&mut SetProgramMetadataVisitor::new());
+    korok.accept(&mut SetProgramMetadataVisitor::new())?;
 
     assert_eq!(
         korok.node,
@@ -90,10 +93,11 @@ fn it_updates_existing_program_nodes() {
             .into()
         )
     );
+    Ok(())
 }
 
 #[test]
-fn it_updates_the_primary_program_of_existing_root_nodes() {
+fn it_updates_the_primary_program_of_existing_root_nodes() -> syn::Result<()> {
     let store = CrateStore::hydrate(quote! {
         solana_program::declare_id!("MyProgramAddress1111111111111111111111111");
     })
@@ -101,7 +105,7 @@ fn it_updates_the_primary_program_of_existing_root_nodes() {
 
     let mut korok = CrateKorok::parse(&store).unwrap();
     korok.node = Some(RootNode::default().into());
-    korok.accept(&mut SetProgramMetadataVisitor::new());
+    korok.accept(&mut SetProgramMetadataVisitor::new())?;
 
     assert_eq!(
         korok.node,
@@ -113,10 +117,11 @@ fn it_updates_the_primary_program_of_existing_root_nodes() {
             .into()
         )
     );
+    Ok(())
 }
 
 #[test]
-fn it_does_not_override_existing_values() {
+fn it_does_not_override_existing_values() -> syn::Result<()> {
     let mut store = CrateStore::hydrate(quote! {
         solana_program::declare_id!("MyMacroProgramAddress1111111111111111111111111");
     })
@@ -133,12 +138,13 @@ fn it_does_not_override_existing_values() {
     };
     korok.node = Some(existing_program.clone().into());
 
-    korok.accept(&mut SetProgramMetadataVisitor::new());
+    korok.accept(&mut SetProgramMetadataVisitor::new())?;
     assert_eq!(korok.node, Some(existing_program.into()));
+    Ok(())
 }
 
 #[test]
-fn it_does_nothing_to_existing_nodes_that_are_not_roots_or_programs() {
+fn it_does_nothing_to_existing_nodes_that_are_not_roots_or_programs() -> syn::Result<()> {
     let store = CrateStore::hydrate(quote! {
         solana_program::declare_id!("MyProgramAddress1111111111111111111111111");
     })
@@ -147,8 +153,9 @@ fn it_does_nothing_to_existing_nodes_that_are_not_roots_or_programs() {
     let mut korok = CrateKorok::parse(&store).unwrap();
     korok.node = Some(StringValueNode::new("hello").into());
 
-    korok.accept(&mut SetProgramMetadataVisitor::new());
+    korok.accept(&mut SetProgramMetadataVisitor::new())?;
     assert_eq!(korok.node, Some(StringValueNode::new("hello").into()));
+    Ok(())
 }
 
 pub fn get_path(relative_path: &str) -> std::path::PathBuf {

--- a/codama-korok-visitors/tests/uniform_visitor.rs
+++ b/codama-korok-visitors/tests/uniform_visitor.rs
@@ -1,11 +1,12 @@
+use codama_errors::CodamaResult;
 use codama_korok_visitors::{KorokVisitable, KorokVisitor, UniformVisitor};
 use codama_koroks::{KorokMut, KorokTrait, StructKorok};
 use codama_nodes::PublicKeyTypeNode;
 
 #[test]
-fn it_can_set_a_node_on_all_koroks() -> syn::Result<()> {
+fn it_can_set_a_node_on_all_koroks() -> CodamaResult<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo(u32); };
-    let mut korok = StructKorok::parse(&ast).unwrap();
+    let mut korok = StructKorok::parse(&ast)?;
 
     korok.accept(&mut UniformVisitor::new(|mut k, visitor| {
         visitor.visit_children(&mut k)?;
@@ -21,9 +22,9 @@ fn it_can_set_a_node_on_all_koroks() -> syn::Result<()> {
 }
 
 #[test]
-fn it_can_reset_all_nodes() -> syn::Result<()> {
+fn it_can_reset_all_nodes() -> CodamaResult<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo(u32); };
-    let mut korok = StructKorok::parse(&ast).unwrap();
+    let mut korok = StructKorok::parse(&ast)?;
     korok.node = Some(PublicKeyTypeNode::new().into());
     korok.fields.node = Some(PublicKeyTypeNode::new().into());
     let field = &mut korok.fields.all[0];
@@ -43,9 +44,9 @@ fn it_can_reset_all_nodes() -> syn::Result<()> {
 }
 
 #[test]
-fn is_can_make_decisions_based_on_the_korok_type() -> syn::Result<()> {
+fn is_can_make_decisions_based_on_the_korok_type() -> CodamaResult<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo(u32); };
-    let mut korok = StructKorok::parse(&ast).unwrap();
+    let mut korok = StructKorok::parse(&ast)?;
 
     korok.accept(&mut UniformVisitor::new(|mut k, visitor| {
         visitor.visit_children(&mut k)?;

--- a/codama-korok-visitors/tests/uniform_visitor.rs
+++ b/codama-korok-visitors/tests/uniform_visitor.rs
@@ -3,23 +3,25 @@ use codama_koroks::{KorokMut, KorokTrait, StructKorok};
 use codama_nodes::PublicKeyTypeNode;
 
 #[test]
-fn it_can_set_a_node_on_all_koroks() {
+fn it_can_set_a_node_on_all_koroks() -> syn::Result<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo(u32); };
     let mut korok = StructKorok::parse(&ast).unwrap();
 
     korok.accept(&mut UniformVisitor::new(|mut k, visitor| {
-        visitor.visit_children(&mut k);
-        k.set_node(Some(PublicKeyTypeNode::new().into()))
-    }));
+        visitor.visit_children(&mut k)?;
+        k.set_node(Some(PublicKeyTypeNode::new().into()));
+        Ok(())
+    }))?;
 
     assert_eq!(korok.node, Some(PublicKeyTypeNode::new().into()));
     assert_eq!(korok.fields.node, Some(PublicKeyTypeNode::new().into()));
     let field = &korok.fields.all[0];
     assert_eq!(field.node, Some(PublicKeyTypeNode::new().into()));
+    Ok(())
 }
 
 #[test]
-fn it_can_reset_all_nodes() {
+fn it_can_reset_all_nodes() -> syn::Result<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo(u32); };
     let mut korok = StructKorok::parse(&ast).unwrap();
     korok.node = Some(PublicKeyTypeNode::new().into());
@@ -28,33 +30,37 @@ fn it_can_reset_all_nodes() {
     field.node = Some(PublicKeyTypeNode::new().into());
 
     korok.accept(&mut UniformVisitor::new(|mut k, visitor| {
-        visitor.visit_children(&mut k);
-        k.set_node(None)
-    }));
+        visitor.visit_children(&mut k)?;
+        k.set_node(None);
+        Ok(())
+    }))?;
 
     assert_eq!(korok.node, None);
     assert_eq!(korok.fields.node, None);
     let field = &korok.fields.all[0];
     assert_eq!(field.node, None);
+    Ok(())
 }
 
 #[test]
-fn is_can_make_decisions_based_on_the_korok_type() {
+fn is_can_make_decisions_based_on_the_korok_type() -> syn::Result<()> {
     let ast: syn::ItemStruct = syn::parse_quote! { struct Foo(u32); };
     let mut korok = StructKorok::parse(&ast).unwrap();
 
     korok.accept(&mut UniformVisitor::new(|mut k, visitor| {
-        visitor.visit_children(&mut k);
+        visitor.visit_children(&mut k)?;
         match k {
             KorokMut::Field(_) => {
                 k.set_node(Some(PublicKeyTypeNode::new().into()));
             }
             _ => {}
-        }
-    }));
+        };
+        Ok(())
+    }))?;
 
     assert_eq!(korok.node, None);
     assert_eq!(korok.fields.node, None);
     let field = &korok.fields.all[0];
     assert_eq!(field.node, Some(PublicKeyTypeNode::new().into()));
+    Ok(())
 }

--- a/codama/src/codama.rs
+++ b/codama/src/codama.rs
@@ -57,7 +57,7 @@ impl Codama {
     pub fn get_visited_korok(&self) -> CodamaResult<RootKorok> {
         let mut korok = self.get_korok()?;
         let run_plugins = resolve_plugins(self.get_plugins());
-        run_plugins(&mut korok);
+        run_plugins(&mut korok)?;
         Ok(korok)
     }
 


### PR DESCRIPTION
This allows this part of Codama to handle errors instead of quietly ignoring erroneous scenarios.