### PR TITLE
Update nightly toolchain in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   RUSTFLAGS: "-Dwarnings"
-  RUST_TOOLCHAIN: "nightly-2024-11-22"
+  RUST_TOOLCHAIN: "nightly-2025-02-16"
 
 jobs:
   lint:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ env:
   # It also helps prevent rate limiting on the registry.
   PUBLISH_GRACE_SLEEP: 15
   RUSTFLAGS: "-Dwarnings"
-  RUST_TOOLCHAIN: "nightly-2024-11-22"
+  RUST_TOOLCHAIN: "nightly-2025-02-16"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This PR upgrades the nightly toolchain so it can be used with the latest version of `cargo release` in CI.