### PR TITLE
Add more entrypoints to Korok plugins

### DIFF
--- a/codama/src/codama.rs
+++ b/codama/src/codama.rs
@@ -1,6 +1,5 @@
 use codama_errors::{CodamaError, CodamaResult};
 use codama_korok_plugins::{resolve_plugins, DefaultPlugin, KorokPlugin};
-use codama_korok_visitors::{CombineModulesVisitor, KorokVisitable};
 use codama_koroks::RootKorok;
 use codama_nodes::{HasKind, Node, NodeTrait, RootNode};
 use codama_stores::RootStore;
@@ -59,12 +58,6 @@ impl Codama {
         let mut korok = self.get_korok()?;
         let run_plugins = resolve_plugins(self.get_plugins());
         run_plugins(&mut korok)?;
-
-        // Combine all modules into a single RootNode.
-        // This could be part of the default plugin, but it would require
-        // every post-plugins to re-run the CombineModulesVisitor.
-        korok.accept(&mut CombineModulesVisitor::new())?;
-
         Ok(korok)
     }
 


### PR DESCRIPTION
This PR adds more injection point for plugins instead of only being able to run visitors before and after the whole Codama machinery. This is useful because handling various `Option<Node>` in the Korok tree may be tricky when we don't know which koroks have combined the data from their children — and therefore we don't know at which layer we should operate.

The new plugin entrypoints make it clear which nodes we should operate on:
- `initialized`: The process has just started and nothing has been done (aside from potential previous plugins having `initialized` entrypoints). It can be good to set `Nodes` inside `FieldKoroks` here before they are being potentially overriden by macros.
- `on_fields_set`: At this point, all `FieldKoroks` should be set with a Node when applicable. Type overrides and modifiers have done their job. It can be good to add more type overrides here or only affects types that have no node assigned.
- `on_program_items_set`: All program items such as `AccountNode`, `InstructionNode`, etc. have now been resolved.
- `on_root_node_set`: The final `RootNode` of the `RootKorok` has been set. Handling other nodes inside the korok tree would be useless at this point unless another `CombineModuleVisitors` was executed afterwards.