### PR TITLE
Deduplicate nodes in `CombineModulesVisitor`

### DIFF
--- a/codama-korok-visitors/tests/combine_modules_visitor/account_node.rs
+++ b/codama-korok-visitors/tests/combine_modules_visitor/account_node.rs
@@ -1,0 +1,118 @@
+use super::utils::{combine_modules, CombineModulesInput};
+use codama_nodes::{
+    AccountNode, BooleanTypeNode, NumberTypeNode, ProgramNode, RootNode, StringTypeNode,
+    StructFieldTypeNode, StructTypeNode, U32,
+};
+
+fn create_account_with_single_field(name: &str, field_name: &str) -> AccountNode {
+    AccountNode::new(
+        name,
+        StructTypeNode::new(vec![StructFieldTypeNode::new(
+            field_name,
+            StringTypeNode::utf8(),
+        )]),
+    )
+}
+
+#[test]
+fn it_merges_accounts_into_root_nodes() {
+    let membership = AccountNode::new(
+        "membership",
+        StructTypeNode::new(vec![
+            StructFieldTypeNode::new("identifier", StringTypeNode::utf8()),
+            StructFieldTypeNode::new("active", BooleanTypeNode::default()),
+        ]),
+    );
+    let person = AccountNode::new(
+        "person",
+        StructTypeNode::new(vec![
+            StructFieldTypeNode::new("name", StringTypeNode::utf8()),
+            StructFieldTypeNode::new("age", NumberTypeNode::le(U32)),
+        ]),
+    );
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(membership.clone())
+                .add_node(person.clone())
+        ),
+        Some(
+            RootNode::new(
+                ProgramNode::default()
+                    .add_account(membership)
+                    .add_account(person)
+            )
+            .into()
+        )
+    );
+}
+
+#[test]
+fn it_merges_accounts_inside_programs_into_root_nodes() {
+    let empty_data = StructTypeNode::new(vec![]);
+    let program_a = ProgramNode::default().add_account(AccountNode::new("foo", empty_data.clone()));
+    let program_b = ProgramNode::default().add_account(AccountNode::new("bar", empty_data.clone()));
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(program_a)
+                .add_node(program_b)
+        ),
+        Some(
+            RootNode::new(
+                ProgramNode::default()
+                    .add_account(AccountNode::new("foo", empty_data.clone()))
+                    .add_account(AccountNode::new("bar", empty_data))
+            )
+            .into()
+        )
+    );
+}
+
+#[test]
+fn it_deduplicates_accounts_with_identical_names_by_using_the_last_one() {
+    let first_counter = create_account_with_single_field("counter", "first");
+    let second_counter = create_account_with_single_field("counter", "second");
+    let third_counter = create_account_with_single_field("counter", "third");
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(first_counter)
+                .add_node(second_counter)
+                .add_node(third_counter.clone())
+        ),
+        Some(RootNode::new(ProgramNode::default().add_account(third_counter)).into())
+    );
+}
+
+#[test]
+fn it_deduplicates_accounts_with_identical_names_inside_programs() {
+    let first_counter = create_account_with_single_field("counter", "first");
+    let second_counter = create_account_with_single_field("counter", "second");
+    let program_a = ProgramNode::default().add_account(first_counter);
+    let program_b = ProgramNode::default().add_account(second_counter.clone());
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(program_a)
+                .add_node(program_b)
+        ),
+        Some(RootNode::new(ProgramNode::default().add_account(second_counter)).into())
+    );
+}
+
+#[test]
+fn it_deduplicates_accounts_with_identical_names_with_an_initial_program_node() {
+    let first_counter = create_account_with_single_field("counter", "first");
+    let second_counter = create_account_with_single_field("counter", "second");
+    let program_a = ProgramNode::default().add_account(first_counter);
+    let program_b = ProgramNode::default().add_account(second_counter.clone());
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .set_initial_node(program_a)
+                .add_node(program_b)
+        ),
+        Some(RootNode::new(ProgramNode::default().add_account(second_counter)).into())
+    );
+}

--- a/codama-korok-visitors/tests/combine_modules_visitor/defined_type_node.rs
+++ b/codama-korok-visitors/tests/combine_modules_visitor/defined_type_node.rs
@@ -1,7 +1,8 @@
 use super::utils::{combine_modules, CombineModulesInput};
 use codama_nodes::{
-    DefinedTypeNode, EnumEmptyVariantTypeNode, EnumTypeNode, NumberTypeNode, ProgramNode, RootNode,
-    StringTypeNode, StructFieldTypeNode, StructTypeNode, U32,
+    DefinedTypeNode, EnumEmptyVariantTypeNode, EnumTypeNode,
+    NumberFormat::{U16, U32, U64},
+    NumberTypeNode, ProgramNode, RootNode, StringTypeNode, StructFieldTypeNode, StructTypeNode,
 };
 
 #[test]
