### PR TITLE
Export only codama-macros from codama in Solana targets

### DIFF
--- a/codama/Cargo.toml
+++ b/codama/Cargo.toml
@@ -7,11 +7,18 @@ edition = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
+codama-macros = { version = "0.5.2", path = "../codama-macros" }
+
+[target.'cfg(not(target_os = "solana"))'.dependencies]
 codama-errors = { version = "0.5.2", path = "../codama-errors" }
 codama-korok-plugins = { version = "0.5.2", path = "../codama-korok-plugins" }
 codama-korok-visitors = { version = "0.5.2", path = "../codama-korok-visitors" }
 codama-koroks = { version = "0.5.2", path = "../codama-koroks" }
-codama-macros = { version = "0.5.2", path = "../codama-macros" }
 codama-nodes = { version = "0.5.2", path = "../codama-nodes" }
 codama-stores = { version = "0.5.2", path = "../codama-stores" }
 proc-macro2 = "1.0"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(target_os, values("solana"))',
+] }

--- a/codama/src/lib.rs
+++ b/codama/src/lib.rs
@@ -1,12 +1,14 @@
+pub use codama_macros::*;
+
+// Solana programs only need Codama macros, which expand to
+// nothing at compile time. Everything else must be excluded
+// to avoid compiling non-Solana-compatible code.
+
+#[cfg(not(target_os = "solana"))]
 mod codama;
 
-pub use codama::*;
-pub use codama_errors::*;
-pub use codama_korok_plugins::*;
-pub use codama_korok_visitors::*;
-pub use codama_koroks::*;
-pub use codama_nodes::*;
-pub use codama_stores::*;
-
-extern crate codama_macros;
-pub use codama_macros::*;
+#[cfg(not(target_os = "solana"))]
+pub use {
+    codama::*, codama_errors::*, codama_korok_plugins::*, codama_korok_visitors::*,
+    codama_koroks::*, codama_nodes::*, codama_stores::*,
+};


### PR DESCRIPTION
### Problem

When using `codama` as a program dependency instead of `codama-macros`, running `cargo build-sbf` will output lots of stack overflow error messages like these:

```
Error: Function _ZN10cargo_toml3afs14find_workspace17h15c954312f2f478fE Stack offset of 6952 exceeded max offset of 4096 by 2856 bytes, please minimize large stack variables. Estimated function frame size: 7104 bytes. Exceeding the maximum stack offset may cause undefined behavior during execution.

Error: Function _ZN6codama6codama6Codama8load_all17h9bd9cdca41235a7dE Stack offset of 17656 exceeded max offset of 4096 by 13560 bytes, please minimize large stack variables. Estimated function frame size: 17920 bytes. Exceeding the maximum stack offset may cause undefined behavior during execution.
```

This is because, when building using `cargo build-sbf`, the compiler adds a 4KB size limit requirement to every single imported function — even if it is unused. This means the simple fact of adding `codama` to program dependencies will make the compiler check for every function in the whole framework and its dependencies.

### Solution

This problem can be avoided by using the `codama-macros` crate instead of the `codama` crate since you shouldn't need any other Codama features in your programs anyway.

However, using `target_os = "solana"` in the `codama` crate, we can ensure only the `codama-macros` module is exported from that crate and nothing else. That way, if a consumer uses the `codama` crate in their program by mistake, it'll be equivalent to using `codama-macros`.

Fixes #27