### PR TITLE
Update struct field inner type only

### DIFF
--- a/codama-korok-visitors/src/apply_codama_type_attributes_visitor.rs
+++ b/codama-korok-visitors/src/apply_codama_type_attributes_visitor.rs
@@ -7,7 +7,7 @@ use codama_errors::CodamaResult;
 use codama_koroks::{KorokMut, KorokTrait};
 use codama_nodes::{
     FixedSizeTypeNode, HasKind, NestedTypeLeaf, NestedTypeNode, NestedTypeNodeTrait, Node,
-    RegisteredTypeNode, SizePrefixTypeNode, StringTypeNode, StructFieldTypeNode, TypeNode,
+    RegisteredTypeNode, SizePrefixTypeNode, StringTypeNode, TypeNode,
 };
 use codama_syn_helpers::extensions::ToTokensExtension;
 
@@ -122,12 +122,7 @@ fn apply_type_directive(
 ) -> CodamaResult<Option<Node>> {
     let node = directive.node.clone();
     match input.korok {
-        // If the `type` directive is applied to a named field then
-        // we need to wrap the provided node in a `StructFieldTypeNode`.
-        KorokMut::Field(korok) => match (node.clone(), korok.name()) {
-            (type_node, Some(name)) => Ok(Some(StructFieldTypeNode::new(name, type_node).into())),
-            _ => Ok(Some(node.into())),
-        },
+        KorokMut::Field(korok) => Ok(korok.get_updated_type_node(node)),
         _ => Ok(Some(node.into())),
     }
 }

--- a/codama-koroks/src/field_korok.rs
+++ b/codama-koroks/src/field_korok.rs
@@ -1,7 +1,7 @@
 use crate::KorokTrait;
 use codama_attributes::{Attributes, NameDirective, TryFromFilter};
 use codama_errors::CodamaResult;
-use codama_nodes::{CamelCaseString, Node, StructFieldTypeNode, TypeNode};
+use codama_nodes::{CamelCaseString, Node, RegisteredTypeNode, StructFieldTypeNode, TypeNode};
 
 #[derive(Debug, PartialEq)]
 pub struct FieldKorok<'a> {
@@ -27,11 +27,24 @@ impl<'a> FieldKorok<'a> {
             .or_else(|| self.ast.ident.as_ref().map(|i| i.to_string().into()))
     }
 
-    pub fn set_type_node(&mut self, node: TypeNode) {
-        self.node = match self.name() {
-            Some(name) => Some(StructFieldTypeNode::new(name, node).into()),
-            None => Some(node.into()),
+    pub fn get_updated_type_node(&self, node: TypeNode) -> Option<Node> {
+        match &self.node {
+            Some(Node::Type(RegisteredTypeNode::StructField(field))) => Some(
+                StructFieldTypeNode {
+                    r#type: node,
+                    ..field.clone()
+                }
+                .into(),
+            ),
+            _ => match self.name() {
+                Some(name) => Some(StructFieldTypeNode::new(name, node).into()),
+                None => Some(node.into()),
+            },
         }
+    }
+
+    pub fn set_type_node(&mut self, node: TypeNode) {
+        self.node = self.get_updated_type_node(node);
     }
 }
 
@@ -46,5 +59,53 @@ impl KorokTrait for FieldKorok<'_> {
 
     fn attributes(&self) -> Option<&Attributes<'_>> {
         Some(&self.attributes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codama_nodes::{
+        NumberFormat::{U32, U64},
+        NumberTypeNode,
+    };
+
+    #[test]
+    fn get_updated_type_node_with_named_none() {
+        let korok = FieldKorok {
+            ast: &syn::parse_quote! { pub my_field: u32 },
+            attributes: Attributes(vec![]),
+            node: None,
+        };
+        assert_eq!(
+            korok.get_updated_type_node(NumberTypeNode::le(U32).into()),
+            Some(StructFieldTypeNode::new("my_field", NumberTypeNode::le(U32)).into())
+        );
+    }
+
+    #[test]
+    fn get_updated_type_node_with_unnamed_none() {
+        let korok = FieldKorok {
+            ast: &syn::parse_quote! { u32 },
+            attributes: Attributes(vec![]),
+            node: None,
+        };
+        assert_eq!(
+            korok.get_updated_type_node(NumberTypeNode::le(U32).into()),
+            Some(NumberTypeNode::le(U32).into())
+        );
+    }
+
+    #[test]
+    fn get_updated_type_node_with_some() {
+        let korok = FieldKorok {
+            ast: &syn::parse_quote! { pub my_field: u32 },
+            attributes: Attributes(vec![]),
+            node: Some(StructFieldTypeNode::new("my_node_name", NumberTypeNode::le(U32)).into()),
+        };
+        assert_eq!(
+            korok.get_updated_type_node(NumberTypeNode::le(U64).into()),
+            Some(StructFieldTypeNode::new("my_node_name", NumberTypeNode::le(U64)).into())
+        );
     }
 }


### PR DESCRIPTION
This PR ensures we keep the rest of the `StructFieldTypeNode` as-is when updating its inner type.