@@ -57,5 +58,53 @@ fn it_merges_defined_types_inside_programs_into_root_nodes() {
             )
             .into()
         )
+    );
+}
+
+#[test]
+fn it_deduplicates_defined_types_with_identical_names_by_using_the_last_one() {
+    let first_counter = DefinedTypeNode::new("counter", NumberTypeNode::le(U16));
+    let second_counter = DefinedTypeNode::new("counter", NumberTypeNode::le(U32));
+    let third_counter = DefinedTypeNode::new("counter", NumberTypeNode::le(U64));
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(first_counter)
+                .add_node(second_counter)
+                .add_node(third_counter.clone())
+        ),
+        Some(RootNode::new(ProgramNode::default().add_defined_type(third_counter)).into())
+    );
+}
+
+#[test]
+fn it_deduplicates_defined_types_with_identical_names_inside_programs() {
+    let first_counter = DefinedTypeNode::new("counter", NumberTypeNode::le(U32));
+    let second_counter = DefinedTypeNode::new("counter", NumberTypeNode::le(U64));
+    let program_a = ProgramNode::default().add_defined_type(first_counter);
+    let program_b = ProgramNode::default().add_defined_type(second_counter.clone());
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(program_a)
+                .add_node(program_b)
+        ),
+        Some(RootNode::new(ProgramNode::default().add_defined_type(second_counter)).into())
+    );
+}
+
+#[test]
+fn it_deduplicates_defined_types_with_identical_names_with_an_initial_program_node() {
+    let first_counter = DefinedTypeNode::new("counter", NumberTypeNode::le(U32));
+    let second_counter = DefinedTypeNode::new("counter", NumberTypeNode::le(U64));
+    let program_a = ProgramNode::default().add_defined_type(first_counter);
+    let program_b = ProgramNode::default().add_defined_type(second_counter.clone());
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .set_initial_node(program_a)
+                .add_node(program_b)
+        ),
+        Some(RootNode::new(ProgramNode::default().add_defined_type(second_counter)).into())
     );
 }

--- a/codama-korok-visitors/tests/combine_modules_visitor/error_node.rs
+++ b/codama-korok-visitors/tests/combine_modules_visitor/error_node.rs
@@ -1,0 +1,87 @@
+use super::utils::{combine_modules, CombineModulesInput};
+use codama_nodes::{ErrorNode, ProgramNode, RootNode};
+
+#[test]
+fn it_merges_errors_into_root_nodes() {
+    let wrong_account = ErrorNode::new("wrongAccount", 1, "This account is not valid");
+    let wrong_argument = ErrorNode::new("wrongArgument", 2, "This argument is not valid");
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(wrong_account.clone())
+                .add_node(wrong_argument.clone())
+        ),
+        Some(
+            RootNode::new(
+                ProgramNode::default()
+                    .add_error(wrong_account)
+                    .add_error(wrong_argument)
+            )
+            .into()
+        )
+    );
+}
+
+#[test]
+fn it_merges_errors_inside_programs_into_root_nodes() {
+    let error_a = ErrorNode::new("foo", 1, "foo");
+    let error_b = ErrorNode::new("bar", 2, "bar");
+    let program_a = ProgramNode::default().add_error(error_a.clone());
+    let program_b = ProgramNode::default().add_error(error_b.clone());
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(program_a)
+                .add_node(program_b)
+        ),
+        Some(RootNode::new(ProgramNode::default().add_error(error_a).add_error(error_b)).into())
+    );
+}
+
+#[test]
+fn it_deduplicates_errors_with_identical_names_by_using_the_last_one() {
+    let first_error = ErrorNode::new("duplicated", 1, "first");
+    let second_error = ErrorNode::new("duplicated", 2, "second");
+    let third_error = ErrorNode::new("duplicated", 3, "third");
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(first_error)
+                .add_node(second_error)
+                .add_node(third_error.clone())
+        ),
+        Some(RootNode::new(ProgramNode::default().add_error(third_error)).into())
+    );
+}
+
+#[test]
+fn it_deduplicates_errors_with_identical_names_inside_programs() {
+    let first_error = ErrorNode::new("duplicated", 1, "first");
+    let second_error = ErrorNode::new("duplicated", 2, "second");
+    let program_a = ProgramNode::default().add_error(first_error);
+    let program_b = ProgramNode::default().add_error(second_error.clone());
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(program_a)
+                .add_node(program_b)
+        ),
+        Some(RootNode::new(ProgramNode::default().add_error(second_error)).into())
+    );
+}
+
+#[test]
+fn it_deduplicates_errors_with_identical_names_with_an_initial_program_node() {
+    let first_error = ErrorNode::new("duplicated", 1, "first");
+    let second_error = ErrorNode::new("duplicated", 2, "second");
+    let program_a = ProgramNode::default().add_error(first_error);
+    let program_b = ProgramNode::default().add_error(second_error.clone());
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .set_initial_node(program_a)
+                .add_node(program_b)
+        ),
+        Some(RootNode::new(ProgramNode::default().add_error(second_error)).into())
+    );
+}

