### PR TITLE
Split apply_codama_type_attributes_visitor

### DIFF
--- a/codama-korok-plugins/src/default_plugin.rs
+++ b/codama-korok-plugins/src/default_plugin.rs
@@ -1,9 +1,9 @@
 use crate::KorokPlugin;
 use codama_errors::CodamaResult;
 use codama_korok_visitors::{
-    ApplyCodamaTypeAttributesVisitor, ComposeVisitor, FilterItemsVisitor, KorokVisitable,
-    SetAccountsVisitor, SetBorshTypesVisitor, SetDefinedTypesVisitor, SetErrorsVisitor,
-    SetInstructionsVisitor, SetLinkTypesVisitor, SetProgramMetadataVisitor,
+    ApplyTypeModifiersVisitor, ApplyTypeOverridesVisitor, ComposeVisitor, FilterItemsVisitor,
+    KorokVisitable, SetAccountsVisitor, SetBorshTypesVisitor, SetDefinedTypesVisitor,
+    SetErrorsVisitor, SetInstructionsVisitor, SetLinkTypesVisitor, SetProgramMetadataVisitor,
 };
 use codama_koroks::KorokTrait;
 
@@ -29,7 +29,8 @@ pub fn get_default_visitor<'a>() -> ComposeVisitor<'a> {
                 .with(SetLinkTypesVisitor::new()),
         ))
         .with(SetProgramMetadataVisitor::new())
-        .with(ApplyCodamaTypeAttributesVisitor::new())
+        .with(ApplyTypeOverridesVisitor::new())
+        .with(ApplyTypeModifiersVisitor::new())
         .with(SetDefinedTypesVisitor::new())
         .with(SetAccountsVisitor::new())
         .with(SetInstructionsVisitor::new())

--- a/codama-korok-visitors/src/apply_type_overrides_visitor.rs
+++ b/codama-korok-visitors/src/apply_type_overrides_visitor.rs
@@ -1,0 +1,86 @@
+use crate::KorokVisitor;
+use codama_attributes::{TryFromFilter, TypeDirective};
+use codama_errors::CodamaResult;
+use codama_koroks::{KorokMut, KorokTrait};
+
+#[derive(Default)]
+pub struct ApplyTypeOverridesVisitor;
+
+impl ApplyTypeOverridesVisitor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl KorokVisitor for ApplyTypeOverridesVisitor {
+    fn visit_root(&mut self, korok: &mut codama_koroks::RootKorok) -> CodamaResult<()> {
+        self.visit_children(korok)?;
+        Ok(())
+    }
+
+    fn visit_crate(&mut self, korok: &mut codama_koroks::CrateKorok) -> CodamaResult<()> {
+        self.visit_children(korok)?;
+        apply_type_override(korok.into())
+    }
+
+    fn visit_file_module(
+        &mut self,
+        korok: &mut codama_koroks::FileModuleKorok,
+    ) -> CodamaResult<()> {
+        self.visit_children(korok)?;
+        apply_type_override(korok.into())
+    }
+
+    fn visit_module(&mut self, korok: &mut codama_koroks::ModuleKorok) -> CodamaResult<()> {
+        self.visit_children(korok)?;
+        apply_type_override(korok.into())
+    }
+
+    fn visit_struct(&mut self, korok: &mut codama_koroks::StructKorok) -> CodamaResult<()> {
+        self.visit_children(korok)?;
+        apply_type_override(korok.into())
+    }
+
+    fn visit_enum(&mut self, korok: &mut codama_koroks::EnumKorok) -> CodamaResult<()> {
+        self.visit_children(korok)?;
+        apply_type_override(korok.into())
+    }
+
+    fn visit_unsupported_item(
+        &mut self,
+        korok: &mut codama_koroks::UnsupportedItemKorok,
+    ) -> CodamaResult<()> {
+        self.visit_children(korok)?;
+        apply_type_override(korok.into())
+    }
+
+    fn visit_enum_variant(
+        &mut self,
+        korok: &mut codama_koroks::EnumVariantKorok,
+    ) -> CodamaResult<()> {
+        self.visit_children(korok)?;
+        apply_type_override(korok.into())
+    }
+
+    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) -> CodamaResult<()> {
+        self.visit_children(korok)?;
+        apply_type_override(korok.into())
+    }
+}
+
+fn apply_type_override(mut korok: KorokMut) -> CodamaResult<()> {
+    let Some(attributes) = korok.attributes() else {
+        return Ok(());
+    };
+
+    let Some(directive) = attributes.get_last(TypeDirective::filter) else {
+        return Ok(());
+    };
+
+    let type_node = directive.node.clone();
+    match korok {
+        KorokMut::Field(korok) => korok.set_type_node(type_node),
+        _ => korok.set_node(Some(type_node.into())),
+    };
+    Ok(())
+}

