### PR TITLE
Decouple codama test dependency from codama_macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,6 @@ dependencies = [
 name = "codama-macros"
 version = "0.1.0"
 dependencies = [
- "codama",
  "codama-attributes",
  "codama-errors",
  "codama-koroks",

--- a/codama-macros/Cargo.toml
+++ b/codama-macros/Cargo.toml
@@ -14,7 +14,6 @@ name = "tests"
 path = "tests/mod.rs"
 
 [dev-dependencies]
-codama = { version = "0.1.0", path = "../codama" }
 trybuild = { version = "1.0.49", features = ["diff"] }
 
 [dependencies]

--- a/codama-macros/tests/codama_account_derive/_pass.rs
+++ b/codama-macros/tests/codama_account_derive/_pass.rs
@@ -1,4 +1,4 @@
-use codama::CodamaAccount;
+use codama_macros::CodamaAccount;
 
 #[derive(CodamaAccount)]
 pub struct StructTest;

--- a/codama-macros/tests/codama_account_derive/multiple_types.fail.rs
+++ b/codama-macros/tests/codama_account_derive/multiple_types.fail.rs
@@ -1,4 +1,4 @@
-use codama::{codama, CodamaAccount};
+use codama_macros::{codama, CodamaAccount};
 
 #[derive(CodamaAccount)]
 #[codama(type = boolean)]

--- a/codama-macros/tests/codama_accounts_derive/_pass.rs
+++ b/codama-macros/tests/codama_accounts_derive/_pass.rs
@@ -1,4 +1,4 @@
-use codama::CodamaAccounts;
+use codama_macros::CodamaAccounts;
 
 #[derive(CodamaAccounts)]
 pub enum TokenAccounts {

--- a/codama-macros/tests/codama_attribute/attribute_directive/_pass.rs
+++ b/codama-macros/tests/codama_attribute/attribute_directive/_pass.rs
@@ -1,4 +1,4 @@
-use codama::{codama, CodamaInstruction};
+use codama_macros::{codama, CodamaInstruction};
 
 pub struct AccountMeta;
 

--- a/codama-macros/tests/codama_attribute/attribute_directive/invalid_optional.fail.rs
+++ b/codama-macros/tests/codama_attribute/attribute_directive/invalid_optional.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(account(optional = invalid))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/attribute_directive/invalid_signer.fail.rs
+++ b/codama-macros/tests/codama_attribute/attribute_directive/invalid_signer.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(account(signer = invalid))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/attribute_directive/invalid_writable.fail.rs
+++ b/codama-macros/tests/codama_attribute/attribute_directive/invalid_writable.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(account(writable = invalid))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/attribute_directive/name_missing.fail.rs
+++ b/codama-macros/tests/codama_attribute/attribute_directive/name_missing.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(account)]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/encoding_directive/_pass.rs
+++ b/codama-macros/tests/codama_attribute/encoding_directive/_pass.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(encoding = utf8)]
 #[codama(encoding = base16)]

--- a/codama-macros/tests/codama_attribute/encoding_directive/invalid_encoding.fail.rs
+++ b/codama-macros/tests/codama_attribute/encoding_directive/invalid_encoding.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(encoding = invalid)]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/explicit_path.pass.rs
+++ b/codama-macros/tests/codama_attribute/explicit_path.pass.rs
@@ -1,4 +1,3 @@
-#[codama::codama(type = boolean)]
 #[codama_macros::codama(type = boolean)]
 pub struct Test;
 

--- a/codama-macros/tests/codama_attribute/fixed_size_directive/_pass.rs
+++ b/codama-macros/tests/codama_attribute/fixed_size_directive/_pass.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(fixed_size = 42)]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/fixed_size_directive/invalid_size.fail.rs
+++ b/codama-macros/tests/codama_attribute/fixed_size_directive/invalid_size.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(fixed_size = invalid(1, 2, 3))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/implicit_path.pass.rs
+++ b/codama-macros/tests/codama_attribute/implicit_path.pass.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = boolean)]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/on_any_item.fail.rs
+++ b/codama-macros/tests/codama_attribute/on_any_item.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = invalid)]
 pub struct StructTest;

--- a/codama-macros/tests/codama_attribute/on_any_item.pass.rs
+++ b/codama-macros/tests/codama_attribute/on_any_item.pass.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = boolean)]
 pub struct StructTest;

--- a/codama-macros/tests/codama_attribute/on_fields.fail.rs
+++ b/codama-macros/tests/codama_attribute/on_fields.fail.rs
@@ -1,4 +1,4 @@
-use codama::{codama, CodamaType};
+use codama_macros::{codama, CodamaType};
 
 #[derive(CodamaType)]
 pub struct StructTest {

--- a/codama-macros/tests/codama_attribute/on_fields.pass.rs
+++ b/codama-macros/tests/codama_attribute/on_fields.pass.rs
@@ -1,4 +1,4 @@
-use codama::{codama, CodamaType};
+use codama_macros::{codama, CodamaType};
 
 #[derive(CodamaType)]
 pub struct StructTest {

--- a/codama-macros/tests/codama_attribute/size_prefix_directive/_pass.rs
+++ b/codama-macros/tests/codama_attribute/size_prefix_directive/_pass.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(size_prefix = number(u32))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/size_prefix_directive/invalid_size.fail.rs
+++ b/codama-macros/tests/codama_attribute/size_prefix_directive/invalid_size.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(size_prefix = string)]
 pub struct TestWithNonNumberTypeNode;

--- a/codama-macros/tests/codama_attribute/type_directive/double_type.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_directive/double_type.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = (number(u32), public_key))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/type_directive/no_type.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_directive/no_type.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = )]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/type_directive/unrecognized_type.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_directive/unrecognized_type.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = unrecognized_type(foo = 42))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/type_nodes/boolean_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/boolean_type_node/_pass.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = boolean)]
 #[codama(type = boolean())]