--- a/codama-korok-visitors/tests/combine_modules_visitor/instruction_node.rs
+++ b/codama-korok-visitors/tests/combine_modules_visitor/instruction_node.rs
@@ -1,0 +1,119 @@
+use super::utils::{combine_modules, CombineModulesInput};
+use codama_nodes::{
+    BooleanTypeNode, InstructionAccountNode, InstructionArgumentNode, InstructionNode, ProgramNode,
+    RootNode,
+};
+
+fn create_instruction_with_single_arg(name: &str, arg_name: &str) -> InstructionNode {
+    InstructionNode {
+        name: name.into(),
+        arguments: vec![InstructionArgumentNode::new(
+            arg_name,
+            BooleanTypeNode::default(),
+        )],
+        ..InstructionNode::default()
+    }
+}
+
+#[test]
+fn it_merges_instructions_into_root_nodes() {
+    let create_instruction = InstructionNode {
+        name: "create".into(),
+        accounts: vec![
+            InstructionAccountNode::new("payer", true, true),
+            InstructionAccountNode::new("authority", false, false),
+        ],
+        ..InstructionNode::default()
+    };
+    let update_instruction = InstructionNode {
+        name: "update".into(),
+        accounts: vec![InstructionAccountNode::new("authority", false, true)],
+        ..InstructionNode::default()
+    };
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(create_instruction.clone())
+                .add_node(update_instruction.clone())
+        ),
+        Some(
+            RootNode::new(
+                ProgramNode::default()
+                    .add_instruction(create_instruction)
+                    .add_instruction(update_instruction)
+            )
+            .into()
+        )
+    );
+}
+
+#[test]
+fn it_merges_instructions_inside_programs_into_root_nodes() {
+    let foo_instruction = create_instruction_with_single_arg("foo", "arg");
+    let bar_instruction = create_instruction_with_single_arg("bar", "arg");
+    let program_a = ProgramNode::default().add_instruction(foo_instruction.clone());
+    let program_b = ProgramNode::default().add_instruction(bar_instruction.clone());
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(program_a)
+                .add_node(program_b)
+        ),
+        Some(
+            RootNode::new(
+                ProgramNode::default()
+                    .add_instruction(foo_instruction)
+                    .add_instruction(bar_instruction)
+            )
+            .into()
+        )
+    );
+}
+
+#[test]
+fn it_deduplicates_instructions_with_identical_names_by_using_the_last_one() {
+    let first_instruction = create_instruction_with_single_arg("create", "first");
+    let second_instruction = create_instruction_with_single_arg("create", "second");
+    let third_instruction = create_instruction_with_single_arg("create", "third");
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(first_instruction)
+                .add_node(second_instruction)
+                .add_node(third_instruction.clone())
+        ),
+        Some(RootNode::new(ProgramNode::default().add_instruction(third_instruction)).into())
+    );
+}
+
+#[test]
+fn it_deduplicates_instructions_with_identical_names_inside_programs() {
+    let first_instruction = create_instruction_with_single_arg("create", "first");
+    let second_instruction = create_instruction_with_single_arg("create", "second");
+    let program_a = ProgramNode::default().add_instruction(first_instruction);
+    let program_b = ProgramNode::default().add_instruction(second_instruction.clone());
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(program_a)
+                .add_node(program_b)
+        ),
+        Some(RootNode::new(ProgramNode::default().add_instruction(second_instruction)).into())
+    );
+}
+
+#[test]
+fn it_deduplicates_instructions_with_identical_names_with_an_initial_program_node() {
+    let first_instruction = create_instruction_with_single_arg("create", "first");
+    let second_instruction = create_instruction_with_single_arg("create", "second");
+    let program_a = ProgramNode::default().add_instruction(first_instruction.clone());
+    let program_b = ProgramNode::default().add_instruction(second_instruction.clone());
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .set_initial_node(program_a)
+                .add_node(program_b)
+        ),
+        Some(RootNode::new(ProgramNode::default().add_instruction(second_instruction)).into())
+    );
+}

