### PR TITLE
Provide no-op macros in Solana targets

### DIFF
--- a/codama-macros/Cargo.toml
+++ b/codama-macros/Cargo.toml
@@ -16,7 +16,7 @@ path = "tests/mod.rs"
 [dev-dependencies]
 trybuild = { version = "1.0.49", features = ["diff"] }
 
-[dependencies]
+[target.'cfg(not(target_os = "solana"))'.dependencies]
 codama-attributes = { version = "0.5.3", path = "../codama-attributes" }
 codama-errors = { version = "0.5.3", path = "../codama-errors" }
 codama-koroks = { version = "0.5.3", path = "../codama-koroks" }
@@ -24,3 +24,8 @@ codama-stores = { version = "0.5.3", path = "../codama-stores" }
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["extra-traits"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = [
+  'cfg(target_os, values("solana"))',
+] }

--- a/codama-macros/src/attributes.rs
+++ b/codama-macros/src/attributes.rs
@@ -1,0 +1,18 @@
+use codama_attributes::{AttributeContext, CodamaAttribute};
+use codama_errors::{CodamaError, CodamaResult};
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+
+pub fn codama_attribute(attr: TokenStream, input: TokenStream) -> TokenStream {
+    codama_attribute_impl(attr.into(), input.into())
+        .unwrap_or_else(CodamaError::into_compile_error)
+        .into()
+}
+
+fn codama_attribute_impl(attr: TokenStream2, input: TokenStream2) -> CodamaResult<TokenStream2> {
+    let attr: syn::Attribute = syn::parse_quote! { #[codama(#attr)] };
+    let item: syn::Item = syn::parse2(input.clone())?;
+    let ctx: AttributeContext = (&item).into();
+    CodamaAttribute::parse(&attr, &ctx)?;
+    Ok(input)
+}

--- a/codama-macros/src/derives.rs
+++ b/codama-macros/src/derives.rs
@@ -1,0 +1,18 @@
+use codama_errors::{CodamaError, CodamaResult};
+use codama_koroks::CrateKorok;
+use codama_stores::CrateStore;
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+
+pub fn codama_derive(input: TokenStream) -> TokenStream {
+    codama_derive_impl(input.into())
+        .unwrap_or_else(CodamaError::into_compile_error)
+        .into()
+}
+
+fn codama_derive_impl(input: TokenStream2) -> CodamaResult<TokenStream2> {
+    let store = CrateStore::hydrate(input)?;
+    CrateKorok::parse(&store)?;
+    Ok(quote! {})
+}

--- a/codama-macros/src/lib.rs
+++ b/codama-macros/src/lib.rs
@@ -1,70 +1,63 @@
-use codama_attributes::{AttributeContext, CodamaAttribute};
-use codama_errors::{CodamaError, CodamaResult};
-use codama_koroks::CrateKorok;
-use codama_stores::CrateStore;
 use proc_macro::TokenStream;
-use proc_macro2::TokenStream as TokenStream2;
-use quote::quote;
+#[cfg(not(target_os = "solana"))]
+mod attributes;
+#[cfg(not(target_os = "solana"))]
+mod derives;
+
+fn codama_derive(input: TokenStream) -> TokenStream {
+    #[cfg(not(target_os = "solana"))]
+    {
+        derives::codama_derive(input)
+    }
+    #[cfg(target_os = "solana")]
+    {
+        input
+    }
+}
+
+fn codama_attribute(attr: TokenStream, input: TokenStream) -> TokenStream {
+    #[cfg(not(target_os = "solana"))]
+    {
+        attributes::codama_attribute(attr, input)
+    }
+    #[cfg(target_os = "solana")]
+    {
+        let _ = attr;
+        input
+    }
+}
 
 #[proc_macro_derive(CodamaAccount, attributes(codama))]
 pub fn codama_account_derive(input: TokenStream) -> TokenStream {
-    codama_derive(input.into())
-        .unwrap_or_else(CodamaError::into_compile_error)
-        .into()
+    codama_derive(input)
 }
 
 #[proc_macro_derive(CodamaAccounts, attributes(codama))]
 pub fn codama_accounts_derive(input: TokenStream) -> TokenStream {
-    codama_derive(input.into())
-        .unwrap_or_else(CodamaError::into_compile_error)
-        .into()
+    codama_derive(input)
 }
 
 #[proc_macro_derive(CodamaErrors, attributes(codama))]
 pub fn codama_errors_derive(input: TokenStream) -> TokenStream {
-    codama_derive(input.into())
-        .unwrap_or_else(CodamaError::into_compile_error)
-        .into()
+    codama_derive(input)
 }
 
 #[proc_macro_derive(CodamaInstruction, attributes(codama))]
 pub fn codama_instruction_derive(input: TokenStream) -> TokenStream {
-    codama_derive(input.into())
-        .unwrap_or_else(CodamaError::into_compile_error)
-        .into()
+    codama_derive(input)
 }
 
 #[proc_macro_derive(CodamaInstructions, attributes(codama))]
 pub fn codama_instructions_derive(input: TokenStream) -> TokenStream {
-    codama_derive(input.into())
-        .unwrap_or_else(CodamaError::into_compile_error)
-        .into()
+    codama_derive(input)
 }
 
 #[proc_macro_derive(CodamaType, attributes(codama))]
 pub fn codama_type_derive(input: TokenStream) -> TokenStream {
-    codama_derive(input.into())
-        .unwrap_or_else(CodamaError::into_compile_error)
-        .into()
-}
-
-fn codama_derive(input: TokenStream2) -> CodamaResult<TokenStream2> {
-    let store = CrateStore::hydrate(input)?;
-    CrateKorok::parse(&store)?;
-    Ok(quote! {})
+    codama_derive(input)
 }
 
 #[proc_macro_attribute]
 pub fn codama(attr: TokenStream, input: TokenStream) -> TokenStream {
-    codama_attribute(attr.into(), input.into())
-        .unwrap_or_else(CodamaError::into_compile_error)
-        .into()
-}
-
-fn codama_attribute(attr: TokenStream2, input: TokenStream2) -> CodamaResult<TokenStream2> {
-    let attr: syn::Attribute = syn::parse_quote! { #[codama(#attr)] };
-    let item: syn::Item = syn::parse2(input.clone())?;
-    let ctx: AttributeContext = (&item).into();
-    CodamaAttribute::parse(&attr, &ctx)?;
-    Ok(input)
+    codama_attribute(attr, input)
 }


### PR DESCRIPTION
This PR removes all dependencies and logic in the `codama-macros` crate when it is imported in a Solana environment (using the `"solana"` target).

This means, when building a program via `cargo build-sbf`, the `codama-macros` crate won't have any work to do before expanding the macros to nothing and it won't even import any dependencies.