### PR TITLE
Extract `CombineModulesVisitor` from default plugin

### DIFF
--- a/codama-korok-plugins/src/default_plugin.rs
+++ b/codama-korok-plugins/src/default_plugin.rs
@@ -1,9 +1,9 @@
 use crate::KorokPlugin;
 use codama_errors::CodamaResult;
 use codama_korok_visitors::{
-    ApplyCodamaTypeAttributesVisitor, CombineModulesVisitor, ComposeVisitor, FilterItemsVisitor,
-    KorokVisitable, SetAccountsVisitor, SetBorshTypesVisitor, SetDefinedTypesVisitor,
-    SetErrorsVisitor, SetInstructionsVisitor, SetLinkTypesVisitor, SetProgramMetadataVisitor,
+    ApplyCodamaTypeAttributesVisitor, ComposeVisitor, FilterItemsVisitor, KorokVisitable,
+    SetAccountsVisitor, SetBorshTypesVisitor, SetDefinedTypesVisitor, SetErrorsVisitor,
+    SetInstructionsVisitor, SetLinkTypesVisitor, SetProgramMetadataVisitor,
 };
 use codama_koroks::KorokTrait;
 
@@ -34,5 +34,4 @@ pub fn get_default_visitor<'a>() -> ComposeVisitor<'a> {
         .with(SetAccountsVisitor::new())
         .with(SetInstructionsVisitor::new())
         .with(SetErrorsVisitor::new())
-        .with(CombineModulesVisitor::new())
 }

--- a/codama/src/codama.rs
+++ b/codama/src/codama.rs
@@ -1,5 +1,6 @@
 use codama_errors::{CodamaError, CodamaResult};
 use codama_korok_plugins::{resolve_plugins, DefaultPlugin, KorokPlugin};
+use codama_korok_visitors::{CombineModulesVisitor, KorokVisitable};
 use codama_koroks::RootKorok;
 use codama_nodes::{HasKind, Node, NodeTrait, RootNode};
 use codama_stores::RootStore;
@@ -58,6 +59,12 @@ impl Codama {
         let mut korok = self.get_korok()?;
         let run_plugins = resolve_plugins(self.get_plugins());
         run_plugins(&mut korok)?;
+
+        // Combine all modules into a single RootNode.
+        // This could be part of the default plugin, but it would require
+        // every post-plugins to re-run the CombineModulesVisitor.
+        korok.accept(&mut CombineModulesVisitor::new())?;
+
         Ok(korok)
     }
 


### PR DESCRIPTION
This PR removes the `CombineModulesVisitor` from the default plugin and instead, makes it an explicit final step after all plugins have been executed.

This is because, otherwise, any changes made by plugins _after_ the `next()` call, won't be propagated up towards the `RootNode` of the `RootKorok` unless each of these plugin explicitly call `CombineModulesVisitor` again. By moving this step to a permanent final step of the process, we ensure all information added by plugins is correctly propagated up towards the `RootNode`.