--- a/codama-korok-visitors/tests/combine_modules_visitor/mod.rs
+++ b/codama-korok-visitors/tests/combine_modules_visitor/mod.rs
@@ -1,4 +1,8 @@
+mod account_node;
 mod defined_type_node;
+mod error_node;
+mod instruction_node;
+mod pda_node;
 mod program_node;
 mod root_node;
 mod utils;

--- a/codama-korok-visitors/tests/combine_modules_visitor/pda_node.rs
+++ b/codama-korok-visitors/tests/combine_modules_visitor/pda_node.rs
@@ -1,0 +1,109 @@
+use super::utils::{combine_modules, CombineModulesInput};
+use codama_nodes::{
+    ConstantPdaSeedNode, PdaNode, ProgramNode, RootNode, StringTypeNode, StringValueNode,
+    VariablePdaSeedNode,
+};
+
+fn create_pda_with_single_seed(name: &str, seed_name: &str) -> PdaNode {
+    PdaNode::new(
+        name,
+        vec![VariablePdaSeedNode::new(seed_name, StringTypeNode::utf8()).into()],
+    )
+}
+
+#[test]
+fn it_merges_pdas_into_root_nodes() {
+    let member_pda = PdaNode::new(
+        "member",
+        vec![
+            ConstantPdaSeedNode::new(StringTypeNode::utf8(), StringValueNode::new("member")).into(),
+            VariablePdaSeedNode::new("identifier", StringTypeNode::utf8()).into(),
+        ],
+    );
+    let person_pda = PdaNode::new(
+        "person",
+        vec![
+            ConstantPdaSeedNode::new(StringTypeNode::utf8(), StringValueNode::new("person")).into(),
+            VariablePdaSeedNode::new("firstname", StringTypeNode::utf8()).into(),
+        ],
+    );
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(member_pda.clone())
+                .add_node(person_pda.clone())
+        ),
+        Some(
+            RootNode::new(
+                ProgramNode::default()
+                    .add_pda(member_pda)
+                    .add_pda(person_pda)
+            )
+            .into()
+        )
+    );
+}
+
+#[test]
+fn it_merges_pdas_inside_programs_into_root_nodes() {
+    let pda_a = create_pda_with_single_seed("foo", "seed");
+    let pda_b = create_pda_with_single_seed("bar", "seed");
+    let program_a = ProgramNode::default().add_pda(pda_a.clone());
+    let program_b = ProgramNode::default().add_pda(pda_b.clone());
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(program_a)
+                .add_node(program_b)
+        ),
+        Some(RootNode::new(ProgramNode::default().add_pda(pda_a).add_pda(pda_b)).into())
+    );
+}
+
+#[test]
+fn it_deduplicates_pdas_with_identical_names_by_using_the_last_one() {
+    let first_counter = create_pda_with_single_seed("counter", "first");
+    let second_counter = create_pda_with_single_seed("counter", "second");
+    let third_counter = create_pda_with_single_seed("counter", "third");
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(first_counter)
+                .add_node(second_counter)
+                .add_node(third_counter.clone())
+        ),
+        Some(RootNode::new(ProgramNode::default().add_pda(third_counter)).into())
+    );
+}
+
+#[test]
+fn it_deduplicates_pdas_with_identical_names_inside_programs() {
+    let first_counter = create_pda_with_single_seed("counter", "first");
+    let second_counter = create_pda_with_single_seed("counter", "second");
+    let program_a = ProgramNode::default().add_pda(first_counter);
+    let program_b = ProgramNode::default().add_pda(second_counter.clone());
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(program_a)
+                .add_node(program_b)
+        ),
+        Some(RootNode::new(ProgramNode::default().add_pda(second_counter)).into())
+    );
+}
+
+#[test]
+fn it_deduplicates_pdas_with_identical_names_with_an_initial_program_node() {
+    let first_counter = create_pda_with_single_seed("counter", "first");
+    let second_counter = create_pda_with_single_seed("counter", "second");
+    let program_a = ProgramNode::default().add_pda(first_counter);
+    let program_b = ProgramNode::default().add_pda(second_counter.clone());
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .set_initial_node(program_a)
+                .add_node(program_b)
+        ),
+        Some(RootNode::new(ProgramNode::default().add_pda(second_counter)).into())
+    );
+}


### PR DESCRIPTION
This PR ensures that running the `CombineModulesVisitor` back to back does not end up creating duplicated nodes. It does this by deduplicating nodes of the same type with the same name before merging them together.