### PR TITLE
Fix: serializes everything to ensure compatibility and adds PdaSeedValueValueNode for PdaSeedValueNode

### DIFF
--- a/codama-nodes/src/account_node.rs
+++ b/codama-nodes/src/account_node.rs
@@ -7,18 +7,14 @@ use codama_nodes_derive::node;
 pub struct AccountNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<usize>,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.
     pub data: NestedTypeNode<StructTypeNode>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub pda: Option<PdaLinkNode>,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub discriminators: Vec<DiscriminatorNode>,
 }
 

--- a/codama-nodes/src/contextual_value_nodes/conditional_value_node.rs
+++ b/codama-nodes/src/contextual_value_nodes/conditional_value_node.rs
@@ -7,11 +7,8 @@ use codama_nodes_derive::{node, node_union};
 pub struct ConditionalValueNode {
     // Children.
     pub condition: ConditionNode,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<ValueNode>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub if_true: Box<Option<InstructionInputValueNode>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub if_false: Box<Option<InstructionInputValueNode>>,
 }
 

--- a/codama-nodes/src/contextual_value_nodes/pda_seed_value_node.rs
+++ b/codama-nodes/src/contextual_value_nodes/pda_seed_value_node.rs
@@ -1,5 +1,10 @@
-use crate::{CamelCaseString, ValueNode};
-use codama_nodes_derive::node;
+use crate::{
+    AccountValueNode, ArgumentValueNode, ArrayValueNode, BooleanValueNode, BytesValueNode,
+    CamelCaseString, ConstantValueNode, EnumValueNode, MapValueNode, NoneValueNode,
+    NumberValueNode, PublicKeyValueNode, SetValueNode, SomeValueNode, StringValueNode,
+    StructValueNode, TupleValueNode,
+};
+use codama_nodes_derive::{node, node_union};
 
 #[node]
 pub struct PdaSeedValueNode {
@@ -7,7 +12,7 @@ pub struct PdaSeedValueNode {
     pub name: CamelCaseString,
 
     // Children.
-    pub value: ValueNode,
+    pub value: PdaSeedValueValueNode,
 }
 
 impl From<PdaSeedValueNode> for crate::Node {
@@ -20,13 +25,35 @@ impl PdaSeedValueNode {
     pub fn new<T, U>(name: T, value: U) -> Self
     where
         T: Into<CamelCaseString>,
-        U: Into<ValueNode>,
+        U: Into<PdaSeedValueValueNode>,
     {
         Self {
             name: name.into(),
             value: value.into(),
         }
     }
+}
+
+#[node_union]
+pub enum PdaSeedValueValueNode {
+    Account(AccountValueNode),
+    Argument(ArgumentValueNode),
+
+    // ValueNodes.
+    Array(ArrayValueNode),
+    Boolean(BooleanValueNode),
+    Bytes(BytesValueNode),
+    Constant(ConstantValueNode),
+    Enum(EnumValueNode),
+    Map(MapValueNode),
+    None(NoneValueNode),
+    Number(NumberValueNode),
+    PublicKey(PublicKeyValueNode),
+    Set(SetValueNode),
+    Some(SomeValueNode),
+    String(StringValueNode),
+    Struct(StructValueNode),
+    Tuple(TupleValueNode),
 }
 
 #[cfg(test)]
@@ -39,7 +66,10 @@ mod tests {
     fn new() {
         let node = PdaSeedValueNode::new("answer", NumberValueNode::new(42));
         assert_eq!(node.name, CamelCaseString::from("answer"));
-        assert_eq!(node.value, ValueNode::Number(NumberValueNode::new(42)));
+        assert_eq!(
+            node.value,
+            PdaSeedValueValueNode::Number(NumberValueNode::new(42))
+        );
     }
 
     #[test]

--- a/codama-nodes/src/contextual_value_nodes/resolver_value_node.rs
+++ b/codama-nodes/src/contextual_value_nodes/resolver_value_node.rs
@@ -6,11 +6,9 @@ pub struct ResolverValueNode {
     // Data.
     pub name: CamelCaseString,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub depends_on: Option<Vec<ResolverDependency>>,
 }
 

--- a/codama-nodes/src/defined_type_node.rs
+++ b/codama-nodes/src/defined_type_node.rs
@@ -6,7 +6,6 @@ pub struct DefinedTypeNode {
     // Data.
     pub name: CamelCaseString,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/error_node.rs
+++ b/codama-nodes/src/error_node.rs
@@ -8,7 +8,6 @@ pub struct ErrorNode {
     pub code: usize,
     pub message: String,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 }
 

--- a/codama-nodes/src/instruction_account_node.rs
+++ b/codama-nodes/src/instruction_account_node.rs
@@ -8,14 +8,11 @@ pub struct InstructionAccountNode {
     pub is_writable: bool,
     pub is_signer: IsAccountSigner,
     #[serde(default)]
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub is_optional: bool,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub default_value: Option<InstructionInputValueNode>,
 }
 

--- a/codama-nodes/src/instruction_argument_node.rs
+++ b/codama-nodes/src/instruction_argument_node.rs
@@ -8,15 +8,12 @@ use codama_nodes_derive::node;
 pub struct InstructionArgumentNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub default_value_strategy: Option<DefaultValueStrategy>,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.
     pub r#type: TypeNode,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub default_value: Option<InstructionInputValueNode>,
 }
 

--- a/codama-nodes/src/instruction_byte_delta_node.rs
+++ b/codama-nodes/src/instruction_byte_delta_node.rs
@@ -6,7 +6,6 @@ pub struct InstructionByteDeltaNode {
     // Data.
     pub with_header: bool,
     #[serde(default)]
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub subtract: bool,
 
     // Children.

--- a/codama-nodes/src/instruction_node.rs
+++ b/codama-nodes/src/instruction_node.rs
@@ -11,29 +11,22 @@ pub struct InstructionNode {
     // Data.
     pub name: CamelCaseString,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
     #[serde(default)]
-    #[serde(skip_serializing_if = "InstructionOptionalAccountStrategy::is_default")]
     pub optional_account_strategy: InstructionOptionalAccountStrategy,
 
     // Children.
     pub accounts: Vec<InstructionAccountNode>,
     pub arguments: Vec<InstructionArgumentNode>,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub extra_arguments: Vec<InstructionArgumentNode>,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub remaining_accounts: Vec<InstructionRemainingAccountsNode>,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub byte_deltas: Vec<InstructionByteDeltaNode>,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub discriminators: Vec<DiscriminatorNode>,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub sub_instructions: Vec<InstructionNode>,
 }
 

--- a/codama-nodes/src/instruction_remaining_accounts_node.rs
+++ b/codama-nodes/src/instruction_remaining_accounts_node.rs
@@ -5,12 +5,10 @@ use codama_nodes_derive::{node, node_union};
 pub struct InstructionRemainingAccountsNode {
     // Data.
     #[serde(default)]
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub is_optional: bool,
     pub is_signer: IsAccountSigner,
     pub is_writable: bool,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/link_nodes/account_link_node.rs
+++ b/codama-nodes/src/link_nodes/account_link_node.rs
@@ -7,7 +7,6 @@ pub struct AccountLinkNode {
     pub name: CamelCaseString,
 
     // Children.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub program: Option<ProgramLinkNode>,
 }
 

--- a/codama-nodes/src/link_nodes/defined_type_link_node.rs
+++ b/codama-nodes/src/link_nodes/defined_type_link_node.rs
@@ -7,7 +7,6 @@ pub struct DefinedTypeLinkNode {
     pub name: CamelCaseString,
 
     // Children.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub program: Option<ProgramLinkNode>,
 }
 

--- a/codama-nodes/src/link_nodes/instruction_account_link_node.rs
+++ b/codama-nodes/src/link_nodes/instruction_account_link_node.rs
@@ -7,7 +7,6 @@ pub struct InstructionAccountLinkNode {
     pub name: CamelCaseString,
 
     // Children.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub instruction: Option<InstructionLinkNode>,
 }
 

--- a/codama-nodes/src/link_nodes/instruction_argument_link_node.rs
+++ b/codama-nodes/src/link_nodes/instruction_argument_link_node.rs
@@ -7,7 +7,6 @@ pub struct InstructionArgumentLinkNode {
     pub name: CamelCaseString,
 
     // Children.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub instruction: Option<InstructionLinkNode>,
 }
 

--- a/codama-nodes/src/link_nodes/instruction_link_node.rs
+++ b/codama-nodes/src/link_nodes/instruction_link_node.rs
@@ -7,7 +7,6 @@ pub struct InstructionLinkNode {
     pub name: CamelCaseString,
 
     // Children.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub program: Option<ProgramLinkNode>,
 }
 

--- a/codama-nodes/src/link_nodes/pda_link_node.rs
+++ b/codama-nodes/src/link_nodes/pda_link_node.rs
@@ -7,7 +7,6 @@ pub struct PdaLinkNode {
     pub name: CamelCaseString,
 
     // Children.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub program: Option<ProgramLinkNode>,
 }
 

--- a/codama-nodes/src/pda_node.rs
+++ b/codama-nodes/src/pda_node.rs
@@ -6,9 +6,7 @@ pub struct PdaNode {
     // Data.
     pub name: CamelCaseString,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub program_id: Option<String>,
 
     // Children.

--- a/codama-nodes/src/pda_seed_nodes/variable_pda_seed_node.rs
+++ b/codama-nodes/src/pda_seed_nodes/variable_pda_seed_node.rs
@@ -6,7 +6,6 @@ pub struct VariablePdaSeedNode {
     // Data.
     pub name: CamelCaseString,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/program_node.rs
+++ b/codama-nodes/src/program_node.rs
@@ -10,23 +10,18 @@ pub struct ProgramNode {
     pub name: CamelCaseString,
     pub public_key: String,
     pub version: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub origin: Option<String>, // 'anchor' | 'shank'. Soon to be deprecated.
     #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.
     pub accounts: Vec<AccountNode>,
     pub instructions: Vec<InstructionNode>,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub defined_types: Vec<DefinedTypeNode>,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub pdas: Vec<PdaNode>,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub errors: Vec<ErrorNode>,
 }
 

--- a/codama-nodes/src/type_nodes/amount_type_node.rs
+++ b/codama-nodes/src/type_nodes/amount_type_node.rs
@@ -5,7 +5,6 @@ use codama_nodes_derive::type_node;
 pub struct AmountTypeNode {
     // Data.
     pub decimals: u8,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub unit: Option<String>,
 
     // Children.

--- a/codama-nodes/src/type_nodes/enum_empty_variant_type_node.rs
+++ b/codama-nodes/src/type_nodes/enum_empty_variant_type_node.rs
@@ -5,7 +5,6 @@ use codama_nodes_derive::node;
 pub struct EnumEmptyVariantTypeNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub discriminator: Option<usize>,
 }
 

--- a/codama-nodes/src/type_nodes/enum_struct_variant_type_node.rs
+++ b/codama-nodes/src/type_nodes/enum_struct_variant_type_node.rs
@@ -5,7 +5,6 @@ use codama_nodes_derive::node;
 pub struct EnumStructVariantTypeNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub discriminator: Option<usize>,
 
     // Children.

--- a/codama-nodes/src/type_nodes/enum_tuple_variant_type_node.rs
+++ b/codama-nodes/src/type_nodes/enum_tuple_variant_type_node.rs
@@ -5,7 +5,6 @@ use codama_nodes_derive::node;
 pub struct EnumTupleVariantTypeNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub discriminator: Option<usize>,
 
     // Children.

--- a/codama-nodes/src/type_nodes/option_type_node.rs
+++ b/codama-nodes/src/type_nodes/option_type_node.rs
@@ -5,7 +5,6 @@ use codama_nodes_derive::type_node;
 pub struct OptionTypeNode {
     // Data.
     #[serde(default)]
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub fixed: bool,
 
     // Children.

--- a/codama-nodes/src/type_nodes/struct_field_type_node.rs
+++ b/codama-nodes/src/type_nodes/struct_field_type_node.rs
@@ -5,15 +5,12 @@ use codama_nodes_derive::node;
 pub struct StructFieldTypeNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub default_value_strategy: Option<DefaultValueStrategy>,
     #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.
     pub r#type: TypeNode,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub default_value: Option<ValueNode>,
 }
 

--- a/codama-nodes/src/type_nodes/zeroable_option_type_node.rs
+++ b/codama-nodes/src/type_nodes/zeroable_option_type_node.rs
@@ -5,7 +5,6 @@ use codama_nodes_derive::type_node;
 pub struct ZeroableOptionTypeNode {
     // Children.
     pub item: Box<TypeNode>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub zero_value: Option<ConstantValueNode>,
 }
 

--- a/codama-nodes/src/value_nodes/enum_value_node.rs
+++ b/codama-nodes/src/value_nodes/enum_value_node.rs
@@ -8,7 +8,6 @@ pub struct EnumValueNode {
 
     // Children.
     pub r#enum: DefinedTypeLinkNode,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub value: Option<EnumVariantData>,
 }
 

--- a/codama-nodes/src/value_nodes/public_key_value_node.rs
+++ b/codama-nodes/src/value_nodes/public_key_value_node.rs
@@ -5,7 +5,6 @@ use codama_nodes_derive::node;
 pub struct PublicKeyValueNode {
     // Data.
     pub public_key: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub identifier: Option<CamelCaseString>,
 }
 


### PR DESCRIPTION
The new node_union is required to add the Account and Argument value nodes, which are used in TS. There may be another way to get that working, but I think this is most consistent with the rest of the codebase. 

todo: 

- [ ] probably need to fix naming on PdaSeedValueValueNode. Open to ANY alternatives here!!
- [ ] Aligning on what serialization should be skipped to allow compatibility with TS codama. I took a sledgehammer to all the skips to get it initially working, but it could definitely be fine-tuned. 
