### PR TITLE
Add field type directive

### DIFF
--- a/codama-attributes/src/codama_directives/type_nodes/boolean_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/boolean_type_node.rs
@@ -4,10 +4,12 @@ use codama_syn_helpers::{extensions::*, Meta};
 
 impl FromMeta for BooleanTypeNode {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        meta.assert_directive("boolean")?;
         let mut size: SetOnce<TypeNode> = SetOnce::new("size");
         if meta.is_path_or_empty_list() {
             return Ok(BooleanTypeNode::default());
         }
+
         meta.as_path_list()?
             .each(|ref meta| match (meta.path_str().as_str(), meta) {
                 ("size", _) => {
@@ -17,6 +19,7 @@ impl FromMeta for BooleanTypeNode {
                 (_, m) if m.is_path_or_list() => size.set(TypeNode::from_meta(meta)?, meta),
                 _ => Err(meta.error("unrecognized attribute")),
             })?;
+
         let size = match NestedTypeNode::<NumberTypeNode>::try_from(size.take(meta)?) {
             Ok(node) => node,
             Err(_) => return Err(meta.error("size must be a NumberTypeNode")),

--- a/codama-attributes/src/codama_directives/type_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/mod.rs
@@ -3,4 +3,5 @@ mod fixed_size_type_node;
 mod number_type_node;
 mod public_key_type_node;
 mod string_type_node;
+mod struct_field_type_node;
 mod type_node;

--- a/codama-attributes/src/codama_directives/type_nodes/number_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/number_type_node.rs
@@ -5,9 +5,11 @@ use syn::{Expr, ExprPath};
 
 impl FromMeta for NumberTypeNode {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("number")?.as_path_list()?;
         let mut format = SetOnce::<NumberFormat>::new("format");
         let mut endian = SetOnce::<Endian>::new("endian").initial_value(Endian::Little);
-        meta.as_path_list()?.each(|ref meta| {
+
+        pl.each(|ref meta| {
             let path = meta.path()?;
             match (meta.path_str().as_str(), meta) {
                 ("format", _) => {
@@ -36,6 +38,7 @@ impl FromMeta for NumberTypeNode {
                 _ => Err(path.error("unrecognized attribute")),
             }
         })?;
+
         Ok(Self::new(format.take(meta)?, endian.take(meta)?))
     }
 }

--- a/codama-attributes/src/codama_directives/type_nodes/public_key_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/public_key_type_node.rs
@@ -4,6 +4,7 @@ use codama_syn_helpers::{extensions::*, Meta};
 
 impl FromMeta for PublicKeyTypeNode {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        meta.assert_directive("public_key")?;
         if !meta.is_path_or_empty_list() {
             return Err(meta.error("public_key does not accept any input"));
         }

--- a/codama-attributes/src/codama_directives/type_nodes/string_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/string_type_node.rs
@@ -5,10 +5,12 @@ use syn::{Expr, ExprPath};
 
 impl FromMeta for StringTypeNode {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        meta.assert_directive("string")?;
         let mut encoding: SetOnce<BytesEncoding> = SetOnce::new("encoding");
         if meta.is_path_or_empty_list() {
             return Ok(StringTypeNode::utf8());
         }
+
         meta.as_path_list()?
             .each(|ref meta| match (meta.path_str().as_str(), meta) {
                 ("encoding", _) => {
@@ -26,6 +28,7 @@ impl FromMeta for StringTypeNode {
                 }
                 _ => Err(meta.error("unrecognized attribute")),
             })?;
+
         Ok(StringTypeNode::new(encoding.take(meta)?))
     }
 }

--- a/codama-attributes/src/codama_directives/type_nodes/struct_field_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/struct_field_type_node.rs
@@ -1,0 +1,132 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{
+    CamelCaseString, DefaultValueStrategy, Docs, StructFieldTypeNode, TypeNode, ValueNode,
+};
+use codama_syn_helpers::{extensions::*, Meta};
+
+// TODO: impl { partial_meta(meta) -> Result<Self, Vec<Meta>> } to reuse in other directives.
+
+impl FromMeta for StructFieldTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("field")?.as_path_list()?;
+        let mut name = SetOnce::<CamelCaseString>::new("name");
+        let mut r#type = SetOnce::<TypeNode>::new("type");
+        let mut default_value = SetOnce::<ValueNode>::new("default_value");
+        let mut default_value_strategy =
+            SetOnce::<DefaultValueStrategy>::new("default_value_strategy");
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "name" => name.set(String::from_meta(meta)?.into(), meta),
+            "type" => {
+                let node = TypeNode::from_meta(&meta.as_path_value()?.value)?;
+                r#type.set(node, meta)
+            }
+            "default_value" => {
+                let node = ValueNode::from_meta(&meta.as_path_value()?.value)?;
+                default_value.set(node, meta)
+            }
+            "default_value_omitted" => {
+                meta.as_path()?;
+                default_value_strategy.set(DefaultValueStrategy::Omitted, meta)
+            }
+            _ => {
+                if let Ok(value) = String::from_meta(meta) {
+                    return name.set(value.into(), meta);
+                }
+                if let Ok(node) = TypeNode::from_meta(meta) {
+                    return r#type.set(node, meta);
+                }
+                Err(meta.error("unrecognized attribute"))
+            }
+        })?;
+        Ok(StructFieldTypeNode {
+            name: name.take(meta)?,
+            r#type: r#type.take(meta)?,
+            default_value: default_value.option(),
+            default_value_strategy: default_value_strategy.option(),
+            docs: Docs::default(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use codama_nodes::{NumberFormat::U32, NumberTypeNode, NumberValueNode};
+
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+
+    #[test]
+    fn implicit_minimum() {
+        assert_type!(
+            { field("age", number(u32)) },
+            StructFieldTypeNode::new("age", NumberTypeNode::le(U32)).into()
+        );
+    }
+
+    #[test]
+    fn explicit_minimum() {
+        assert_type!(
+            { field(name = "age", type = number(u32)) },
+            StructFieldTypeNode::new("age", NumberTypeNode::le(U32)).into()
+        );
+    }
+
+    #[test]
+    fn with_default_value() {
+        assert_type!(
+            { field("age", number(u32), default_value = 42) },
+            StructFieldTypeNode {
+                default_value: Some(NumberValueNode::new(42u32).into()),
+                ..StructFieldTypeNode::new("age", NumberTypeNode::le(U32))
+            }
+            .into()
+        );
+    }
+
+    #[test]
+    fn with_default_value_strategy() {
+        assert_type!(
+            {
+                field(
+                    "age",
+                    number(u32),
+                    default_value = 42,
+                    default_value_omitted,
+                )
+            },
+            StructFieldTypeNode {
+                default_value: Some(NumberValueNode::new(42u32).into()),
+                default_value_strategy: Some(DefaultValueStrategy::Omitted),
+                ..StructFieldTypeNode::new("age", NumberTypeNode::le(U32))
+            }
+            .into()
+        );
+    }
+
+    #[test]
+    fn missing_name() {
+        assert_type_err!({ field(type = number(u8)) }, "name is missing");
+    }
+
+    #[test]
+    fn missing_type() {
+        assert_type_err!({ field(name = "age") }, "type is missing");
+    }
+
+    #[test]
+    fn invalid_name() {
+        assert_type_err!({ field(name = unrecognized) }, "expected a string");
+    }
+
+    #[test]
+    fn invalid_type() {
+        assert_type_err!({ field(type = unrecognized) }, "unrecognized type");
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ field(unrecognized) }, "unrecognized attribute");
+        assert_type_err!({ field(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/type_node.rs
@@ -1,7 +1,7 @@
 use crate::utils::FromMeta;
 use codama_nodes::{
     BooleanTypeNode, FixedSizeTypeNode, NumberTypeNode, PublicKeyTypeNode, RegisteredTypeNode,
-    StringTypeNode, TypeNode,
+    StringTypeNode, StructFieldTypeNode, TypeNode,
 };
 use codama_syn_helpers::{extensions::*, Meta};
 
@@ -9,6 +9,7 @@ impl FromMeta for RegisteredTypeNode {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
         match meta.path_str().as_str() {
             "boolean" => BooleanTypeNode::from_meta(meta).map(Self::from),
+            "field" => StructFieldTypeNode::from_meta(meta).map(Self::from),
             "fixed_size" => FixedSizeTypeNode::from_meta(meta).map(Self::from),
             "number" => NumberTypeNode::from_meta(meta).map(Self::from),
             "public_key" => PublicKeyTypeNode::from_meta(meta).map(Self::from),

--- a/codama-korok-visitors/tests/apply_type_overrides_visitor.rs
+++ b/codama-korok-visitors/tests/apply_type_overrides_visitor.rs
@@ -35,6 +35,23 @@ fn it_wraps_the_node_in_a_struct_field_for_named_field_koroks() -> CodamaResult<
 }
 
 #[test]
+fn it_keeps_field_type_nodes_as_given_for_named_field_koroks() -> CodamaResult<()> {
+    let item: syn::Field = syn::parse_quote! {
+        #[codama(type = field("valid", boolean))]
+        pub is_valid: u8
+    };
+    let mut korok = FieldKorok::parse(&item)?;
+
+    assert_eq!(korok.node, None);
+    korok.accept(&mut ApplyTypeOverridesVisitor::new())?;
+    assert_eq!(
+        korok.node,
+        Some(StructFieldTypeNode::new("valid", BooleanTypeNode::default()).into())
+    );
+    Ok(())
+}
+
+#[test]
 fn it_uses_the_name_directive() -> CodamaResult<()> {
     let item: syn::Field = syn::parse_quote! {
         #[codama(name = "is_valid")]

--- a/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/_pass.rs
@@ -1,0 +1,15 @@
+use codama_macros::codama;
+
+#[codama(type = field("age", number(u32)))]
+pub struct ImplicitTest;
+
+#[codama(type = field(name = "age", type = number(u32)))]
+pub struct ExplicitTest;
+
+#[codama(type = field("age", number(u32), default_value = 42))]
+pub struct TestWithDefaultValue;
+
+#[codama(type = field("age", number(u32), default_value = 42, default_value_omitted))]
+pub struct TestWithDefaultValueStrategy;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/name_already_set.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/name_already_set.fail.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(type = field("age", number(u8), "years"))]
+pub struct Test;
+
+#[codama(type = field(name = "age", type = number(u8), name = "years"))]
+pub struct TestExplicit;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/name_already_set.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/name_already_set.fail.stderr
@@ -1,0 +1,11 @@
+error: name is already set
+ --> tests/codama_attribute/type_nodes/struct_field_type_node/name_already_set.fail.rs:3:42
+  |
+3 | #[codama(type = field("age", number(u8), "years"))]
+  |                                          ^^^^^^^
+
+error: name is already set
+ --> tests/codama_attribute/type_nodes/struct_field_type_node/name_already_set.fail.rs:6:56
+  |
+6 | #[codama(type = field(name = "age", type = number(u8), name = "years"))]
+  |                                                        ^^^^^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/name_missing.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/name_missing.fail.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(type = field(number(u32)))]
+pub struct Test;
+
+#[codama(type = field(type = number(u32)))]
+pub struct TestExplicit;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/name_missing.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/name_missing.fail.stderr
@@ -1,0 +1,11 @@
+error: name is missing
+ --> tests/codama_attribute/type_nodes/struct_field_type_node/name_missing.fail.rs:3:17
+  |
+3 | #[codama(type = field(number(u32)))]
+  |                 ^^^^^^^^^^^^^^^^^^
+
+error: name is missing
+ --> tests/codama_attribute/type_nodes/struct_field_type_node/name_missing.fail.rs:6:17
+  |
+6 | #[codama(type = field(type = number(u32)))]
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/type_already_set.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/type_already_set.fail.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(type = field(number(u8), "age", number(u32)))]
+pub struct Test;
+
+#[codama(type = field(type = number(u8), name = "age", type = number(u32)))]
+pub struct TestExplicit;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/type_already_set.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/type_already_set.fail.stderr
@@ -1,0 +1,11 @@
+error: type is already set
+ --> tests/codama_attribute/type_nodes/struct_field_type_node/type_already_set.fail.rs:3:42
+  |
+3 | #[codama(type = field(number(u8), "age", number(u32)))]
+  |                                          ^^^^^^^^^^^
+
+error: type is already set
+ --> tests/codama_attribute/type_nodes/struct_field_type_node/type_already_set.fail.rs:6:56
+  |
+6 | #[codama(type = field(type = number(u8), name = "age", type = number(u32)))]
+  |                                                        ^^^^^^^^^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/type_missing.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/type_missing.fail.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(type = field("age"))]
+pub struct Test;
+
+#[codama(type = field(name = "age"))]
+pub struct TestExplicit;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/type_missing.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/type_missing.fail.stderr
@@ -1,0 +1,11 @@
+error: type is missing
+ --> tests/codama_attribute/type_nodes/struct_field_type_node/type_missing.fail.rs:3:17
+  |
+3 | #[codama(type = field("age"))]
+  |                 ^^^^^^^^^^^^
+
+error: type is missing
+ --> tests/codama_attribute/type_nodes/struct_field_type_node/type_missing.fail.rs:6:17
+  |
+6 | #[codama(type = field(name = "age"))]
+  |                 ^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR add the `field` type directive making it possible to explicit set the type of some Rust code as the provided struct field.

### Implicit API

```rs
struct Person {
  #[codama(type = field("age", number(u8)))]
  pub current_year_minus_year_of_birth: MyComplexType;
}
```

### Explicit API

```rs
struct Person {
  #[codama(type = field(name = "age", type = number(u8)))]
  pub current_year_minus_year_of_birth: MyComplexType;
}
```

### With default value

```rs
struct Person {
  #[codama(type = field("age", number(u8), default_value = 42))]
  pub current_year_minus_year_of_birth: MyComplexType;
}
```

### With default value strategy

```rs
struct Person {
  #[codama(type = field("age", number(u8), default_value = 42, default_value_omitted))]
  pub current_year_minus_year_of_birth: MyComplexType;
}
```