### PR TITLE
Add variant `Default` in `InstructionOptionalAccountStrategy`

### DIFF
--- a/codama-nodes/src/instruction_node.rs
+++ b/codama-nodes/src/instruction_node.rs
@@ -34,6 +34,7 @@ pub struct InstructionNode {
 #[serde(rename_all = "camelCase")]
 pub enum InstructionOptionalAccountStrategy {
     Omitted,
+    Default,
     #[default]
     ProgramId,
 }


### PR DESCRIPTION
Currently, it is impossible to get the default key if the account is equal to none. Perhaps this should be added to the TS section.