--- a/codama-korok-visitors/src/lib.rs
+++ b/codama-korok-visitors/src/lib.rs
@@ -1,4 +1,5 @@
-mod apply_codama_type_attributes_visitor;
+mod apply_type_modifiers_visitor;
+mod apply_type_overrides_visitor;
 mod combine_modules_visitor;
 mod combine_types_visitor;
 mod compose_visitor;
@@ -15,7 +16,8 @@ mod uniform_visitor;
 mod visitable;
 mod visitor;
 
-pub use apply_codama_type_attributes_visitor::*;
+pub use apply_type_modifiers_visitor::*;
+pub use apply_type_overrides_visitor::*;
 pub use combine_modules_visitor::*;
 pub use combine_types_visitor::*;
 pub use compose_visitor::*;

--- a/codama-korok-visitors/tests/apply_type_modifiers_visitor/encoding_directive.rs
+++ b/codama-korok-visitors/tests/apply_type_modifiers_visitor/encoding_directive.rs
@@ -1,6 +1,6 @@
 use codama_errors::CodamaResult;
 use codama_korok_visitors::{
-    ApplyCodamaTypeAttributesVisitor, KorokVisitable, SetBorshTypesVisitor,
+    ApplyTypeModifiersVisitor, ApplyTypeOverridesVisitor, KorokVisitable, SetBorshTypesVisitor,
 };
 use codama_koroks::{FieldKorok, KorokTrait};
 use codama_nodes::{
@@ -18,7 +18,8 @@ fn it_updates_the_encoding_of_string_type_nodes() -> CodamaResult<()> {
     let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
+    korok.accept(&mut ApplyTypeOverridesVisitor::new())?;
+    korok.accept(&mut ApplyTypeModifiersVisitor::new())?;
     assert_eq!(korok.node, Some(StringTypeNode::base16().into()));
     Ok(())
 }
@@ -36,7 +37,7 @@ fn it_updates_the_encoding_of_nested_string_type_nodes() -> CodamaResult<()> {
         korok.node,
         Some(SizePrefixTypeNode::new(StringTypeNode::utf8(), NumberTypeNode::le(U32)).into())
     );
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
+    korok.accept(&mut ApplyTypeModifiersVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(SizePrefixTypeNode::new(StringTypeNode::base16(), NumberTypeNode::le(U32)).into())
@@ -54,7 +55,8 @@ fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() -> CodamaResult<()> {
     let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
+    korok.accept(&mut ApplyTypeOverridesVisitor::new())?;
+    korok.accept(&mut ApplyTypeModifiersVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(StructFieldTypeNode::new("field", StringTypeNode::base16()).into())
@@ -81,7 +83,7 @@ fn it_keeps_the_nested_type_wrapped_in_a_struct_field_type_node() -> CodamaResul
             .into()
         )
     );
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
+    korok.accept(&mut ApplyTypeModifiersVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(
@@ -105,7 +107,7 @@ fn it_fails_on_empty_nodes() -> CodamaResult<()> {
 
     assert_eq!(korok.node, None);
     let error = korok
-        .accept(&mut ApplyCodamaTypeAttributesVisitor::new())
+        .accept(&mut ApplyTypeModifiersVisitor::new())
         .unwrap_err();
     assert_eq!(
         error.to_string(),
@@ -124,7 +126,7 @@ fn it_fails_on_non_type_nodes() -> CodamaResult<()> {
     korok.set_node(Some(StringValueNode::new("Some string value").into()));
 
     let error = korok
-        .accept(&mut ApplyCodamaTypeAttributesVisitor::new())
+        .accept(&mut ApplyTypeModifiersVisitor::new())
         .unwrap_err();
     assert_eq!(
         error.to_string(),
@@ -145,7 +147,7 @@ fn it_fails_on_nested_type_nodes_that_are_not_string_types() -> CodamaResult<()>
     ));
 
     let error = korok
-        .accept(&mut ApplyCodamaTypeAttributesVisitor::new())
+        .accept(&mut ApplyTypeModifiersVisitor::new())
         .unwrap_err();
     assert_eq!(
         error.to_string(),

--- a/codama-korok-visitors/tests/apply_type_modifiers_visitor/fixed_size_directive.rs
+++ b/codama-korok-visitors/tests/apply_type_modifiers_visitor/fixed_size_directive.rs
@@ -1,6 +1,6 @@
 use codama_errors::CodamaResult;
 use codama_korok_visitors::{
-    ApplyCodamaTypeAttributesVisitor, KorokVisitable, SetBorshTypesVisitor,
+    ApplyTypeModifiersVisitor, ApplyTypeOverridesVisitor, KorokVisitable, SetBorshTypesVisitor,
 };
 use codama_koroks::FieldKorok;
 use codama_nodes::{
@@ -17,7 +17,7 @@ fn it_wraps_any_type_into_a_fixed_size_type_node() -> CodamaResult<()> {
 
     assert_eq!(korok.node, None);
     korok.accept(&mut SetBorshTypesVisitor::new())?;
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
+    korok.accept(&mut ApplyTypeModifiersVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(FixedSizeTypeNode::new(NumberTypeNode::le(U32), 8).into())
@@ -35,7 +35,8 @@ fn it_wraps_any_overridden_type_into_a_fixed_size_type_node() -> CodamaResult<()
     let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
+    korok.accept(&mut ApplyTypeOverridesVisitor::new())?;
+    korok.accept(&mut ApplyTypeModifiersVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(FixedSizeTypeNode::new(StringTypeNode::utf8(), 42).into())
@@ -54,7 +55,8 @@ fn it_replaces_the_size_of_existing_fixed_size_type_nodes() -> CodamaResult<()> 
     let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
+    korok.accept(&mut ApplyTypeOverridesVisitor::new())?;
+    korok.accept(&mut ApplyTypeModifiersVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(FixedSizeTypeNode::new(StringTypeNode::utf8(), 222).into())
@@ -72,7 +74,7 @@ fn it_replaces_size_prefixed_type_nodes() -> CodamaResult<()> {
 
     assert_eq!(korok.node, None);
     korok.accept(&mut SetBorshTypesVisitor::new())?;
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
+    korok.accept(&mut ApplyTypeModifiersVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(FixedSizeTypeNode::new(StringTypeNode::utf8(), 42).into())
@@ -90,7 +92,7 @@ fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() -> CodamaResult<()> {
 
     assert_eq!(korok.node, None);
     korok.accept(&mut SetBorshTypesVisitor::new())?;
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
+    korok.accept(&mut ApplyTypeModifiersVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(

--- a/codama-korok-visitors/tests/apply_type_modifiers_visitor/mod.rs
+++ b/codama-korok-visitors/tests/apply_type_modifiers_visitor/mod.rs
@@ -1,4 +1,3 @@
 mod encoding_directive;
 mod fixed_size_directive;
 mod size_prefix_directive;
-mod type_directive;

--- a/codama-korok-visitors/tests/apply_type_modifiers_visitor/size_prefix_directive.rs
+++ b/codama-korok-visitors/tests/apply_type_modifiers_visitor/size_prefix_directive.rs
@@ -1,6 +1,6 @@
 use codama_errors::CodamaResult;
 use codama_korok_visitors::{
-    ApplyCodamaTypeAttributesVisitor, KorokVisitable, SetBorshTypesVisitor,
+    ApplyTypeModifiersVisitor, ApplyTypeOverridesVisitor, KorokVisitable, SetBorshTypesVisitor,
 };
 use codama_koroks::FieldKorok;
 use codama_nodes::{
@@ -19,7 +19,7 @@ fn it_wraps_any_type_into_a_size_prefix_type_node() -> CodamaResult<()> {
 
     assert_eq!(korok.node, None);
     korok.accept(&mut SetBorshTypesVisitor::new())?;
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
+    korok.accept(&mut ApplyTypeModifiersVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(SizePrefixTypeNode::new(NumberTypeNode::le(U32), NumberTypeNode::le(U8)).into())
@@ -37,7 +37,7 @@ fn it_accepts_nested_number_type_nodes_as_size_prefixes() -> CodamaResult<()> {
 
     assert_eq!(korok.node, None);
     korok.accept(&mut SetBorshTypesVisitor::new())?;
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
+    korok.accept(&mut ApplyTypeModifiersVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(
@@ -61,7 +61,8 @@ fn it_wraps_any_overridden_type_into_a_size_prefix_type_node() -> CodamaResult<(
     let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
+    korok.accept(&mut ApplyTypeOverridesVisitor::new())?;
+    korok.accept(&mut ApplyTypeModifiersVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(SizePrefixTypeNode::new(StringTypeNode::utf8(), NumberTypeNode::le(U8)).into())
@@ -80,7 +81,8 @@ fn it_replaces_the_size_of_existing_size_prefix_type_nodes() -> CodamaResult<()>
     let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
+    korok.accept(&mut ApplyTypeOverridesVisitor::new())?;
+    korok.accept(&mut ApplyTypeModifiersVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(SizePrefixTypeNode::new(StringTypeNode::utf8(), NumberTypeNode::le(U16)).into())
@@ -99,7 +101,8 @@ fn it_replaces_fixed_size_type_nodes() -> CodamaResult<()> {
     let mut korok = FieldKorok::parse(&ast)?;
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
+    korok.accept(&mut ApplyTypeOverridesVisitor::new())?;
+    korok.accept(&mut ApplyTypeModifiersVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(SizePrefixTypeNode::new(StringTypeNode::utf8(), NumberTypeNode::le(U8)).into())
@@ -117,7 +120,7 @@ fn it_keeps_the_type_wrapped_in_a_struct_field_type_node() -> CodamaResult<()> {
 
     assert_eq!(korok.node, None);
     korok.accept(&mut SetBorshTypesVisitor::new())?;
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
+    korok.accept(&mut ApplyTypeModifiersVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(

--- a/codama-korok-visitors/tests/apply_type_overrides_visitor.rs
+++ b/codama-korok-visitors/tests/apply_type_overrides_visitor.rs
@@ -1,5 +1,5 @@
 use codama_errors::CodamaResult;
-use codama_korok_visitors::{ApplyCodamaTypeAttributesVisitor, KorokVisitable};
+use codama_korok_visitors::{ApplyTypeOverridesVisitor, KorokVisitable};
 use codama_koroks::{FieldKorok, StructKorok};
 use codama_nodes::{BooleanTypeNode, StructFieldTypeNode};
 
@@ -12,7 +12,7 @@ fn it_set_the_node_on_the_korok() -> CodamaResult<()> {
     let mut korok = StructKorok::parse(&item)?;
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
+    korok.accept(&mut ApplyTypeOverridesVisitor::new())?;
     assert_eq!(korok.node, Some(BooleanTypeNode::default().into()));
     Ok(())
 }
@@ -26,7 +26,7 @@ fn it_wraps_the_node_in_a_struct_field_for_named_field_koroks() -> CodamaResult<
     let mut korok = FieldKorok::parse(&item)?;
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
+    korok.accept(&mut ApplyTypeOverridesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(StructFieldTypeNode::new("isValid", BooleanTypeNode::default()).into())
@@ -44,7 +44,7 @@ fn it_uses_the_name_directive() -> CodamaResult<()> {
     let mut korok = FieldKorok::parse(&item)?;
 
     assert_eq!(korok.node, None);
-    korok.accept(&mut ApplyCodamaTypeAttributesVisitor::new())?;
+    korok.accept(&mut ApplyTypeOverridesVisitor::new())?;
     assert_eq!(
         korok.node,
         Some(StructFieldTypeNode::new("isValid", BooleanTypeNode::default()).into())

--- a/codama-korok-visitors/tests/lib.rs
+++ b/codama-korok-visitors/tests/lib.rs
@@ -1,4 +1,5 @@
-mod apply_codama_type_attributes_visitor;
+mod apply_type_modifiers_visitor;
+mod apply_type_overrides_visitor;
 mod combine_modules_visitor;
 mod combine_types_visitor;
 mod debug_visitor;


### PR DESCRIPTION
They have separate purposes and could technically profit from having other visitors injected between them.