### PR TITLE
Support custom size enums

### DIFF
--- a/codama-attributes/src/attribute.rs
+++ b/codama-attributes/src/attribute.rs
@@ -35,4 +35,18 @@ impl<'a> Attribute<'a> {
             _ => None,
         }
     }
+
+    pub fn derive(&self) -> Option<&DeriveAttribute<'a>> {
+        match self {
+            Attribute::Derive(a) => Some(a),
+            _ => None,
+        }
+    }
+
+    pub fn repr(&self) -> Option<&ReprAttribute<'a>> {
+        match self {
+            Attribute::Repr(a) => Some(a),
+            _ => None,
+        }
+    }
 }

--- a/codama-attributes/src/attribute.rs
+++ b/codama-attributes/src/attribute.rs
@@ -1,13 +1,17 @@
-use crate::{AttributeContext, CodamaAttribute, DeriveAttribute, UnsupportedAttribute};
+use crate::{
+    AttributeContext, CodamaAttribute, DeriveAttribute, ReprAttribute, UnsupportedAttribute,
+};
 use codama_syn_helpers::extensions::*;
 use derive_more::derive::From;
 
 #[derive(Debug, PartialEq, From)]
 pub enum Attribute<'a> {
-    // E.g. `#[derive(Debug, CodamaType)]`.
-    Derive(DeriveAttribute<'a>),
     // E.g. `#[codama(type = number(u8))]` or `#[codama(fixed_size = 32)]`.
     Codama(CodamaAttribute<'a>),
+    // E.g. `#[derive(Debug, CodamaType)]`.
+    Derive(DeriveAttribute<'a>),
+    // E.g. `#[repr(u32, align(8))]`.
+    Repr(ReprAttribute<'a>),
     // E.g. `#[some_unsupported_attribute = 42]`.
     Unsupported(UnsupportedAttribute<'a>),
 }
@@ -16,10 +20,11 @@ impl<'a> Attribute<'a> {
     pub fn parse(attr: &'a syn::Attribute, ctx: &AttributeContext) -> syn::Result<Self> {
         let path = attr.path();
         match (path.prefix().as_str(), path.last_str().as_str()) {
-            ("", "derive") => Ok(DeriveAttribute::parse(attr)?.into()),
             ("" | "codama_macros" | "codama", "codama") => {
                 Ok(CodamaAttribute::parse(attr, ctx)?.into())
             }
+            ("", "derive") => Ok(DeriveAttribute::parse(attr)?.into()),
+            ("", "repr") => Ok(ReprAttribute::parse(attr)?.into()),
             _ => Ok(UnsupportedAttribute::new(attr).into()),
         }
     }

--- a/codama-attributes/src/attributes.rs
+++ b/codama-attributes/src/attributes.rs
@@ -66,12 +66,10 @@ impl<'a> Attributes<'a> {
     }
 
     pub fn has_derive(&self, prefixes: &[&str], last: &str) -> bool {
-        self.iter().any(|attr| match attr {
-            Attribute::Derive(a) => a
-                .derives
+        self.iter().filter_map(Attribute::derive).any(|attr| {
+            attr.derives
                 .iter()
-                .any(|p| prefixes.contains(&p.prefix().as_str()) && p.last_str() == last),
-            _ => false,
+                .any(|p| prefixes.contains(&p.prefix().as_str()) && p.last_str() == last)
         })
     }
 

--- a/codama-attributes/src/lib.rs
+++ b/codama-attributes/src/lib.rs
@@ -6,6 +6,7 @@ mod attributes;
 mod codama_attribute;
 mod codama_directives;
 mod derive_attribute;
+mod repr_attribute;
 mod unsupported_attribute;
 
 pub use attribute::*;
@@ -14,4 +15,5 @@ pub use attributes::*;
 pub use codama_attribute::*;
 pub use codama_directives::*;
 pub use derive_attribute::*;
+pub use repr_attribute::*;
 pub use unsupported_attribute::*;

--- a/codama-attributes/src/repr_attribute.rs
+++ b/codama-attributes/src/repr_attribute.rs
@@ -1,0 +1,55 @@
+use codama_syn_helpers::extensions::*;
+
+#[derive(Debug, PartialEq)]
+pub struct ReprAttribute<'a> {
+    pub ast: &'a syn::Attribute,
+    pub metas: Vec<syn::Meta>,
+}
+
+impl<'a> ReprAttribute<'a> {
+    pub fn parse(ast: &'a syn::Attribute) -> syn::Result<Self> {
+        // Check if the attribute is feature-gated.
+        let unfeatured = ast.unfeatured();
+        let attr = unfeatured.as_ref().unwrap_or(ast);
+
+        // Check if the attribute is a #[repr(...)] attribute.
+        let list = attr.meta.require_list()?;
+        if !list.path.is_strict("repr") {
+            return Err(list.path.error("expected #[repr(...)]"));
+        };
+
+        // Parse the list of metas.
+        let metas = list.parse_comma_args::<syn::Meta>()?;
+        Ok(Self { ast, metas })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_quote;
+
+    #[test]
+    fn test_repr_attribute() {
+        let ast = parse_quote! { #[repr(u32, align(4))] };
+        let attribute = ReprAttribute::parse(&ast).unwrap();
+
+        assert_eq!(attribute.ast, &ast);
+        assert_eq!(
+            attribute.metas,
+            [(parse_quote! { u32 }), (parse_quote! { align(4) })]
+        );
+    }
+
+    #[test]
+    fn test_feature_gated_repr_attribute() {
+        let ast = parse_quote! { #[cfg_attr(feature = "some_feature", repr(u32, align(4)))] };
+        let attribute = ReprAttribute::parse(&ast).unwrap();
+
+        assert_eq!(attribute.ast, &ast);
+        assert_eq!(
+            attribute.metas,
+            [(parse_quote! { u32 }), (parse_quote! { align(4) })]
+        );
+    }
+}

--- a/codama-korok-visitors/src/set_instructions_visitors.rs
+++ b/codama-korok-visitors/src/set_instructions_visitors.rs
@@ -3,15 +3,17 @@ use codama_attributes::{Attribute, Attributes, CodamaAttribute};
 use codama_errors::CodamaResult;
 use codama_koroks::FieldsKorok;
 use codama_nodes::{
-    DefaultValueStrategy, Docs, EnumVariantTypeNode, FieldDiscriminatorNode,
-    InstructionAccountNode, InstructionArgumentNode, InstructionNode, NestedTypeNode, Node,
-    NumberFormat::U8, NumberTypeNode, NumberValueNode, ProgramNode, StructTypeNode, TypeNode,
+    DefaultValueStrategy, DefinedTypeNode, Docs, EnumVariantTypeNode, FieldDiscriminatorNode,
+    InstructionAccountNode, InstructionArgumentNode, InstructionNode, NestedTypeNode,
+    NestedTypeNodeTrait, Node, NumberFormat::U8, NumberTypeNode, NumberValueNode, ProgramNode,
+    StructTypeNode, TypeNode,
 };
 use codama_syn_helpers::extensions::{ExprExtension, ToTokensExtension};
 
 pub struct SetInstructionsVisitor {
     combine_types: CombineTypesVisitor,
     enum_name: Option<String>,
+    enum_size: Option<NumberTypeNode>,
     enum_current_discriminator: usize,
 }
 
@@ -29,6 +31,7 @@ impl Default for SetInstructionsVisitor {
                 ..CombineTypesVisitor::strict()
             },
             enum_name: None,
+            enum_size: None,
             enum_current_discriminator: 0,
         }
     }
@@ -84,11 +87,25 @@ impl KorokVisitor for SetInstructionsVisitor {
         // Create a `DefinedTypeNode` from the enum.
         self.combine_types.visit_enum(korok)?;
 
+        // Get details from the defined type enum.
+        let (enum_name, enum_size) = match &korok.node {
+            Some(Node::DefinedType(DefinedTypeNode { name, r#type, .. })) => match r#type {
+                TypeNode::Enum(data) => (
+                    Some(name.to_string()),
+                    Some(data.size.get_nested_type_node().clone()),
+                ),
+                _ => (Some(name.to_string()), None),
+            },
+            _ => (None, None),
+        };
+
         // Transform each variant into an `InstructionNode`.
-        self.enum_name = Some(korok.ast.ident.to_string());
+        self.enum_name = Some(enum_name.unwrap_or(korok.ast.ident.to_string()));
+        self.enum_size = enum_size;
         self.enum_current_discriminator = 0;
         self.visit_children(korok)?;
         self.enum_name = None;
+        self.enum_size = None;
         self.enum_current_discriminator = 0;
 
         // Gather all instructions in a `ProgramNode`.
@@ -130,7 +147,11 @@ impl KorokVisitor for SetInstructionsVisitor {
             name: discriminator_name.clone().into(),
             default_value_strategy: Some(DefaultValueStrategy::Omitted),
             docs: Docs::default(),
-            r#type: NumberTypeNode::le(U8).into(),
+            r#type: self
+                .enum_size
+                .clone()
+                .unwrap_or(NumberTypeNode::le(U8))
+                .into(),
             default_value: Some(NumberValueNode::new(current_discriminator as u64).into()),
         };
         arguments.insert(0, discriminator);

--- a/codama-korok-visitors/tests/set_accounts_visitor/from_codama_accounts.rs
+++ b/codama-korok-visitors/tests/set_accounts_visitor/from_codama_accounts.rs
@@ -3,7 +3,7 @@ use codama_korok_visitors::{KorokVisitable, SetAccountsVisitor, SetBorshTypesVis
 use codama_koroks::{EnumKorok, StructKorok};
 use codama_nodes::{
     AccountNode, BooleanTypeNode, DefaultValueStrategy, Docs, FieldDiscriminatorNode,
-    NumberFormat::{U64, U8},
+    NumberFormat::{U32, U64, U8},
     NumberTypeNode, NumberValueNode, OptionTypeNode, ProgramNode, PublicKeyTypeNode,
     StructFieldTypeNode, StructTypeNode,
 };
@@ -173,5 +173,65 @@ fn no_overrides() -> CodamaResult<()> {
 
     korok.accept(&mut SetAccountsVisitor::new())?;
     assert_eq!(korok.node, Some(BooleanTypeNode::default().into()));
+    Ok(())
+}
+
+#[test]
+fn with_custom_enum_size() -> CodamaResult<()> {
+    let item: syn::Item = syn::parse_quote! {
+        #[derive(CodamaAccounts)]
+        #[repr(u32)]
+        enum MyProgramAccounts {
+            Mint,
+            Token,
+        }
+    };
+    let mut korok = EnumKorok::parse(&item)?;
+
+    assert_eq!(korok.node, None);
+    korok.accept(&mut SetAccountsVisitor::new())?;
+    assert_eq!(
+        korok.node,
+        Some(
+            ProgramNode {
+                accounts: vec![
+                    AccountNode {
+                        name: "mint".into(),
+                        size: None,
+                        docs: Docs::default(),
+                        data: StructTypeNode::new(vec![
+                            StructFieldTypeNode {
+                                name: "discriminator".into(),
+                                default_value_strategy: Some(DefaultValueStrategy::Omitted),
+                                docs: Docs::default(),
+                                r#type: NumberTypeNode::le(U32).into(),
+                                default_value: Some(NumberValueNode::new(0u32).into()),
+                            },
+                        ]).into(),
+                        pda: None,
+                        discriminators: vec![FieldDiscriminatorNode::new("discriminator", 0).into()],
+                    },
+                    AccountNode {
+                        name: "token".into(),
+                        size: None,
+                        docs: Docs::default(),
+                        data: StructTypeNode::new(vec![
+                            StructFieldTypeNode {
+                                name: "discriminator".into(),
+                                default_value_strategy: Some(DefaultValueStrategy::Omitted),
+                                docs: Docs::default(),
+                                r#type: NumberTypeNode::le(U32).into(),
+                                default_value: Some(NumberValueNode::new(1u32).into()),
+                            },
+                        ]).into(),
+                        pda: None,
+                        discriminators: vec![FieldDiscriminatorNode::new("discriminator", 0).into()],
+                    }
+                ],
+                ..ProgramNode::default()
+            }
+            .into()
+        )
+    );
     Ok(())
 }

--- a/codama-korok-visitors/tests/set_instructions_visitor/from_codama_instructions.rs
+++ b/codama-korok-visitors/tests/set_instructions_visitor/from_codama_instructions.rs
@@ -387,7 +387,6 @@ fn with_custom_enum_size() -> CodamaResult<()> {
     let mut korok = EnumKorok::parse(&item)?;
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut SetBorshTypesVisitor::new())?;
     korok.accept(&mut SetInstructionsVisitor::new())?;
     assert_eq!(
         korok.node,

--- a/codama-nodes/src/node.rs
+++ b/codama-nodes/src/node.rs
@@ -81,6 +81,15 @@ impl HasKind for Node {
     }
 }
 
+impl HasKind for Option<Node> {
+    fn kind(&self) -> &'static str {
+        match self {
+            Some(node) => node.kind(),
+            None => "None",
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/codama/tests/system/crate/src/errors.rs
+++ b/codama/tests/system/crate/src/errors.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-// TODO: Add CodamaError(s)
+// TODO: Add CodamaErrors
 pub enum SystemError {
     #[error("an account with the same address already exists")]
     AccountAlreadyInUse,

--- a/codama/tests/system/crate/src/instructions.rs
+++ b/codama/tests/system/crate/src/instructions.rs
@@ -2,7 +2,7 @@ use codama::CodamaInstructions;
 use solana_pubkey::Pubkey;
 
 #[derive(CodamaInstructions)]
-// TODO: Enum size: u32
+#[repr(u32)]
 pub enum SystemInstruction {
     #[codama(account(name = "payer", signer, writable))] // TODO: Default value?
     #[codama(account(name = "new_account", signer, writable))]

--- a/codama/tests/system/crate/src/state.rs
+++ b/codama/tests/system/crate/src/state.rs
@@ -11,14 +11,14 @@ pub struct Nonce {
 }
 
 #[derive(CodamaType)]
-// TODO: Enum size: u32
+#[repr(u32)]
 pub enum NonceVersion {
     Legacy,
     Current,
 }
 
 #[derive(CodamaType)]
-// TODO: Enum size: u32
+#[repr(u32)]
 pub enum NonceState {
     Uninitialized,
     Initialized,

--- a/codama/tests/system/mod.rs
+++ b/codama/tests/system/mod.rs
@@ -92,7 +92,7 @@ fn get_idl() {
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -152,7 +152,7 @@ fn get_idl() {
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -200,7 +200,7 @@ fn get_idl() {
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -256,7 +256,7 @@ fn get_idl() {
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -351,7 +351,7 @@ fn get_idl() {
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -410,7 +410,7 @@ fn get_idl() {
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -466,7 +466,7 @@ fn get_idl() {
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -514,7 +514,7 @@ fn get_idl() {
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -556,7 +556,7 @@ fn get_idl() {
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -606,7 +606,7 @@ fn get_idl() {
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -686,7 +686,7 @@ fn get_idl() {
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -763,7 +763,7 @@ fn get_idl() {
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -830,7 +830,7 @@ fn get_idl() {
             "defaultValueStrategy": "omitted",
             "type": {
               "kind": "numberTypeNode",
-              "format": "u8",
+              "format": "u32",
               "endian": "le"
             },
             "defaultValue": {
@@ -866,7 +866,7 @@ fn get_idl() {
           ],
           "size": {
             "kind": "numberTypeNode",
-            "format": "u8",
+            "format": "u32",
             "endian": "le"
           }
         }
@@ -888,7 +888,7 @@ fn get_idl() {
           ],
           "size": {
             "kind": "numberTypeNode",
-            "format": "u8",
+            "format": "u32",
             "endian": "le"
           }
         }


### PR DESCRIPTION
This PR uses the `#[repr(...)]` macro to figure out the size of enums and therefore discriminators.