### PR TITLE
Don't combine modules if root node is already set

### DIFF
--- a/codama-korok-visitors/src/combine_modules_visitor.rs
+++ b/codama-korok-visitors/src/combine_modules_visitor.rs
@@ -4,16 +4,27 @@ use codama_koroks::KorokTrait;
 use codama_nodes::{HasName, Node, ProgramNode, RootNode};
 
 #[derive(Default)]
-pub struct CombineModulesVisitor;
+pub struct CombineModulesVisitor {
+    force: bool,
+}
 
 impl CombineModulesVisitor {
     pub fn new() -> Self {
-        Self
+        Self { force: false }
+    }
+
+    pub fn force() -> Self {
+        Self { force: true }
     }
 }
 
 impl KorokVisitor for CombineModulesVisitor {
     fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) -> CodamaResult<()> {
+        // Unless forced, if the root node is already set, do not combine modules.
+        if !self.force && korok.node.is_some() {
+            return Ok(());
+        }
+
         self.visit_children(korok)?;
         korok.node = combine_koroks(&korok.node, &korok.crates);
         Ok(())


### PR DESCRIPTION
This PR introduce a new default behaviour to the `CombineModulesVisitor`. If, when visiting the `RootKorok`, we see that a `RootNode` has already been set up, we stop trying to combine modules. This provides ways for plugins to provide their own logic for propagating information up the tree without having the final hardcoded step overriding their work.

This PR also introduces a new `force` option for that visitor to override the existing `RootNode` anyway.