### PR TITLE
Add default value macros for instruction accounts

### DIFF
--- a/codama-attributes/src/codama_directives/codama_directive.rs
+++ b/codama-attributes/src/codama_directives/codama_directive.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AccountDirective, AttributeContext, EncodingDirective, ErrorDirective, FixedSizeDirective,
-    SizePrefixDirective, TypeDirective,
+    AccountDirective, AttributeContext, DefaultValueDirective, EncodingDirective, ErrorDirective,
+    FixedSizeDirective, SizePrefixDirective, TypeDirective,
 };
 use codama_syn_helpers::{extensions::*, Meta};
 use derive_more::derive::From;
@@ -9,6 +9,7 @@ use derive_more::derive::From;
 pub enum CodamaDirective {
     // Type directives.
     Type(TypeDirective),
+    DefaultValue(DefaultValueDirective),
     Encoding(EncodingDirective),
     FixedSize(FixedSizeDirective),
     SizePrefix(SizePrefixDirective),
@@ -26,6 +27,7 @@ impl CodamaDirective {
         match path.to_string().as_str() {
             // Type directives.
             "type" => Ok(TypeDirective::parse(meta)?.into()),
+            "default_value" => Ok(DefaultValueDirective::parse(meta)?.into()),
             "encoding" => Ok(EncodingDirective::parse(meta)?.into()),
             "fixed_size" => Ok(FixedSizeDirective::parse(meta)?.into()),
             "size_prefix" => Ok(SizePrefixDirective::parse(meta)?.into()),
@@ -44,6 +46,7 @@ impl CodamaDirective {
         match self {
             // Type directives.
             Self::Type(_) => "type",
+            Self::DefaultValue(_) => "default_value",
             Self::Encoding(_) => "encoding",
             Self::FixedSize(_) => "fixed_size",
             Self::SizePrefix(_) => "size_prefix",

--- a/codama-attributes/src/codama_directives/default_value_directive.rs
+++ b/codama-attributes/src/codama_directives/default_value_directive.rs
@@ -1,0 +1,75 @@
+use crate::{utils::FromMeta, Attribute, CodamaAttribute, CodamaDirective};
+use codama_errors::CodamaError;
+use codama_nodes::ValueNode;
+use codama_syn_helpers::Meta;
+
+#[derive(Debug, PartialEq)]
+pub struct DefaultValueDirective {
+    pub node: ValueNode, // TODO: Superset like InstructionInputValueNode?
+}
+
+impl DefaultValueDirective {
+    pub fn parse(meta: &Meta) -> syn::Result<Self> {
+        let pv = meta.assert_directive("default_value")?.as_path_value()?;
+        let node = ValueNode::from_meta(&pv.value)?;
+        Ok(Self { node })
+    }
+}
+
+impl<'a> TryFrom<&'a CodamaAttribute<'a>> for &'a DefaultValueDirective {
+    type Error = CodamaError;
+
+    fn try_from(attribute: &'a CodamaAttribute) -> Result<Self, Self::Error> {
+        match attribute.directive {
+            CodamaDirective::DefaultValue(ref a) => Ok(a),
+            _ => Err(CodamaError::InvalidCodamaDirective {
+                expected: "default_value".to_string(),
+                actual: attribute.directive.name().to_string(),
+            }),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a Attribute<'a>> for &'a DefaultValueDirective {
+    type Error = CodamaError;
+
+    fn try_from(attribute: &'a Attribute) -> Result<Self, Self::Error> {
+        <&CodamaAttribute>::try_from(attribute)?.try_into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codama_nodes::BooleanValueNode;
+    use syn::parse_quote;
+
+    #[test]
+    fn ok() {
+        let meta: Meta = parse_quote! { default_value = true };
+        let node = DefaultValueDirective::parse(&meta).unwrap().node;
+
+        assert_eq!(node, BooleanValueNode::new(true).into());
+    }
+
+    #[test]
+    fn no_input() {
+        let meta: Meta = parse_quote! { default_value =  };
+        let error = DefaultValueDirective::parse(&meta).unwrap_err();
+        assert_eq!(error.to_string(), "unrecognized value");
+    }
+
+    #[test]
+    fn multiple_inputs() {
+        let meta: Meta = parse_quote! { default_value = (true, false) };
+        let error = DefaultValueDirective::parse(&meta).unwrap_err();
+        assert_eq!(error.to_string(), "expected a single value, found a list");
+    }
+
+    #[test]
+    fn unrecognized_value() {
+        let meta: Meta = parse_quote! { default_value = banana };
+        let error = DefaultValueDirective::parse(&meta).unwrap_err();
+        assert_eq!(error.to_string(), "unrecognized value");
+    }
+}

--- a/codama-attributes/src/codama_directives/default_value_directive.rs
+++ b/codama-attributes/src/codama_directives/default_value_directive.rs
@@ -1,17 +1,17 @@
 use crate::{utils::FromMeta, Attribute, CodamaAttribute, CodamaDirective};
 use codama_errors::CodamaError;
-use codama_nodes::ValueNode;
+use codama_nodes::InstructionInputValueNode;
 use codama_syn_helpers::Meta;
 
 #[derive(Debug, PartialEq)]
 pub struct DefaultValueDirective {
-    pub node: ValueNode, // TODO: Superset like InstructionInputValueNode?
+    pub node: InstructionInputValueNode,
 }
 
 impl DefaultValueDirective {
     pub fn parse(meta: &Meta) -> syn::Result<Self> {
         let pv = meta.assert_directive("default_value")?.as_path_value()?;
-        let node = ValueNode::from_meta(&pv.value)?;
+        let node = InstructionInputValueNode::from_meta(&pv.value)?;
         Ok(Self { node })
     }
 }

--- a/codama-attributes/src/codama_directives/error_directive.rs
+++ b/codama-attributes/src/codama_directives/error_directive.rs
@@ -24,17 +24,16 @@ impl ErrorDirective {
                 meta.as_path_value()?
                     .value
                     .as_expr()?
-                    .as_literal_integer()?,
+                    .as_unsigned_integer()?,
                 meta,
             ),
-            ("message", _) => message.set(
-                meta.as_path_value()?.value.as_expr()?.as_literal_string()?,
-                meta,
-            ),
+            ("message", _) => {
+                message.set(meta.as_path_value()?.value.as_expr()?.as_string()?, meta)
+            }
             (_, Meta::Expr(expr)) => {
-                if let Ok(value) = expr.as_literal_integer() {
+                if let Ok(value) = expr.as_unsigned_integer() {
                     code.set(value, meta)
-                } else if let Ok(value) = expr.as_literal_string() {
+                } else if let Ok(value) = expr.as_string() {
                     message.set(value, meta)
                 } else {
                     Err(expr.error("expected an integer or a string"))

--- a/codama-attributes/src/codama_directives/fixed_size_directive.rs
+++ b/codama-attributes/src/codama_directives/fixed_size_directive.rs
@@ -10,7 +10,7 @@ pub struct FixedSizeDirective {
 impl FixedSizeDirective {
     pub fn parse(meta: &Meta) -> syn::Result<Self> {
         let pv = meta.assert_directive("fixed_size")?.as_path_value()?;
-        let size = pv.value.as_expr()?.as_literal_integer()?;
+        let size = pv.value.as_expr()?.as_unsigned_integer()?;
         Ok(Self { size })
     }
 }

--- a/codama-attributes/src/codama_directives/mod.rs
+++ b/codama-attributes/src/codama_directives/mod.rs
@@ -1,7 +1,9 @@
 mod type_nodes;
+mod value_nodes;
 
 mod account_directive;
 mod codama_directive;
+mod default_value_directive;
 mod encoding_directive;
 mod error_directive;
 mod fixed_size_directive;
@@ -10,6 +12,7 @@ mod type_directive;
 
 pub use account_directive::*;
 pub use codama_directive::*;
+pub use default_value_directive::*;
 pub use encoding_directive::*;
 pub use error_directive::*;
 pub use fixed_size_directive::*;

--- a/codama-attributes/src/codama_directives/type_nodes/fixed_size_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/fixed_size_type_node.rs
@@ -16,11 +16,11 @@ impl FromMeta for FixedSizeTypeNode<TypeNode> {
                     meta.as_path_value()?
                         .value
                         .as_expr()?
-                        .as_literal_integer()?,
+                        .as_unsigned_integer()?,
                     meta,
                 ),
                 (_, m) if m.is_path_or_list() => r#type.set(TypeNode::from_meta(meta)?, meta),
-                (_, Meta::Expr(expr)) => size.set(expr.as_literal_integer()?, meta),
+                (_, Meta::Expr(expr)) => size.set(expr.as_unsigned_integer()?, meta),
                 _ => Err(meta.error("unrecognized attribute")),
             })?;
         let r#type = r#type.take(meta)?;

--- a/codama-attributes/src/codama_directives/type_nodes/type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/type_node.rs
@@ -7,11 +7,11 @@ use codama_syn_helpers::{extensions::*, Meta};
 impl FromMeta for TypeNode {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
         match meta.path_str().as_str() {
-            "boolean" => Ok(BooleanTypeNode::from_meta(meta)?.into()),
-            "fixed_size" => Ok(FixedSizeTypeNode::from_meta(meta)?.into()),
-            "number" => Ok(NumberTypeNode::from_meta(meta)?.into()),
-            "public_key" => Ok(PublicKeyTypeNode::from_meta(meta)?.into()),
-            "string" => Ok(StringTypeNode::from_meta(meta)?.into()),
+            "boolean" => BooleanTypeNode::from_meta(meta).map(Self::from),
+            "fixed_size" => FixedSizeTypeNode::from_meta(meta).map(Self::from),
+            "number" => NumberTypeNode::from_meta(meta).map(Self::from),
+            "public_key" => PublicKeyTypeNode::from_meta(meta).map(Self::from),
+            "string" => StringTypeNode::from_meta(meta).map(Self::from),
             _ => Err(meta.error("unrecognized type")),
         }
     }

--- a/codama-attributes/src/codama_directives/value_nodes/boolean_value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/boolean_value_node.rs
@@ -4,7 +4,7 @@ use codama_syn_helpers::{extensions::*, Meta};
 
 impl FromMeta for BooleanValueNode {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
-        let value = meta.as_expr()?.as_literal_bool()?;
+        let value = meta.as_expr()?.as_bool()?;
         Ok(BooleanValueNode::new(value))
     }
 }

--- a/codama-attributes/src/codama_directives/value_nodes/boolean_value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/boolean_value_node.rs
@@ -1,0 +1,22 @@
+use crate::utils::FromMeta;
+use codama_nodes::BooleanValueNode;
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for BooleanValueNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let value = meta.as_expr()?.as_literal_bool()?;
+        Ok(BooleanValueNode::new(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::assert_value;
+
+    #[test]
+    fn ok() {
+        assert_value!({ true }, BooleanValueNode::new(true).into());
+        assert_value!({ false }, BooleanValueNode::new(false).into());
+    }
+}

--- a/codama-attributes/src/codama_directives/value_nodes/instruction_input_value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/instruction_input_value_node.rs
@@ -1,0 +1,12 @@
+use crate::utils::FromMeta;
+use codama_nodes::{InstructionInputValueNode, PublicKeyValueNode, ValueNode};
+use codama_syn_helpers::Meta;
+
+impl FromMeta for InstructionInputValueNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        match meta.path_str().as_str() {
+            "payer" => PublicKeyValueNode::from_meta(meta).map(Self::from), // TODO
+            _ => ValueNode::from_meta(meta).map(Self::from),
+        }
+    }
+}

--- a/codama-attributes/src/codama_directives/value_nodes/instruction_input_value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/instruction_input_value_node.rs
@@ -1,11 +1,11 @@
 use crate::utils::FromMeta;
-use codama_nodes::{InstructionInputValueNode, PublicKeyValueNode, ValueNode};
+use codama_nodes::{InstructionInputValueNode, PayerValueNode, ValueNode};
 use codama_syn_helpers::Meta;
 
 impl FromMeta for InstructionInputValueNode {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
         match meta.path_str().as_str() {
-            "payer" => PublicKeyValueNode::from_meta(meta).map(Self::from), // TODO
+            "payer" => PayerValueNode::from_meta(meta).map(Self::from),
             _ => ValueNode::from_meta(meta).map(Self::from),
         }
     }

--- a/codama-attributes/src/codama_directives/value_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/mod.rs
@@ -2,4 +2,5 @@ mod boolean_value_node;
 mod number_value_node;
 mod public_key_value_node;
 mod string_value_node;
+mod sysvar;
 mod value_node;

--- a/codama-attributes/src/codama_directives/value_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/mod.rs
@@ -1,6 +1,7 @@
 mod boolean_value_node;
 mod instruction_input_value_node;
 mod number_value_node;
+mod payer_value_node;
 mod public_key_value_node;
 mod string_value_node;
 mod sysvar;

--- a/codama-attributes/src/codama_directives/value_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/mod.rs
@@ -1,0 +1,2 @@
+mod boolean_value_node;
+mod value_node;

--- a/codama-attributes/src/codama_directives/value_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/mod.rs
@@ -1,2 +1,4 @@
 mod boolean_value_node;
+mod number_value_node;
+mod string_value_node;
 mod value_node;

--- a/codama-attributes/src/codama_directives/value_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/mod.rs
@@ -1,4 +1,5 @@
 mod boolean_value_node;
 mod number_value_node;
+mod public_key_value_node;
 mod string_value_node;
 mod value_node;

--- a/codama-attributes/src/codama_directives/value_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/mod.rs
@@ -1,4 +1,5 @@
 mod boolean_value_node;
+mod instruction_input_value_node;
 mod number_value_node;
 mod public_key_value_node;
 mod string_value_node;

--- a/codama-attributes/src/codama_directives/value_nodes/number_value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/number_value_node.rs
@@ -1,0 +1,29 @@
+use crate::utils::FromMeta;
+use codama_nodes::{Number, NumberValueNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for NumberValueNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let expr = meta.as_expr()?;
+        let value = expr
+            .as_unsigned_integer::<u64>()
+            .map(Number::from)
+            .or(expr.as_signed_integer::<i64>().map(Number::from))
+            .or(expr.as_float::<f64>().map(Number::from))?;
+        Ok(NumberValueNode::new(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::assert_value;
+
+    #[test]
+    fn ok() {
+        assert_value!({ 42 }, NumberValueNode::new(42u64).into());
+        assert_value!({ -42 }, NumberValueNode::new(-42i64).into());
+        assert_value!({ 1.5 }, NumberValueNode::new(1.5f64).into());
+        assert_value!({ -1.5 }, NumberValueNode::new(-1.5f64).into());
+    }
+}

--- a/codama-attributes/src/codama_directives/value_nodes/payer_value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/payer_value_node.rs
@@ -1,0 +1,33 @@
+use crate::utils::FromMeta;
+use codama_nodes::PayerValueNode;
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for PayerValueNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        if !meta.is_path_or_empty_list() {
+            return Err(meta.error("payer value does not accept any input"));
+        }
+        Ok(Self::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_value, assert_value_err};
+
+    #[test]
+    fn ok() {
+        assert_value!({ payer }, PayerValueNode::new().into());
+        assert_value!({ payer() }, PayerValueNode::new().into());
+    }
+
+    #[test]
+    fn unexpected_input() {
+        assert_value_err!(
+            { payer(unexpected) },
+            "payer value does not accept any input"
+        );
+        assert_value_err!({ payer(foo = 42) }, "payer value does not accept any input");
+    }
+}

--- a/codama-attributes/src/codama_directives/value_nodes/public_key_value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/public_key_value_node.rs
@@ -1,0 +1,39 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::PublicKeyValueNode;
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for PublicKeyValueNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pv = meta.as_path_list()?;
+        let mut public_key = SetOnce::<String>::new("public_key");
+        pv.each(|ref meta| {
+            let value = meta.as_expr()?.as_string()?;
+            public_key.set(value, meta)
+        })?;
+        Ok(Self::new(public_key.take(meta)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_value, assert_value_err};
+
+    #[test]
+    fn ok() {
+        assert_value!(
+            { public_key("1111") },
+            PublicKeyValueNode::new("1111").into()
+        );
+        assert_value!(
+            { public_key("2222") },
+            PublicKeyValueNode::new("2222").into()
+        );
+    }
+
+    #[test]
+    fn invalid_input() {
+        assert_value_err!({ public_key(unexpected) }, "expected a string");
+        assert_value_err!({ public_key(foo = 42) }, "expected a valid expression");
+    }
+}

--- a/codama-attributes/src/codama_directives/value_nodes/string_value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/string_value_node.rs
@@ -1,0 +1,22 @@
+use crate::utils::FromMeta;
+use codama_nodes::StringValueNode;
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for StringValueNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let value = meta.as_expr()?.as_string()?;
+        Ok(StringValueNode::new(value))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::assert_value;
+
+    #[test]
+    fn ok() {
+        assert_value!({ "hello" }, StringValueNode::new("hello").into());
+        assert_value!({ "world" }, StringValueNode::new("world").into());
+    }
+}

--- a/codama-attributes/src/codama_directives/value_nodes/sysvar.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/sysvar.rs
@@ -1,0 +1,50 @@
+use crate::utils::SetOnce;
+use codama_nodes::PublicKeyValueNode;
+use codama_syn_helpers::{extensions::*, Meta};
+
+pub fn public_key_value_node_from_sysvar(meta: &Meta) -> syn::Result<PublicKeyValueNode> {
+    let pv = meta.as_path_list()?;
+    let mut sysvar = SetOnce::<String>::new("sysvar_identifier");
+    pv.each(|ref meta| {
+        let value = meta.as_expr()?.as_string()?;
+        let public_key = match value.as_str() {
+            "clock" => "SysvarC1ock11111111111111111111111111111111",
+            "epoch_rewards" => "SysvarEpochRewards1111111111111111111111111",
+            "epoch_schedule" => "SysvarEpochSchedu1e111111111111111111111111",
+            "instructions" => "Sysvar1nstructions1111111111111111111111111",
+            "last_restart_slot" => "SysvarLastRestartS1ot1111111111111111111111",
+            "recent_blockhashes" => "SysvarRecentB1ockHashes11111111111111111111",
+            "rent" => "SysvarRent111111111111111111111111111111111",
+            "slot_hashes" => "SysvarS1otHashes111111111111111111111111111",
+            "slot_history" => "SysvarS1otHistory11111111111111111111111111",
+            "stake_history" => "SysvarStakeHistory1111111111111111111111111",
+            _ => return Err(meta.error("unrecognized sysvar")),
+        };
+        sysvar.set(public_key.to_string(), meta)
+    })?;
+    Ok(PublicKeyValueNode::new(sysvar.take(meta)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_value, assert_value_err};
+
+    #[test]
+    fn ok() {
+        assert_value!(
+            { sysvar("clock") },
+            PublicKeyValueNode::new("SysvarC1ock11111111111111111111111111111111").into()
+        );
+        assert_value!(
+            { sysvar("rent") },
+            PublicKeyValueNode::new("SysvarRent111111111111111111111111111111111").into()
+        );
+    }
+
+    #[test]
+    fn invalid_input() {
+        assert_value_err!({ sysvar("invalid_sysvar") }, "unrecognized sysvar");
+        assert_value_err!({ sysvar(foo = 42) }, "expected a valid expression");
+    }
+}

--- a/codama-attributes/src/codama_directives/value_nodes/value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/value_node.rs
@@ -1,0 +1,18 @@
+use crate::utils::FromMeta;
+use codama_nodes::{BooleanValueNode, ValueNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for ValueNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        match meta.path_str().as_str() {
+            "todo" => Ok(BooleanValueNode::from_meta(meta)?.into()),
+            _ => {
+                if let Ok(value) = BooleanValueNode::from_meta(meta) {
+                    Ok(value.into())
+                } else {
+                    Err(meta.error("unrecognized value"))
+                }
+            }
+        }
+    }
+}

--- a/codama-attributes/src/codama_directives/value_nodes/value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/value_node.rs
@@ -1,15 +1,17 @@
 use crate::utils::FromMeta;
-use codama_nodes::{BooleanValueNode, NumberValueNode, StringValueNode, ValueNode};
+use codama_nodes::{
+    BooleanValueNode, NumberValueNode, PublicKeyValueNode, StringValueNode, ValueNode,
+};
 use codama_syn_helpers::{extensions::*, Meta};
 
 impl FromMeta for ValueNode {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
         match meta.path_str().as_str() {
-            "todo" => Ok(BooleanValueNode::from_meta(meta)?.into()),
+            "public_key" => PublicKeyValueNode::from_meta(meta).map(Self::from),
             _ => BooleanValueNode::from_meta(meta)
-                .map(ValueNode::from)
-                .or(StringValueNode::from_meta(meta).map(ValueNode::from))
-                .or(NumberValueNode::from_meta(meta).map(ValueNode::from))
+                .map(Self::from)
+                .or(StringValueNode::from_meta(meta).map(Self::from))
+                .or(NumberValueNode::from_meta(meta).map(Self::from))
                 .map_err(|_| meta.error("unrecognized value")),
         }
     }

--- a/codama-attributes/src/codama_directives/value_nodes/value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/value_node.rs
@@ -1,18 +1,16 @@
 use crate::utils::FromMeta;
-use codama_nodes::{BooleanValueNode, ValueNode};
+use codama_nodes::{BooleanValueNode, NumberValueNode, StringValueNode, ValueNode};
 use codama_syn_helpers::{extensions::*, Meta};
 
 impl FromMeta for ValueNode {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
         match meta.path_str().as_str() {
             "todo" => Ok(BooleanValueNode::from_meta(meta)?.into()),
-            _ => {
-                if let Ok(value) = BooleanValueNode::from_meta(meta) {
-                    Ok(value.into())
-                } else {
-                    Err(meta.error("unrecognized value"))
-                }
-            }
+            _ => BooleanValueNode::from_meta(meta)
+                .map(ValueNode::from)
+                .or(StringValueNode::from_meta(meta).map(ValueNode::from))
+                .or(NumberValueNode::from_meta(meta).map(ValueNode::from))
+                .map_err(|_| meta.error("unrecognized value")),
         }
     }
 }

--- a/codama-attributes/src/codama_directives/value_nodes/value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/value_node.rs
@@ -3,11 +3,13 @@ use codama_nodes::{
     BooleanValueNode, NumberValueNode, PublicKeyValueNode, StringValueNode, ValueNode,
 };
 use codama_syn_helpers::{extensions::*, Meta};
+use crate::codama_directives::value_nodes::sysvar::public_key_value_node_from_sysvar;
 
 impl FromMeta for ValueNode {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
         match meta.path_str().as_str() {
             "public_key" => PublicKeyValueNode::from_meta(meta).map(Self::from),
+            "sysvar" => public_key_value_node_from_sysvar(meta).map(Self::from),
             _ => BooleanValueNode::from_meta(meta)
                 .map(Self::from)
                 .or(StringValueNode::from_meta(meta).map(Self::from))

--- a/codama-attributes/src/codama_directives/value_nodes/value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/value_node.rs
@@ -1,9 +1,9 @@
+use crate::codama_directives::value_nodes::sysvar::public_key_value_node_from_sysvar;
 use crate::utils::FromMeta;
 use codama_nodes::{
     BooleanValueNode, NumberValueNode, PublicKeyValueNode, StringValueNode, ValueNode,
 };
 use codama_syn_helpers::{extensions::*, Meta};
-use crate::codama_directives::value_nodes::sysvar::public_key_value_node_from_sysvar;
 
 impl FromMeta for ValueNode {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {

--- a/codama-attributes/src/utils/from_meta.rs
+++ b/codama-attributes/src/utils/from_meta.rs
@@ -11,7 +11,7 @@ where
 
 impl FromMeta for String {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
-        meta.as_path_value()?.value.as_expr()?.as_literal_string()
+        meta.as_path_value()?.value.as_expr()?.as_string()
     }
 }
 
@@ -19,7 +19,7 @@ impl FromMeta for bool {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
         match meta {
             Meta::Expr(Expr::Path(_)) => Ok(true),
-            _ => meta.as_path_value()?.value.as_expr()?.as_literal_bool(),
+            _ => meta.as_path_value()?.value.as_expr()?.as_bool(),
         }
     }
 }
@@ -30,10 +30,10 @@ impl FromMeta for IsAccountSigner {
             Meta::Expr(Expr::Path(_)) => Ok(Self::True),
             _ => {
                 let expr = meta.as_path_value()?.value.as_expr()?;
-                if let Ok(value) = expr.as_literal_bool() {
+                if let Ok(value) = expr.as_bool() {
                     return Ok(value.into());
                 }
-                match expr.as_literal_string() {
+                match expr.as_string() {
                     Ok(value) if value == "either" => Ok(Self::Either),
                     _ => Err(expr.error("expected boolean or `\"either\"`")),
                 }

--- a/codama-attributes/src/utils/macros.rs
+++ b/codama-attributes/src/utils/macros.rs
@@ -19,3 +19,25 @@ macro_rules! assert_type_err {
         }
     };
 }
+
+#[macro_export]
+macro_rules! assert_value {
+    ({$($attr:tt)*}, $expected:expr) => {
+        {
+            let meta: codama_syn_helpers::Meta = syn::parse_quote! { default_value = $($attr)* };
+            let node = $crate::DefaultValueDirective::parse(&meta).unwrap().node;
+            assert_eq!(node, $expected);
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! assert_value_err {
+    ({$($attr:tt)*}, $expected:expr) => {
+        {
+            let meta: codama_syn_helpers::Meta = syn::parse_quote! { default_value = $($attr)* };
+            let message = $crate::DefaultValueDirective::parse(&meta).unwrap_err().to_string();
+            assert_eq!(message, $expected);
+        }
+    };
+}

--- a/codama-korok-visitors/src/combine_types_visitor.rs
+++ b/codama-korok-visitors/src/combine_types_visitor.rs
@@ -212,7 +212,7 @@ impl KorokVisitor for CombineTypesVisitor {
             .ast
             .discriminant
             .as_ref()
-            .and_then(|(_, x)| x.as_literal_integer::<usize>().ok());
+            .and_then(|(_, x)| x.as_unsigned_integer::<usize>().ok());
 
         korok.node = match (&korok.ast.fields, &korok.fields.node) {
             (syn::Fields::Unit, _) => Some(

--- a/codama-korok-visitors/src/set_accounts_visitor.rs
+++ b/codama-korok-visitors/src/set_accounts_visitor.rs
@@ -125,7 +125,7 @@ impl KorokVisitor for SetAccountsVisitor {
     ) -> CodamaResult<()> {
         // Update current discriminator.
         let current_discriminator = match &korok.ast.discriminant {
-            Some((_, expr)) => expr.as_literal_integer()?,
+            Some((_, expr)) => expr.as_unsigned_integer()?,
             _ => self.enum_current_discriminator,
         };
         self.enum_current_discriminator = current_discriminator + 1;

--- a/codama-korok-visitors/src/set_borsh_types_visitor.rs
+++ b/codama-korok-visitors/src/set_borsh_types_visitor.rs
@@ -93,7 +93,7 @@ fn get_type_node(ty: &syn::Type) -> Option<TypeNode> {
             }
         }
         syn::Type::Array(syn::TypeArray { elem, len, .. }) => {
-            let Ok(size) = len.as_literal_integer::<usize>() else {
+            let Ok(size) = len.as_unsigned_integer::<usize>() else {
                 return None;
             };
             get_type_node(elem)

--- a/codama-korok-visitors/src/set_errors_visitor.rs
+++ b/codama-korok-visitors/src/set_errors_visitor.rs
@@ -83,7 +83,7 @@ impl KorokVisitor for SetErrorsVisitor {
     ) -> CodamaResult<()> {
         // Update current discriminator.
         let current_discriminator = match &korok.ast.discriminant {
-            Some((_, expr)) => expr.as_literal_integer()?,
+            Some((_, expr)) => expr.as_unsigned_integer()?,
             _ => self.enum_current_discriminator,
         };
         self.enum_current_discriminator = current_discriminator + 1;
@@ -140,6 +140,6 @@ pub fn get_message_from_thiserror(attributes: &Attributes) -> Option<String> {
 
         // Get the first meta as a string, if possible.
         let metas = list.parse_metas().ok()?;
-        metas.first()?.as_expr().ok()?.as_literal_string().ok()
+        metas.first()?.as_expr().ok()?.as_string().ok()
     })
 }

--- a/codama-korok-visitors/src/set_instructions_visitors.rs
+++ b/codama-korok-visitors/src/set_instructions_visitors.rs
@@ -135,7 +135,7 @@ impl KorokVisitor for SetInstructionsVisitor {
     ) -> CodamaResult<()> {
         // Update current discriminator.
         let current_discriminator = match &korok.ast.discriminant {
-            Some((_, expr)) => expr.as_literal_integer()?,
+            Some((_, expr)) => expr.as_unsigned_integer()?,
             _ => self.enum_current_discriminator,
         };
         self.enum_current_discriminator = current_discriminator + 1;

--- a/codama-macros/tests/codama_attribute/attribute_directive/invalid_optional.fail.stderr
+++ b/codama-macros/tests/codama_attribute/attribute_directive/invalid_optional.fail.stderr
@@ -1,4 +1,4 @@
-error: expected a literal boolean
+error: expected a boolean
  --> tests/codama_attribute/attribute_directive/invalid_optional.fail.rs:3:29
   |
 3 | #[codama(account(optional = invalid))]

--- a/codama-macros/tests/codama_attribute/attribute_directive/invalid_writable.fail.stderr
+++ b/codama-macros/tests/codama_attribute/attribute_directive/invalid_writable.fail.stderr
@@ -1,4 +1,4 @@
-error: expected a literal boolean
+error: expected a boolean
  --> tests/codama_attribute/attribute_directive/invalid_writable.fail.rs:3:29
   |
 3 | #[codama(account(writable = invalid))]

--- a/codama-macros/tests/codama_attribute/error_directive/invalid_code.fail.stderr
+++ b/codama-macros/tests/codama_attribute/error_directive/invalid_code.fail.stderr
@@ -1,4 +1,4 @@
-error: expected a literal integer
+error: expected an unsigned integer
  --> tests/codama_attribute/error_directive/invalid_code.fail.rs:3:23
   |
 3 | #[codama(error(code = "42"))]

--- a/codama-macros/tests/codama_attribute/error_directive/invalid_message.fail.stderr
+++ b/codama-macros/tests/codama_attribute/error_directive/invalid_message.fail.stderr
@@ -1,4 +1,4 @@
-error: expected a literal string
+error: expected a string
  --> tests/codama_attribute/error_directive/invalid_message.fail.rs:3:26
   |
 3 | #[codama(error(message = 42))]

--- a/codama-macros/tests/codama_attribute/fixed_size_directive/invalid_size.fail.stderr
+++ b/codama-macros/tests/codama_attribute/fixed_size_directive/invalid_size.fail.stderr
@@ -4,7 +4,7 @@ error: expected a valid expression
 3 | #[codama(fixed_size = invalid(1, 2, 3))]
   |                       ^^^^^^^^^^^^^^^^
 
-error: expected a literal integer
+error: expected an unsigned integer
  --> tests/codama_attribute/fixed_size_directive/invalid_size.fail.rs:6:23
   |
 6 | #[codama(fixed_size = invalid)]

--- a/codama-macros/tests/codama_attribute/values_nodes/boolean_value_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/boolean_value_node/_pass.rs
@@ -1,0 +1,7 @@
+use codama_macros::codama;
+
+#[codama(default_value = true)]
+#[codama(default_value = false)]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/number_value_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/number_value_node/_pass.rs
@@ -1,0 +1,10 @@
+use codama_macros::codama;
+
+#[codama(default_value = 0)]
+#[codama(default_value = 42)]
+#[codama(default_value = -42)]
+#[codama(default_value = 1.5)]
+#[codama(default_value = -1.5)]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/payer_value_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/payer_value_node/_pass.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(default_value = payer)]
+pub struct Test;
+
+#[codama(default_value = payer())]
+pub struct TestWithParenthesis;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/payer_value_node/with_input.fail.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/payer_value_node/with_input.fail.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(default_value = payer(42))]
+pub struct TestWithInteger;
+
+#[codama(default_value = payer(banana))]
+pub struct TestWithPath;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/payer_value_node/with_input.fail.stderr
+++ b/codama-macros/tests/codama_attribute/values_nodes/payer_value_node/with_input.fail.stderr
@@ -1,0 +1,11 @@
+error: payer value does not accept any input
+ --> tests/codama_attribute/values_nodes/payer_value_node/with_input.fail.rs:3:26
+  |
+3 | #[codama(default_value = payer(42))]
+  |                          ^^^^^^^^^
+
+error: payer value does not accept any input
+ --> tests/codama_attribute/values_nodes/payer_value_node/with_input.fail.rs:6:26
+  |
+6 | #[codama(default_value = payer(banana))]
+  |                          ^^^^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/values_nodes/public_key_value_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/public_key_value_node/_pass.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(default_value = public_key("1111"))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/public_key_value_node/invalid_input.fail.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/public_key_value_node/invalid_input.fail.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(default_value = public_key(42))]
+pub struct TestWithInteger;
+
+#[codama(default_value = public_key(banana))]
+pub struct TestWithPath;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/public_key_value_node/invalid_input.fail.stderr
+++ b/codama-macros/tests/codama_attribute/values_nodes/public_key_value_node/invalid_input.fail.stderr
@@ -1,0 +1,11 @@
+error: expected a string
+ --> tests/codama_attribute/values_nodes/public_key_value_node/invalid_input.fail.rs:3:37
+  |
+3 | #[codama(default_value = public_key(42))]
+  |                                     ^^
+
+error: expected a string
+ --> tests/codama_attribute/values_nodes/public_key_value_node/invalid_input.fail.rs:6:37
+  |
+6 | #[codama(default_value = public_key(banana))]
+  |                                     ^^^^^^

--- a/codama-macros/tests/codama_attribute/values_nodes/public_key_value_node/no_input.fail.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/public_key_value_node/no_input.fail.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(default_value = public_key)]
+pub struct Test;
+
+#[codama(default_value = public_key())]
+pub struct TestWithParenthesis;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/public_key_value_node/no_input.fail.stderr
+++ b/codama-macros/tests/codama_attribute/values_nodes/public_key_value_node/no_input.fail.stderr
@@ -1,0 +1,11 @@
+error: expected a list: `public_key(...)` or `public_key = (...)`
+ --> tests/codama_attribute/values_nodes/public_key_value_node/no_input.fail.rs:3:26
+  |
+3 | #[codama(default_value = public_key)]
+  |                          ^^^^^^^^^^
+
+error: public_key is missing
+ --> tests/codama_attribute/values_nodes/public_key_value_node/no_input.fail.rs:6:26
+  |
+6 | #[codama(default_value = public_key())]
+  |                          ^^^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/values_nodes/public_key_value_node/too_many_inputs.fail.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/public_key_value_node/too_many_inputs.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(default_value = public_key("1111", "2222"))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/public_key_value_node/too_many_inputs.fail.stderr
+++ b/codama-macros/tests/codama_attribute/values_nodes/public_key_value_node/too_many_inputs.fail.stderr
@@ -1,0 +1,5 @@
+error: public_key is already set
+ --> tests/codama_attribute/values_nodes/public_key_value_node/too_many_inputs.fail.rs:3:45
+  |
+3 | #[codama(default_value = public_key("1111", "2222"))]
+  |                                             ^^^^^^

--- a/codama-macros/tests/codama_attribute/values_nodes/string_value_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/string_value_node/_pass.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(default_value = "hello world")]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/sysvar/_pass.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/sysvar/_pass.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(default_value = sysvar("rent"))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/sysvar/invalid_input.fail.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/sysvar/invalid_input.fail.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(default_value = sysvar(42))]
+pub struct TestWithInteger;
+
+#[codama(default_value = sysvar(banana))]
+pub struct TestWithPath;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/sysvar/invalid_input.fail.stderr
+++ b/codama-macros/tests/codama_attribute/values_nodes/sysvar/invalid_input.fail.stderr
@@ -1,0 +1,11 @@
+error: expected a string
+ --> tests/codama_attribute/values_nodes/sysvar/invalid_input.fail.rs:3:33
+  |
+3 | #[codama(default_value = sysvar(42))]
+  |                                 ^^
+
+error: expected a string
+ --> tests/codama_attribute/values_nodes/sysvar/invalid_input.fail.rs:6:33
+  |
+6 | #[codama(default_value = sysvar(banana))]
+  |                                 ^^^^^^

--- a/codama-macros/tests/codama_attribute/values_nodes/sysvar/no_input.fail.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/sysvar/no_input.fail.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(default_value = sysvar)]
+pub struct Test;
+
+#[codama(default_value = sysvar())]
+pub struct TestWithParenthesis;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/sysvar/no_input.fail.stderr
+++ b/codama-macros/tests/codama_attribute/values_nodes/sysvar/no_input.fail.stderr
@@ -1,0 +1,11 @@
+error: expected a list: `sysvar(...)` or `sysvar = (...)`
+ --> tests/codama_attribute/values_nodes/sysvar/no_input.fail.rs:3:26
+  |
+3 | #[codama(default_value = sysvar)]
+  |                          ^^^^^^
+
+error: sysvar_identifier is missing
+ --> tests/codama_attribute/values_nodes/sysvar/no_input.fail.rs:6:26
+  |
+6 | #[codama(default_value = sysvar())]
+  |                          ^^^^^^^^

--- a/codama-macros/tests/codama_attribute/values_nodes/sysvar/too_many_inputs.fail.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/sysvar/too_many_inputs.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(default_value = sysvar("rent", "clock"))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/sysvar/too_many_inputs.fail.stderr
+++ b/codama-macros/tests/codama_attribute/values_nodes/sysvar/too_many_inputs.fail.stderr
@@ -1,0 +1,5 @@
+error: sysvar_identifier is already set
+ --> tests/codama_attribute/values_nodes/sysvar/too_many_inputs.fail.rs:3:41
+  |
+3 | #[codama(default_value = sysvar("rent", "clock"))]
+  |                                         ^^^^^^^

--- a/codama-macros/tests/codama_attribute/values_nodes/sysvar/unrecognized_sysvar.fail.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/sysvar/unrecognized_sysvar.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(default_value = sysvar("banana"))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/sysvar/unrecognized_sysvar.fail.stderr
+++ b/codama-macros/tests/codama_attribute/values_nodes/sysvar/unrecognized_sysvar.fail.stderr
@@ -1,0 +1,5 @@
+error: unrecognized sysvar
+ --> tests/codama_attribute/values_nodes/sysvar/unrecognized_sysvar.fail.rs:3:33
+  |
+3 | #[codama(default_value = sysvar("banana"))]
+  |                                 ^^^^^^^^

--- a/codama-syn-helpers/src/extensions/expr.rs
+++ b/codama-syn-helpers/src/extensions/expr.rs
@@ -1,11 +1,11 @@
 use super::ToTokensExtension;
-use syn::{Expr, ExprLit, ExprPath};
+use syn::{Expr, ExprLit, ExprPath, ExprUnary};
 
 pub trait ExprExtension {
     fn get_self(&self) -> &Expr;
 
-    /// Returns the integer value of the expression if it is a literal integer.
-    fn as_literal_integer<T>(&self) -> syn::Result<T>
+    /// Returns the integer value of the expression if it is a literal unsigned integer.
+    fn as_unsigned_integer<T>(&self) -> syn::Result<T>
     where
         T: std::str::FromStr,
         T::Err: std::fmt::Display,
@@ -16,31 +16,85 @@ pub trait ExprExtension {
                 lit: syn::Lit::Int(value),
                 ..
             }) => value.base10_parse::<T>(),
-            _ => Err(this.error("expected a literal integer")),
+            _ => Err(this.error("expected an unsigned integer")),
         }
     }
 
+    /// Returns the integer value of the expression if it is a literal signed integer.
+    fn as_signed_integer<T>(&self) -> syn::Result<T>
+    where
+        T: std::str::FromStr + std::ops::Neg<Output = T>,
+        T::Err: std::fmt::Display,
+    {
+        let this = self.get_self();
+        let result = match this {
+            Expr::Unary(ExprUnary {
+                op: syn::UnOp::Neg(_),
+                expr: unsigned_expr,
+                ..
+            }) => unsigned_expr
+                .as_unsigned_integer::<T>()
+                .map(|value| value.neg()),
+            _ => this.as_unsigned_integer::<T>(),
+        };
+
+        result.map_err(|_| this.error("expected a signed integer"))
+    }
+
+    fn as_unsigned_float<T>(&self) -> syn::Result<T>
+    where
+        T: std::str::FromStr,
+        T::Err: std::fmt::Display,
+    {
+        let this = self.get_self();
+        match this {
+            Expr::Lit(ExprLit {
+                lit: syn::Lit::Float(value),
+                ..
+            }) => value.base10_parse::<T>(),
+            _ => Err(this.error("expected an unsigned float")),
+        }
+    }
+
+    fn as_float<T>(&self) -> syn::Result<T>
+    where
+        T: std::str::FromStr + std::ops::Neg<Output = T>,
+        T::Err: std::fmt::Display,
+    {
+        let this = self.get_self();
+        let result = match this {
+            Expr::Unary(ExprUnary {
+                op: syn::UnOp::Neg(_),
+                expr: float_expr,
+                ..
+            }) => float_expr.as_unsigned_float::<T>().map(|value| value.neg()),
+            _ => this.as_unsigned_float::<T>(),
+        };
+
+        result.map_err(|_| this.error("expected a float"))
+    }
+
     /// Returns the string value of the expression if it is a literal string.
-    fn as_literal_string(&self) -> syn::Result<String> {
+    fn as_string(&self) -> syn::Result<String> {
         let this = self.get_self();
         match this {
             Expr::Lit(ExprLit {
                 lit: syn::Lit::Str(value),
                 ..
             }) => Ok(value.value()),
-            _ => Err(this.error("expected a literal string")),
+            _ => Err(this.error("expected a string")),
         }
     }
 
     /// Returns the boolean value of the expression if it is a literal bool.
-    fn as_literal_bool(&self) -> syn::Result<bool> {
+    fn as_bool(&self) -> syn::Result<bool> {
         let this = self.get_self();
         match this {
             Expr::Lit(ExprLit {
                 lit: syn::Lit::Bool(value),
                 ..
             }) => Ok(value.value()),
-            _ => Err(this.error("expected a literal boolean")),
+            _ => Err(this.error("expected a boolean")),
         }
     }
 
@@ -66,31 +120,87 @@ mod tests {
     use crate::extensions::*;
 
     #[test]
-    fn as_literal_integer_ok() {
+    fn as_unsigned_integer_ok() {
         let expr: Expr = syn::parse_quote! { 42 };
-        let result = expr.as_literal_integer::<usize>();
-        assert!(matches!(result, Ok(42usize)));
+        let result = expr.as_unsigned_integer::<usize>().unwrap();
+        assert_eq!(result, 42usize);
     }
 
     #[test]
-    fn as_literal_integer_err() {
-        let expr: Expr = syn::parse_quote! { 40 + 2 };
-        let error = expr.as_literal_integer::<usize>().unwrap_err();
-        assert_eq!(error.to_string(), "expected a literal integer");
+    fn as_unsigned_integer_err() {
+        let expr: Expr = syn::parse_quote! { -42 };
+        let error = expr.as_unsigned_integer::<usize>().unwrap_err();
+        assert_eq!(error.to_string(), "expected an unsigned integer");
     }
 
     #[test]
-    fn as_literal_string_ok() {
+    fn as_signed_integer_ok() {
+        let expr: Expr = syn::parse_quote! { -42 };
+        let result = expr.as_signed_integer::<isize>().unwrap();
+        assert_eq!(result, -42isize);
+    }
+
+    #[test]
+    fn as_signed_integer_ok_with_unsigned() {
+        let expr: Expr = syn::parse_quote! { 42 };
+        let result = expr.as_signed_integer::<isize>().unwrap();
+        assert_eq!(result, 42isize);
+    }
+
+    #[test]
+    fn as_signed_integer_err() {
+        let expr: Expr = syn::parse_quote! { -42.5 };
+        let error = expr.as_signed_integer::<isize>().unwrap_err();
+        assert_eq!(error.to_string(), "expected a signed integer");
+    }
+
+    #[test]
+    fn as_float_ok() {
+        let expr: Expr = syn::parse_quote! { 1.5 };
+        let result = expr.as_float::<f64>().unwrap();
+        assert_eq!(result, 1.5f64);
+    }
+
+    #[test]
+    fn as_float_ok_negative() {
+        let expr: Expr = syn::parse_quote! { -1.5 };
+        let result = expr.as_float::<f64>().unwrap();
+        assert_eq!(result, -1.5f64);
+    }
+
+    #[test]
+    fn as_float_err() {
+        let expr: Expr = syn::parse_quote! { "3.14" };
+        let error = expr.as_float::<f64>().unwrap_err();
+        assert_eq!(error.to_string(), "expected a float");
+    }
+
+    #[test]
+    fn as_string_ok() {
         let expr: Expr = syn::parse_quote! { "hello" };
-        let result = expr.as_literal_string().unwrap();
+        let result = expr.as_string().unwrap();
         assert_eq!(result, "hello");
     }
 
     #[test]
-    fn as_literal_string_err() {
+    fn as_string_err() {
         let expr: Expr = syn::parse_quote! { 40 + 2 };
-        let error = expr.as_literal_string().unwrap_err();
-        assert_eq!(error.to_string(), "expected a literal string");
+        let error = expr.as_string().unwrap_err();
+        assert_eq!(error.to_string(), "expected a string");
+    }
+
+    #[test]
+    fn as_bool_ok() {
+        let expr: Expr = syn::parse_quote! { true};
+        let result = expr.as_bool().unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn as_bool_err() {
+        let expr: Expr = syn::parse_quote! { 42 };
+        let error = expr.as_bool().unwrap_err();
+        assert_eq!(error.to_string(), "expected a boolean");
     }
 
     #[test]

--- a/codama-syn-helpers/src/extensions/meta_list.rs
+++ b/codama-syn-helpers/src/extensions/meta_list.rs
@@ -49,6 +49,6 @@ mod tests {
         let meta = items[2].as_path_value().unwrap();
         let expr = meta.value.as_expr().unwrap();
         assert!(meta.path.is_strict("three"));
-        assert_eq!(expr.as_literal_integer::<usize>().unwrap(), 42);
+        assert_eq!(expr.as_unsigned_integer::<usize>().unwrap(), 42);
     }
 }

--- a/codama-syn-helpers/src/meta.rs
+++ b/codama-syn-helpers/src/meta.rs
@@ -371,7 +371,7 @@ mod tests {
         };
         assert!(meta.path.is_strict("foo"));
         let expr = meta.value.as_expr().unwrap();
-        assert_eq!(expr.as_literal_integer::<usize>().unwrap(), 42);
+        assert_eq!(expr.as_unsigned_integer::<usize>().unwrap(), 42);
     }
 
     #[test]
@@ -382,7 +382,7 @@ mod tests {
         };
         assert!(meta.path.is_strict("foo"));
         let expr = meta.value.as_expr().unwrap();
-        assert!(expr.as_literal_bool().unwrap());
+        assert!(expr.as_bool().unwrap());
     }
 
     #[test]

--- a/codama/tests/system/crate/src/instructions.rs
+++ b/codama/tests/system/crate/src/instructions.rs
@@ -4,7 +4,7 @@ use solana_pubkey::Pubkey;
 #[derive(CodamaInstructions)]
 #[repr(u32)]
 pub enum SystemInstruction {
-    #[codama(account(name = "payer", signer, writable))] // TODO: Default value?
+    #[codama(account(name = "payer", signer, writable, default_value = payer))]
     #[codama(account(name = "new_account", signer, writable))]
     CreateAccount {
         lamports: u64,
@@ -32,20 +32,20 @@ pub enum SystemInstruction {
     },
 
     #[codama(account(name = "nonce_account", writable))]
-    #[codama(account(name = "recent_blockhashes_sysvar"))] // TODO: auto default value
+    #[codama(account(name = "recent_blockhashes_sysvar", default_value = sysvar("recent_blockhashes")))]
     #[codama(account(name = "nonce_authority", signer))]
     AdvanceNonceAccount,
 
     #[codama(account(name = "nonce_account", writable))]
     #[codama(account(name = "recipient_account", writable))]
-    #[codama(account(name = "recent_blockhashes_sysvar"))] // TODO: auto default value
-    #[codama(account(name = "rent_sysvar"))] // TODO: auto default value
+    #[codama(account(name = "recent_blockhashes_sysvar", default_value = sysvar("recent_blockhashes")))]
+    #[codama(account(name = "rent_sysvar", default_value = sysvar("rent")))]
     #[codama(account(name = "nonce_authority", signer))]
     WithdrawNonceAccount { withdraw_amount: u64 },
 
     #[codama(account(name = "nonce_account", writable))]
-    #[codama(account(name = "recent_blockhashes_sysvar"))] // TODO: auto default value
-    #[codama(account(name = "rent_sysvar"))] // TODO: auto default value
+    #[codama(account(name = "recent_blockhashes_sysvar", default_value = sysvar("recent_blockhashes")))]
+    #[codama(account(name = "rent_sysvar", default_value = sysvar("rent")))]
     InitializeNonceAccount { nonce_authority: Pubkey },
 
     #[codama(account(name = "nonce_account", writable))]

--- a/codama/tests/system/mod.rs
+++ b/codama/tests/system/mod.rs
@@ -76,7 +76,10 @@ fn get_idl() {
             "kind": "instructionAccountNode",
             "name": "payer",
             "isWritable": true,
-            "isSigner": true
+            "isSigner": true,
+            "defaultValue": {
+              "kind": "payerValueNode"
+            }
           },
           {
             "kind": "instructionAccountNode",
@@ -335,7 +338,11 @@ fn get_idl() {
             "kind": "instructionAccountNode",
             "name": "recentBlockhashesSysvar",
             "isWritable": false,
-            "isSigner": false
+            "isSigner": false,
+            "defaultValue": {
+              "kind": "publicKeyValueNode",
+              "publicKey": "SysvarRecentB1ockHashes11111111111111111111"
+            }
           },
           {
             "kind": "instructionAccountNode",
@@ -388,13 +395,21 @@ fn get_idl() {
             "kind": "instructionAccountNode",
             "name": "recentBlockhashesSysvar",
             "isWritable": false,
-            "isSigner": false
+            "isSigner": false,
+            "defaultValue": {
+              "kind": "publicKeyValueNode",
+              "publicKey": "SysvarRecentB1ockHashes11111111111111111111"
+            }
           },
           {
             "kind": "instructionAccountNode",
             "name": "rentSysvar",
             "isWritable": false,
-            "isSigner": false
+            "isSigner": false,
+            "defaultValue": {
+              "kind": "publicKeyValueNode",
+              "publicKey": "SysvarRent111111111111111111111111111111111"
+            }
           },
           {
             "kind": "instructionAccountNode",
@@ -450,13 +465,21 @@ fn get_idl() {
             "kind": "instructionAccountNode",
             "name": "recentBlockhashesSysvar",
             "isWritable": false,
-            "isSigner": false
+            "isSigner": false,
+            "defaultValue": {
+              "kind": "publicKeyValueNode",
+              "publicKey": "SysvarRecentB1ockHashes11111111111111111111"
+            }
           },
           {
             "kind": "instructionAccountNode",
             "name": "rentSysvar",
             "isWritable": false,
-            "isSigner": false
+            "isSigner": false,
+            "defaultValue": {
+              "kind": "publicKeyValueNode",
+              "publicKey": "SysvarRent111111111111111111111111111111111"
+            }
           }
         ],
         "arguments": [


### PR DESCRIPTION
This PR starts the process of adding support for `ValueNodes` and `ContextualValueNodes` in Codama Macros. It creates a new `#[codama(default_value = ...)]` attribute but more importantly, it offers a `FromMeta` implementation for _some_ instances of value nodes. Much like type nodes, adding support for value nodes is a lengthy process so this PR focuses on a few select value nodes to make adding more value nodes easier moving forwards. Namely, it add supports for:
- Booleans: e.g. `default_value = true`.
- Strings: e.g. `default_value = "hello world"`.
- Numbers: e.g. `default_value = -3.14`.
- Public keys: e.g. `default_value = public_key("1111..1111")`.
- Sysvars (public key shortcuts): e.g. `default_value = sysvar("rent")`.
- Payer flag: e.g. `default_value = payer`.

It then uses these default value macros in the `#[codama(account(...))]` attribute making it possible for instruction accounts to defined default values.

There are many other places where value node macros could be used but they are out of scope for this PR and will need implementing in subsequent PRs. The scope here is defined by the ability to extract an IDL for the System program (the first MVP milestone of this project).