### PR TITLE
Add struct type directive

### DIFF
--- a/codama-attributes/src/codama_directives/type_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/mod.rs
@@ -4,4 +4,5 @@ mod number_type_node;
 mod public_key_type_node;
 mod string_type_node;
 mod struct_field_type_node;
+mod struct_type_node;
 mod type_node;

--- a/codama-attributes/src/codama_directives/type_nodes/struct_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/struct_type_node.rs
@@ -1,0 +1,87 @@
+use crate::utils::FromMeta;
+use codama_errors::IteratorCombineErrors;
+use codama_nodes::{StructFieldTypeNode, StructTypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for StructTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        meta.assert_directive("struct")?;
+        if meta.is_path_or_empty_list() {
+            return Ok(StructTypeNode::default());
+        }
+
+        let fields = meta
+            .as_path_list()?
+            .parse_metas()?
+            .into_iter()
+            .map(|ref meta| match meta {
+                Meta::PathList(pl) if pl.path.is_strict("field") => {
+                    StructFieldTypeNode::from_meta(meta)
+                }
+                _ => Err(meta.error("expected field(...) attribute")),
+            })
+            .collect_and_combine_errors()?;
+
+        Ok(StructTypeNode { fields })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{NumberFormat::U32, NumberTypeNode, StringTypeNode};
+
+    #[test]
+    fn empty() {
+        assert_type!(
+            { struct },
+            StructTypeNode::default().into()
+        );
+    }
+
+    #[test]
+    fn empty_with_braces() {
+        assert_type!(
+            { struct() },
+            StructTypeNode::default().into()
+        );
+    }
+
+    #[test]
+    fn with_one_field() {
+        assert_type!(
+            { struct(field("age", number(u32))) },
+            StructTypeNode::new(vec![
+                StructFieldTypeNode::new("age", NumberTypeNode::le(U32))
+            ]).into()
+        );
+    }
+
+    #[test]
+    fn with_multiple_fields() {
+        assert_type!(
+            { struct(field("age", number(u32)), field("name", string(utf8))) },
+            StructTypeNode::new(vec![
+                StructFieldTypeNode::new("age", NumberTypeNode::le(U32)),
+                StructFieldTypeNode::new("name", StringTypeNode::utf8())
+            ]).into()
+        );
+    }
+
+    #[test]
+    fn with_brackets() {
+        assert_type!(
+            { struct[field("age", number(u32)), field("name", string(utf8))] },
+            StructTypeNode::new(vec![
+                StructFieldTypeNode::new("age", NumberTypeNode::le(U32)),
+                StructFieldTypeNode::new("name", StringTypeNode::utf8())
+            ]).into()
+        );
+    }
+
+    #[test]
+    fn invalid_fields_inside() {
+        assert_type_err!({ struct(boolean, number(u32)) }, "expected field(...) attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/type_node.rs
@@ -1,7 +1,7 @@
 use crate::utils::FromMeta;
 use codama_nodes::{
     BooleanTypeNode, FixedSizeTypeNode, NumberTypeNode, PublicKeyTypeNode, RegisteredTypeNode,
-    StringTypeNode, StructFieldTypeNode, TypeNode,
+    StringTypeNode, StructFieldTypeNode, StructTypeNode, TypeNode,
 };
 use codama_syn_helpers::{extensions::*, Meta};
 
@@ -14,6 +14,7 @@ impl FromMeta for RegisteredTypeNode {
             "number" => NumberTypeNode::from_meta(meta).map(Self::from),
             "public_key" => PublicKeyTypeNode::from_meta(meta).map(Self::from),
             "string" => StringTypeNode::from_meta(meta).map(Self::from),
+            "struct" => StructTypeNode::from_meta(meta).map(Self::from),
             _ => Err(meta.error("unrecognized type")),
         }
     }

--- a/codama-macros/tests/codama_attribute/type_nodes/struct_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/struct_type_node/_pass.rs
@@ -1,0 +1,18 @@
+use codama_macros::codama;
+
+#[codama(type = struct)]
+pub struct EmptyTest;
+
+#[codama(type = struct())]
+pub struct EmptyTestWithBraces;
+
+#[codama(type = struct(field("age", number(u32))))]
+pub struct OneFieldTest;
+
+#[codama(type = struct(field("age", number(u32)), field("name", string(utf8))))]
+pub struct MultipleFieldTest;
+
+#[codama(type = struct[field("age", number(u32)), field("name", string(utf8))])]
+pub struct MultipleFieldTestWithBrackets;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/struct_type_node/invalid_fields.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/struct_type_node/invalid_fields.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = struct(number(u32), boolean, field("age", number(u8)), 3 * 4))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/struct_type_node/invalid_fields.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/struct_type_node/invalid_fields.fail.stderr
@@ -1,0 +1,17 @@
+error: expected field(...) attribute
+ --> tests/codama_attribute/type_nodes/struct_type_node/invalid_fields.fail.rs:3:24
+  |
+3 | #[codama(type = struct(number(u32), boolean, field("age", number(u8)), 3 * 4))]
+  |                        ^^^^^^^^^^^
+
+error: expected field(...) attribute
+ --> tests/codama_attribute/type_nodes/struct_type_node/invalid_fields.fail.rs:3:37
+  |
+3 | #[codama(type = struct(number(u32), boolean, field("age", number(u8)), 3 * 4))]
+  |                                     ^^^^^^^
+
+error: expected field(...) attribute
+ --> tests/codama_attribute/type_nodes/struct_type_node/invalid_fields.fail.rs:3:72
+  |
+3 | #[codama(type = struct(number(u32), boolean, field("age", number(u8)), 3 * 4))]
+  |                                                                        ^^^^^


### PR DESCRIPTION
This PR adds a new `struct` type directive that can be used to explicitly set the node of some Rust code to the given struct.

### Empty struct

```rs
#[codama(type = struct)]
struct Person {
  pub age: u8;
}
```

Also works with delimiters.

```rs
#[codama(type = struct())]
struct Person {
  pub age: u8;
}
```

### Struct with fields

```rs
#[codama(type = struct(field("age", number(u8)), field("name", string(utf8))))]
struct Person;
```

Also work with bracket delimiters.

```rs
#[codama(type = struct[field("age", number(u8)), field("name", string(utf8))])]
struct Person;
```