--- a/codama-macros/tests/codama_attribute/type_nodes/boolean_type_node/size_already_set.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/boolean_type_node/size_already_set.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = boolean(number(u32), number(u32)))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/type_nodes/boolean_type_node/unrecognized_attribute.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/boolean_type_node/unrecognized_attribute.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = boolean(foo = 42))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/type_nodes/boolean_type_node/unrecognized_type.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/boolean_type_node/unrecognized_type.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = boolean(unrecognized))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/type_nodes/fixed_size_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/fixed_size_type_node/_pass.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = fixed_size(boolean, 42))]
 #[codama(type = fixed_size(type = boolean, size = 42))]

--- a/codama-macros/tests/codama_attribute/type_nodes/fixed_size_type_node/size_already_set.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/fixed_size_type_node/size_already_set.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = fixed_size(42, boolean, 100))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/type_nodes/fixed_size_type_node/size_missing.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/fixed_size_type_node/size_missing.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = fixed_size(boolean))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/type_nodes/fixed_size_type_node/type_already_set.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/fixed_size_type_node/type_already_set.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = fixed_size(boolean, 42, number(u32)))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/type_nodes/fixed_size_type_node/type_missing.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/fixed_size_type_node/type_missing.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = fixed_size(42))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/type_nodes/number_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/number_type_node/_pass.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = number(u32))]
 #[codama(type = number(u32, be))]

--- a/codama-macros/tests/codama_attribute/type_nodes/number_type_node/endian_already_set.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/number_type_node/endian_already_set.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = number(be, le, u32))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/type_nodes/number_type_node/format_already_set.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/number_type_node/format_already_set.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = number(u32, u64))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/type_nodes/number_type_node/format_missing.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/number_type_node/format_missing.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = number(le))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/type_nodes/number_type_node/invalid_endian.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/number_type_node/invalid_endian.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = number(u32, endian = invalid))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/type_nodes/number_type_node/invalid_format.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/number_type_node/invalid_format.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = number(format = invalid))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/type_nodes/number_type_node/unrecognized_attribute.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/number_type_node/unrecognized_attribute.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = number(u32, unrecognized = 42, le))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/type_nodes/public_key_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/public_key_type_node/_pass.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = public_key)]
 #[codama(type = public_key())]

--- a/codama-macros/tests/codama_attribute/type_nodes/public_key_type_node/with_input.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/public_key_type_node/with_input.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = public_key(foo = 42))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/type_nodes/string_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/string_type_node/_pass.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = string)]
 #[codama(type = string())]

--- a/codama-macros/tests/codama_attribute/type_nodes/string_type_node/encoding_already_set.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/string_type_node/encoding_already_set.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = string(utf8, base64))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/type_nodes/string_type_node/invalid_encoding.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/string_type_node/invalid_encoding.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = string(encoding = invalid))]
 pub struct Test;

--- a/codama-macros/tests/codama_attribute/type_nodes/string_type_node/unrecognized_attribute.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/string_type_node/unrecognized_attribute.fail.rs
@@ -1,4 +1,4 @@
-use codama::codama;
+use codama_macros::codama;
 
 #[codama(type = string(unrecognized))]
 pub struct Test;

--- a/codama-macros/tests/codama_instruction_derive/_pass.rs
+++ b/codama-macros/tests/codama_instruction_derive/_pass.rs
@@ -1,4 +1,4 @@
-use codama::CodamaInstruction;
+use codama_macros::CodamaInstruction;
 
 #[derive(CodamaInstruction)]
 pub struct StructTest;

--- a/codama-macros/tests/codama_instruction_derive/multiple_types.fail.rs
+++ b/codama-macros/tests/codama_instruction_derive/multiple_types.fail.rs
@@ -1,4 +1,4 @@
-use codama::{codama, CodamaInstruction};
+use codama_macros::{codama, CodamaInstruction};
 
 #[derive(CodamaInstruction)]
 #[codama(type = boolean)]

--- a/codama-macros/tests/codama_instructions_derive/_pass.rs
+++ b/codama-macros/tests/codama_instructions_derive/_pass.rs
@@ -1,4 +1,4 @@
-use codama::CodamaInstructions;
+use codama_macros::CodamaInstructions;
 
 #[derive(CodamaInstructions)]
 pub enum TokenInstructions {

--- a/codama-macros/tests/codama_type_derive/_pass.rs
+++ b/codama-macros/tests/codama_type_derive/_pass.rs
@@ -1,4 +1,4 @@
-use codama::CodamaType;
+use codama_macros::CodamaType;
 
 #[derive(CodamaType)]
 pub struct StructTest;

--- a/codama-macros/tests/codama_type_derive/multiple_types.fail.rs
+++ b/codama-macros/tests/codama_type_derive/multiple_types.fail.rs
@@ -1,4 +1,4 @@
-use codama::{codama, CodamaType};
+use codama_macros::{codama, CodamaType};
 
 #[derive(CodamaType)]
 #[codama(type = boolean)]


### PR DESCRIPTION
This creates a circular dependency since `codama` re-exports `codama_macros`.