### PR TITLE
Fix: Added PdaSeedValueValueNode and marked missing skip_serializing fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,7 @@ dependencies = [
  "codama-errors",
  "codama-nodes-derive",
  "derive_more",
+ "pretty_assertions",
  "serde",
  "serde_json",
 ]
@@ -194,6 +195,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "dissimilar"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,6 +245,16 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -496,3 +513,9 @@ checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"

--- a/codama-nodes/Cargo.toml
+++ b/codama-nodes/Cargo.toml
@@ -12,3 +12,6 @@ codama-nodes-derive = { version = "0.3.0", path = "derive" }
 derive_more = { version = "1.0", features = ["from"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[dev-dependencies]
+pretty_assertions = "1.4.1"

--- a/codama-nodes/src/account_node.rs
+++ b/codama-nodes/src/account_node.rs
@@ -9,14 +9,16 @@ pub struct AccountNode {
     pub name: CamelCaseString,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<usize>,
-    #[serde(default, skip_serializing_if = "Docs::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.
     pub data: NestedTypeNode<StructTypeNode>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pda: Option<PdaLinkNode>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub discriminators: Vec<DiscriminatorNode>,
 }
 

--- a/codama-nodes/src/account_node.rs
+++ b/codama-nodes/src/account_node.rs
@@ -7,18 +7,16 @@ use codama_nodes_derive::node;
 pub struct AccountNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub size: Option<usize>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub docs: Docs,
 
     // Children.
     pub data: NestedTypeNode<StructTypeNode>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub pda: Option<PdaLinkNode>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub discriminators: Vec<DiscriminatorNode>,
 }
 

--- a/codama-nodes/src/account_node.rs
+++ b/codama-nodes/src/account_node.rs
@@ -9,16 +9,14 @@ pub struct AccountNode {
     pub name: CamelCaseString,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<usize>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.
     pub data: NestedTypeNode<StructTypeNode>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pda: Option<PdaLinkNode>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub discriminators: Vec<DiscriminatorNode>,
 }
 

--- a/codama-nodes/src/contextual_value_nodes/conditional_value_node.rs
+++ b/codama-nodes/src/contextual_value_nodes/conditional_value_node.rs
@@ -7,11 +7,11 @@ use codama_nodes_derive::{node, node_union};
 pub struct ConditionalValueNode {
     // Children.
     pub condition: ConditionNode,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub value: Option<ValueNode>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub if_true: Box<Option<InstructionInputValueNode>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub if_false: Box<Option<InstructionInputValueNode>>,
 }
 

--- a/codama-nodes/src/contextual_value_nodes/pda_seed_value_node.rs
+++ b/codama-nodes/src/contextual_value_nodes/pda_seed_value_node.rs
@@ -1,5 +1,10 @@
-use crate::{CamelCaseString, ValueNode};
-use codama_nodes_derive::node;
+use crate::{
+    AccountValueNode, ArgumentValueNode, ArrayValueNode, BooleanValueNode, BytesValueNode,
+    CamelCaseString, ConstantValueNode, EnumValueNode, MapValueNode, NoneValueNode,
+    NumberValueNode, PublicKeyValueNode, SetValueNode, SomeValueNode, StringValueNode,
+    StructValueNode, TupleValueNode,
+};
+use codama_nodes_derive::{node, node_union};
 
 #[node]
 pub struct PdaSeedValueNode {
@@ -7,7 +12,7 @@ pub struct PdaSeedValueNode {
     pub name: CamelCaseString,
 
     // Children.
-    pub value: ValueNode,
+    pub value: PdaSeedValueValueNode,
 }
 
 impl From<PdaSeedValueNode> for crate::Node {
@@ -20,13 +25,35 @@ impl PdaSeedValueNode {
     pub fn new<T, U>(name: T, value: U) -> Self
     where
         T: Into<CamelCaseString>,
-        U: Into<ValueNode>,
+        U: Into<PdaSeedValueValueNode>,
     {
         Self {
             name: name.into(),
             value: value.into(),
         }
     }
+}
+
+#[node_union]
+pub enum PdaSeedValueValueNode {
+    Account(AccountValueNode),
+    Argument(ArgumentValueNode),
+
+    // ValueNodes.
+    Array(ArrayValueNode),
+    Boolean(BooleanValueNode),
+    Bytes(BytesValueNode),
+    Constant(ConstantValueNode),
+    Enum(EnumValueNode),
+    Map(MapValueNode),
+    None(NoneValueNode),
+    Number(NumberValueNode),
+    PublicKey(PublicKeyValueNode),
+    Set(SetValueNode),
+    Some(SomeValueNode),
+    String(StringValueNode),
+    Struct(StructValueNode),
+    Tuple(TupleValueNode),
 }
 
 #[cfg(test)]
@@ -39,7 +66,10 @@ mod tests {
     fn new() {
         let node = PdaSeedValueNode::new("answer", NumberValueNode::new(42));
         assert_eq!(node.name, CamelCaseString::from("answer"));
-        assert_eq!(node.value, ValueNode::Number(NumberValueNode::new(42)));
+        assert_eq!(
+            node.value,
+            PdaSeedValueValueNode::Number(NumberValueNode::new(42))
+        );
     }
 
     #[test]

--- a/codama-nodes/src/contextual_value_nodes/resolver_value_node.rs
+++ b/codama-nodes/src/contextual_value_nodes/resolver_value_node.rs
@@ -5,12 +5,11 @@ use codama_nodes_derive::{node, node_union};
 pub struct ResolverValueNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub docs: Docs,
 
     // Children.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub depends_on: Option<Vec<ResolverDependency>>,
 }
 

--- a/codama-nodes/src/contextual_value_nodes/resolver_value_node.rs
+++ b/codama-nodes/src/contextual_value_nodes/resolver_value_node.rs
@@ -5,7 +5,8 @@ use codama_nodes_derive::{node, node_union};
 pub struct ResolverValueNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(default, skip_serializing_if = "Docs::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/contextual_value_nodes/resolver_value_node.rs
+++ b/codama-nodes/src/contextual_value_nodes/resolver_value_node.rs
@@ -5,8 +5,7 @@ use codama_nodes_derive::{node, node_union};
 pub struct ResolverValueNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/defined_type_node.rs
+++ b/codama-nodes/src/defined_type_node.rs
@@ -5,7 +5,8 @@ use codama_nodes_derive::node;
 pub struct DefinedTypeNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(default, skip_serializing_if = "Docs::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/defined_type_node.rs
+++ b/codama-nodes/src/defined_type_node.rs
@@ -5,8 +5,7 @@ use codama_nodes_derive::node;
 pub struct DefinedTypeNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/defined_type_node.rs
+++ b/codama-nodes/src/defined_type_node.rs
@@ -5,8 +5,7 @@ use codama_nodes_derive::node;
 pub struct DefinedTypeNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/error_node.rs
+++ b/codama-nodes/src/error_node.rs
@@ -7,7 +7,8 @@ pub struct ErrorNode {
     pub name: CamelCaseString,
     pub code: usize,
     pub message: String,
-    #[serde(default, skip_serializing_if = "Docs::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 }
 

--- a/codama-nodes/src/error_node.rs
+++ b/codama-nodes/src/error_node.rs
@@ -7,8 +7,7 @@ pub struct ErrorNode {
     pub name: CamelCaseString,
     pub code: usize,
     pub message: String,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub docs: Docs,
 }
 

--- a/codama-nodes/src/error_node.rs
+++ b/codama-nodes/src/error_node.rs
@@ -7,8 +7,7 @@ pub struct ErrorNode {
     pub name: CamelCaseString,
     pub code: usize,
     pub message: String,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 }
 

--- a/codama-nodes/src/instruction_account_node.rs
+++ b/codama-nodes/src/instruction_account_node.rs
@@ -7,7 +7,7 @@ pub struct InstructionAccountNode {
     pub name: CamelCaseString,
     pub is_writable: bool,
     pub is_signer: IsAccountSigner,
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub is_optional: bool,
     #[serde(default, skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,

--- a/codama-nodes/src/instruction_account_node.rs
+++ b/codama-nodes/src/instruction_account_node.rs
@@ -7,9 +7,11 @@ pub struct InstructionAccountNode {
     pub name: CamelCaseString,
     pub is_writable: bool,
     pub is_signer: IsAccountSigner,
-    #[serde(default, skip_serializing_if = "crate::is_default")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub is_optional: bool,
-    #[serde(default, skip_serializing_if = "Docs::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/instruction_account_node.rs
+++ b/codama-nodes/src/instruction_account_node.rs
@@ -7,11 +7,9 @@ pub struct InstructionAccountNode {
     pub name: CamelCaseString,
     pub is_writable: bool,
     pub is_signer: IsAccountSigner,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub is_optional: bool,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/instruction_account_node.rs
+++ b/codama-nodes/src/instruction_account_node.rs
@@ -7,15 +7,13 @@ pub struct InstructionAccountNode {
     pub name: CamelCaseString,
     pub is_writable: bool,
     pub is_signer: IsAccountSigner,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "crate::is_default")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub is_optional: bool,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub docs: Docs,
 
     // Children.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub default_value: Option<InstructionInputValueNode>,
 }
 

--- a/codama-nodes/src/instruction_argument_node.rs
+++ b/codama-nodes/src/instruction_argument_node.rs
@@ -10,8 +10,7 @@ pub struct InstructionArgumentNode {
     pub name: CamelCaseString,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_value_strategy: Option<DefaultValueStrategy>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/instruction_argument_node.rs
+++ b/codama-nodes/src/instruction_argument_node.rs
@@ -8,15 +8,14 @@ use codama_nodes_derive::node;
 pub struct InstructionArgumentNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub default_value_strategy: Option<DefaultValueStrategy>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub docs: Docs,
 
     // Children.
     pub r#type: TypeNode,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub default_value: Option<InstructionInputValueNode>,
 }
 

--- a/codama-nodes/src/instruction_argument_node.rs
+++ b/codama-nodes/src/instruction_argument_node.rs
@@ -10,7 +10,8 @@ pub struct InstructionArgumentNode {
     pub name: CamelCaseString,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_value_strategy: Option<DefaultValueStrategy>,
-    #[serde(default, skip_serializing_if = "Docs::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/instruction_byte_delta_node.rs
+++ b/codama-nodes/src/instruction_byte_delta_node.rs
@@ -5,7 +5,8 @@ use codama_nodes_derive::{node, node_union};
 pub struct InstructionByteDeltaNode {
     // Data.
     pub with_header: bool,
-    #[serde(default, skip_serializing_if = "crate::is_default")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub subtract: bool,
 
     // Children.

--- a/codama-nodes/src/instruction_byte_delta_node.rs
+++ b/codama-nodes/src/instruction_byte_delta_node.rs
@@ -5,8 +5,7 @@ use codama_nodes_derive::{node, node_union};
 pub struct InstructionByteDeltaNode {
     // Data.
     pub with_header: bool,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub subtract: bool,
 
     // Children.

--- a/codama-nodes/src/instruction_byte_delta_node.rs
+++ b/codama-nodes/src/instruction_byte_delta_node.rs
@@ -5,7 +5,7 @@ use codama_nodes_derive::{node, node_union};
 pub struct InstructionByteDeltaNode {
     // Data.
     pub with_header: bool,
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub subtract: bool,
 
     // Children.

--- a/codama-nodes/src/instruction_byte_delta_node.rs
+++ b/codama-nodes/src/instruction_byte_delta_node.rs
@@ -5,8 +5,7 @@ use codama_nodes_derive::{node, node_union};
 pub struct InstructionByteDeltaNode {
     // Data.
     pub with_header: bool,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "crate::is_default")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub subtract: bool,
 
     // Children.

--- a/codama-nodes/src/instruction_node.rs
+++ b/codama-nodes/src/instruction_node.rs
@@ -10,23 +10,30 @@ use serde::{Deserialize, Serialize};
 pub struct InstructionNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(default, skip_serializing_if = "Docs::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
-    #[serde(default, skip_serializing_if = "crate::is_default")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub optional_account_strategy: InstructionOptionalAccountStrategy,
 
     // Children.
     pub accounts: Vec<InstructionAccountNode>,
     pub arguments: Vec<InstructionArgumentNode>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub extra_arguments: Vec<InstructionArgumentNode>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub remaining_accounts: Vec<InstructionRemainingAccountsNode>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub byte_deltas: Vec<InstructionByteDeltaNode>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub discriminators: Vec<DiscriminatorNode>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub sub_instructions: Vec<InstructionNode>,
 }
 

--- a/codama-nodes/src/instruction_node.rs
+++ b/codama-nodes/src/instruction_node.rs
@@ -12,10 +12,7 @@ pub struct InstructionNode {
     pub name: CamelCaseString,
     #[serde(default, skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
-    #[serde(
-        default,
-        skip_serializing_if = "InstructionOptionalAccountStrategy::is_default"
-    )]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub optional_account_strategy: InstructionOptionalAccountStrategy,
 
     // Children.
@@ -39,12 +36,6 @@ pub enum InstructionOptionalAccountStrategy {
     Omitted,
     #[default]
     ProgramId,
-}
-
-impl InstructionOptionalAccountStrategy {
-    pub fn is_default(&self) -> bool {
-        matches!(self, Self::ProgramId)
-    }
 }
 
 #[cfg(test)]

--- a/codama-nodes/src/instruction_node.rs
+++ b/codama-nodes/src/instruction_node.rs
@@ -10,30 +10,26 @@ use serde::{Deserialize, Serialize};
 pub struct InstructionNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "InstructionOptionalAccountStrategy::is_default")]
+    #[serde(
+        default,
+        skip_serializing_if = "InstructionOptionalAccountStrategy::is_default"
+    )]
     pub optional_account_strategy: InstructionOptionalAccountStrategy,
 
     // Children.
     pub accounts: Vec<InstructionAccountNode>,
     pub arguments: Vec<InstructionArgumentNode>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extra_arguments: Vec<InstructionArgumentNode>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub remaining_accounts: Vec<InstructionRemainingAccountsNode>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub byte_deltas: Vec<InstructionByteDeltaNode>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub discriminators: Vec<DiscriminatorNode>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub sub_instructions: Vec<InstructionNode>,
 }
 

--- a/codama-nodes/src/instruction_node.rs
+++ b/codama-nodes/src/instruction_node.rs
@@ -10,30 +10,23 @@ use serde::{Deserialize, Serialize};
 pub struct InstructionNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub docs: Docs,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "crate::is_default")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub optional_account_strategy: InstructionOptionalAccountStrategy,
 
     // Children.
     pub accounts: Vec<InstructionAccountNode>,
     pub arguments: Vec<InstructionArgumentNode>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub extra_arguments: Vec<InstructionArgumentNode>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub remaining_accounts: Vec<InstructionRemainingAccountsNode>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub byte_deltas: Vec<InstructionByteDeltaNode>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub discriminators: Vec<DiscriminatorNode>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub sub_instructions: Vec<InstructionNode>,
 }
 

--- a/codama-nodes/src/instruction_remaining_accounts_node.rs
+++ b/codama-nodes/src/instruction_remaining_accounts_node.rs
@@ -4,9 +4,11 @@ use codama_nodes_derive::{node, node_union};
 #[node]
 pub struct InstructionRemainingAccountsNode {
     // Data.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub is_optional: bool,
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub is_signer: IsAccountSigner,
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub is_writable: bool,
     #[serde(default, skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,

--- a/codama-nodes/src/instruction_remaining_accounts_node.rs
+++ b/codama-nodes/src/instruction_remaining_accounts_node.rs
@@ -4,13 +4,11 @@ use codama_nodes_derive::{node, node_union};
 #[node]
 pub struct InstructionRemainingAccountsNode {
     // Data.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub is_optional: bool,
     pub is_signer: IsAccountSigner,
     pub is_writable: bool,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/instruction_remaining_accounts_node.rs
+++ b/codama-nodes/src/instruction_remaining_accounts_node.rs
@@ -4,13 +4,17 @@ use codama_nodes_derive::{node, node_union};
 #[node]
 pub struct InstructionRemainingAccountsNode {
     // Data.
-    #[serde(default, skip_serializing_if = "crate::is_default")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub is_optional: bool,
-    #[serde(default, skip_serializing_if = "crate::is_default")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub is_signer: IsAccountSigner,
-    #[serde(default, skip_serializing_if = "crate::is_default")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub is_writable: bool,
-    #[serde(default, skip_serializing_if = "Docs::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/instruction_remaining_accounts_node.rs
+++ b/codama-nodes/src/instruction_remaining_accounts_node.rs
@@ -4,17 +4,13 @@ use codama_nodes_derive::{node, node_union};
 #[node]
 pub struct InstructionRemainingAccountsNode {
     // Data.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "crate::is_default")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub is_optional: bool,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "crate::is_default")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub is_signer: IsAccountSigner,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "crate::is_default")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub is_writable: bool,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/lib.rs
+++ b/codama-nodes/src/lib.rs
@@ -41,3 +41,8 @@ pub use shared::*;
 pub use traits::*;
 pub use type_nodes::*;
 pub use value_nodes::*;
+
+// Serde helper function to use with `#[serde(some_thing = "crate::is_default")]`.
+fn is_default<T: Default + PartialEq>(t: &T) -> bool {
+    t == &T::default()
+}

--- a/codama-nodes/src/link_nodes/account_link_node.rs
+++ b/codama-nodes/src/link_nodes/account_link_node.rs
@@ -7,7 +7,7 @@ pub struct AccountLinkNode {
     pub name: CamelCaseString,
 
     // Children.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub program: Option<ProgramLinkNode>,
 }
 

--- a/codama-nodes/src/link_nodes/defined_type_link_node.rs
+++ b/codama-nodes/src/link_nodes/defined_type_link_node.rs
@@ -7,7 +7,7 @@ pub struct DefinedTypeLinkNode {
     pub name: CamelCaseString,
 
     // Children.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub program: Option<ProgramLinkNode>,
 }
 

--- a/codama-nodes/src/link_nodes/instruction_account_link_node.rs
+++ b/codama-nodes/src/link_nodes/instruction_account_link_node.rs
@@ -7,7 +7,7 @@ pub struct InstructionAccountLinkNode {
     pub name: CamelCaseString,
 
     // Children.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub instruction: Option<InstructionLinkNode>,
 }
 

--- a/codama-nodes/src/link_nodes/instruction_argument_link_node.rs
+++ b/codama-nodes/src/link_nodes/instruction_argument_link_node.rs
@@ -7,7 +7,7 @@ pub struct InstructionArgumentLinkNode {
     pub name: CamelCaseString,
 
     // Children.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub instruction: Option<InstructionLinkNode>,
 }
 

--- a/codama-nodes/src/link_nodes/instruction_link_node.rs
+++ b/codama-nodes/src/link_nodes/instruction_link_node.rs
@@ -7,7 +7,7 @@ pub struct InstructionLinkNode {
     pub name: CamelCaseString,
 
     // Children.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub program: Option<ProgramLinkNode>,
 }
 

--- a/codama-nodes/src/link_nodes/pda_link_node.rs
+++ b/codama-nodes/src/link_nodes/pda_link_node.rs
@@ -7,7 +7,7 @@ pub struct PdaLinkNode {
     pub name: CamelCaseString,
 
     // Children.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub program: Option<ProgramLinkNode>,
 }
 

--- a/codama-nodes/src/pda_node.rs
+++ b/codama-nodes/src/pda_node.rs
@@ -5,7 +5,8 @@ use codama_nodes_derive::node;
 pub struct PdaNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(default, skip_serializing_if = "Docs::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub program_id: Option<String>,

--- a/codama-nodes/src/pda_node.rs
+++ b/codama-nodes/src/pda_node.rs
@@ -5,8 +5,7 @@ use codama_nodes_derive::node;
 pub struct PdaNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub program_id: Option<String>,

--- a/codama-nodes/src/pda_node.rs
+++ b/codama-nodes/src/pda_node.rs
@@ -5,10 +5,9 @@ use codama_nodes_derive::node;
 pub struct PdaNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub docs: Docs,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub program_id: Option<String>,
 
     // Children.

--- a/codama-nodes/src/pda_seed_nodes/variable_pda_seed_node.rs
+++ b/codama-nodes/src/pda_seed_nodes/variable_pda_seed_node.rs
@@ -5,8 +5,7 @@ use codama_nodes_derive::node;
 pub struct VariablePdaSeedNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/pda_seed_nodes/variable_pda_seed_node.rs
+++ b/codama-nodes/src/pda_seed_nodes/variable_pda_seed_node.rs
@@ -5,7 +5,8 @@ use codama_nodes_derive::node;
 pub struct VariablePdaSeedNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(default, skip_serializing_if = "Docs::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/pda_seed_nodes/variable_pda_seed_node.rs
+++ b/codama-nodes/src/pda_seed_nodes/variable_pda_seed_node.rs
@@ -5,8 +5,7 @@ use codama_nodes_derive::node;
 pub struct VariablePdaSeedNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/program_node.rs
+++ b/codama-nodes/src/program_node.rs
@@ -10,10 +10,9 @@ pub struct ProgramNode {
     pub name: CamelCaseString,
     pub public_key: String,
     pub version: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub origin: Option<String>, // 'anchor' | 'shank'. Soon to be deprecated.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/program_node.rs
+++ b/codama-nodes/src/program_node.rs
@@ -12,21 +12,17 @@ pub struct ProgramNode {
     pub version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub origin: Option<String>, // 'anchor' | 'shank'. Soon to be deprecated.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.
     pub accounts: Vec<AccountNode>,
     pub instructions: Vec<InstructionNode>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub defined_types: Vec<DefinedTypeNode>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub pdas: Vec<PdaNode>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub errors: Vec<ErrorNode>,
 }
 

--- a/codama-nodes/src/program_node.rs
+++ b/codama-nodes/src/program_node.rs
@@ -16,10 +16,15 @@ pub struct ProgramNode {
     pub docs: Docs,
 
     // Children.
+    #[serde(default)]
     pub accounts: Vec<AccountNode>,
+    #[serde(default)]
     pub instructions: Vec<InstructionNode>,
+    #[serde(default)]
     pub defined_types: Vec<DefinedTypeNode>,
+    #[serde(default)]
     pub pdas: Vec<PdaNode>,
+    #[serde(default)]
     pub errors: Vec<ErrorNode>,
 }
 
@@ -66,6 +71,7 @@ impl ProgramNode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn new() {
@@ -128,13 +134,13 @@ mod tests {
         let json = serde_json::to_string(&node).unwrap();
         assert_eq!(
             json,
-            r#"{"kind":"programNode","name":"myProgram","publicKey":"1234..5678","version":"1.2.3","accounts":[],"instructions":[]}"#
+            r#"{"kind":"programNode","name":"myProgram","publicKey":"1234..5678","version":"1.2.3","accounts":[],"instructions":[],"definedTypes":[],"pdas":[],"errors":[]}"#
         );
     }
 
     #[test]
     fn from_json() {
-        let json = r#"{"kind":"programNode","name":"myProgram","publicKey":"1234..5678","version":"1.2.3","accounts":[],"instructions":[]}"#;
+        let json = r#"{"kind":"programNode","name":"myProgram","publicKey":"1234..5678","version":"1.2.3"}"#;
         let node: ProgramNode = serde_json::from_str(json).unwrap();
         assert_eq!(
             node,

--- a/codama-nodes/src/program_node.rs
+++ b/codama-nodes/src/program_node.rs
@@ -12,17 +12,21 @@ pub struct ProgramNode {
     pub version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub origin: Option<String>, // 'anchor' | 'shank'. Soon to be deprecated.
-    #[serde(default, skip_serializing_if = "Docs::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.
     pub accounts: Vec<AccountNode>,
     pub instructions: Vec<InstructionNode>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub defined_types: Vec<DefinedTypeNode>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub pdas: Vec<PdaNode>,
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub errors: Vec<ErrorNode>,
 }
 

--- a/codama-nodes/src/program_node.rs
+++ b/codama-nodes/src/program_node.rs
@@ -19,14 +19,8 @@ pub struct ProgramNode {
     // Children.
     pub accounts: Vec<AccountNode>,
     pub instructions: Vec<InstructionNode>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub defined_types: Vec<DefinedTypeNode>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub pdas: Vec<PdaNode>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub errors: Vec<ErrorNode>,
 }
 

--- a/codama-nodes/src/root_node.rs
+++ b/codama-nodes/src/root_node.rs
@@ -46,6 +46,7 @@ impl From<ProgramNode> for RootNode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     #[test]
     fn new() {
@@ -112,7 +113,7 @@ mod tests {
         let json = serde_json::to_string(&node).unwrap();
         assert_eq!(
             json,
-            r#"{"kind":"rootNode","standard":"codama","version":"1.0.0","program":{"kind":"programNode","name":"myProgram","publicKey":"1234..5678","version":"1.2.3","accounts":[],"instructions":[]},"additionalPrograms":[]}"#
+            r#"{"kind":"rootNode","standard":"codama","version":"1.0.0","program":{"kind":"programNode","name":"myProgram","publicKey":"1234..5678","version":"1.2.3","accounts":[],"instructions":[],"definedTypes":[],"pdas":[],"errors":[]},"additionalPrograms":[]}"#
         );
     }
 

--- a/codama-nodes/src/type_nodes/amount_type_node.rs
+++ b/codama-nodes/src/type_nodes/amount_type_node.rs
@@ -5,7 +5,7 @@ use codama_nodes_derive::type_node;
 pub struct AmountTypeNode {
     // Data.
     pub decimals: u8,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub unit: Option<String>,
 
     // Children.

--- a/codama-nodes/src/type_nodes/enum_empty_variant_type_node.rs
+++ b/codama-nodes/src/type_nodes/enum_empty_variant_type_node.rs
@@ -5,7 +5,7 @@ use codama_nodes_derive::node;
 pub struct EnumEmptyVariantTypeNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub discriminator: Option<usize>,
 }
 

--- a/codama-nodes/src/type_nodes/enum_struct_variant_type_node.rs
+++ b/codama-nodes/src/type_nodes/enum_struct_variant_type_node.rs
@@ -5,7 +5,7 @@ use codama_nodes_derive::node;
 pub struct EnumStructVariantTypeNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub discriminator: Option<usize>,
 
     // Children.

--- a/codama-nodes/src/type_nodes/enum_tuple_variant_type_node.rs
+++ b/codama-nodes/src/type_nodes/enum_tuple_variant_type_node.rs
@@ -5,7 +5,7 @@ use codama_nodes_derive::node;
 pub struct EnumTupleVariantTypeNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub discriminator: Option<usize>,
 
     // Children.

--- a/codama-nodes/src/type_nodes/option_type_node.rs
+++ b/codama-nodes/src/type_nodes/option_type_node.rs
@@ -4,7 +4,7 @@ use codama_nodes_derive::type_node;
 #[type_node]
 pub struct OptionTypeNode {
     // Data.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub fixed: bool,
 
     // Children.

--- a/codama-nodes/src/type_nodes/option_type_node.rs
+++ b/codama-nodes/src/type_nodes/option_type_node.rs
@@ -4,8 +4,7 @@ use codama_nodes_derive::type_node;
 #[type_node]
 pub struct OptionTypeNode {
     // Data.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "crate::is_default")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub fixed: bool,
 
     // Children.

--- a/codama-nodes/src/type_nodes/option_type_node.rs
+++ b/codama-nodes/src/type_nodes/option_type_node.rs
@@ -4,8 +4,7 @@ use codama_nodes_derive::type_node;
 #[type_node]
 pub struct OptionTypeNode {
     // Data.
-    #[serde(default)]
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub fixed: bool,
 
     // Children.

--- a/codama-nodes/src/type_nodes/option_type_node.rs
+++ b/codama-nodes/src/type_nodes/option_type_node.rs
@@ -4,7 +4,8 @@ use codama_nodes_derive::type_node;
 #[type_node]
 pub struct OptionTypeNode {
     // Data.
-    #[serde(default, skip_serializing_if = "crate::is_default")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub fixed: bool,
 
     // Children.

--- a/codama-nodes/src/type_nodes/struct_field_type_node.rs
+++ b/codama-nodes/src/type_nodes/struct_field_type_node.rs
@@ -5,15 +5,14 @@ use codama_nodes_derive::node;
 pub struct StructFieldTypeNode {
     // Data.
     pub name: CamelCaseString,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub default_value_strategy: Option<DefaultValueStrategy>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub docs: Docs,
 
     // Children.
     pub r#type: TypeNode,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub default_value: Option<ValueNode>,
 }
 

--- a/codama-nodes/src/type_nodes/struct_field_type_node.rs
+++ b/codama-nodes/src/type_nodes/struct_field_type_node.rs
@@ -7,7 +7,8 @@ pub struct StructFieldTypeNode {
     pub name: CamelCaseString,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_value_strategy: Option<DefaultValueStrategy>,
-    #[serde(default, skip_serializing_if = "Docs::is_empty")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/type_nodes/struct_field_type_node.rs
+++ b/codama-nodes/src/type_nodes/struct_field_type_node.rs
@@ -7,8 +7,7 @@ pub struct StructFieldTypeNode {
     pub name: CamelCaseString,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub default_value_strategy: Option<DefaultValueStrategy>,
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Docs::is_empty")]
+    #[serde(default, skip_serializing_if = "Docs::is_empty")]
     pub docs: Docs,
 
     // Children.

--- a/codama-nodes/src/type_nodes/zeroable_option_type_node.rs
+++ b/codama-nodes/src/type_nodes/zeroable_option_type_node.rs
@@ -5,7 +5,7 @@ use codama_nodes_derive::type_node;
 pub struct ZeroableOptionTypeNode {
     // Children.
     pub item: Box<TypeNode>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub zero_value: Option<ConstantValueNode>,
 }
 

--- a/codama-nodes/src/value_nodes/enum_value_node.rs
+++ b/codama-nodes/src/value_nodes/enum_value_node.rs
@@ -8,7 +8,7 @@ pub struct EnumValueNode {
 
     // Children.
     pub r#enum: DefinedTypeLinkNode,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub value: Option<EnumVariantData>,
 }
 

--- a/codama-nodes/src/value_nodes/public_key_value_node.rs
+++ b/codama-nodes/src/value_nodes/public_key_value_node.rs
@@ -5,7 +5,7 @@ use codama_nodes_derive::node;
 pub struct PublicKeyValueNode {
     // Data.
     pub public_key: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "crate::is_default")]
     pub identifier: Option<CamelCaseString>,
 }
 

--- a/codama/tests/membership/mod.rs
+++ b/codama/tests/membership/mod.rs
@@ -96,7 +96,9 @@ fn get_idl() {
           }
         }
       }
-    ]
+    ],
+    "pdas": [],
+    "errors": []
   },
   "additionalPrograms": []
 }"#

--- a/codama/tests/system/mod.rs
+++ b/codama/tests/system/mod.rs
@@ -917,6 +917,7 @@ fn get_idl() {
         }
       }
     ],
+    "pdas": [],
     "errors": [
       {
         "kind": "errorNode",


### PR DESCRIPTION
This should ensure compatibility with the TS definitions. In addition, the InstructionRemainingAccountsNode had fields marked as optional in TS, so this marks them optional here too. https://github.com/codama-idl/codama/pull/512 makes additional changes to the TS definitions to ensure the rest of the optional fields are compatible.