### PR TITLE
Add MetaConsumer trait for partial meta parsing

### DIFF
--- a/codama-attributes/src/codama_directives/type_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/mod.rs
@@ -3,6 +3,7 @@ mod fixed_size_type_node;
 mod number_type_node;
 mod public_key_type_node;
 mod string_type_node;
+mod struct_field_meta_consumer;
 mod struct_field_type_node;
 mod struct_type_node;
 mod type_node;

--- a/codama-attributes/src/codama_directives/type_nodes/struct_field_meta_consumer.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/struct_field_meta_consumer.rs
@@ -1,0 +1,92 @@
+use crate::utils::{FromMeta, MetaConsumer, SetOnce};
+use codama_nodes::{
+    CamelCaseString, DefaultValueStrategy, InstructionInputValueNode, TypeNode, ValueNode,
+};
+use codama_syn_helpers::Meta;
+
+pub(crate) struct StructFieldMetaConsumer {
+    pub metas: Vec<Meta>,
+    pub name: SetOnce<CamelCaseString>,
+    pub r#type: SetOnce<TypeNode>,
+    pub default_value: SetOnce<ValueNode>,
+    #[allow(dead_code)]
+    pub argument_default_value: SetOnce<InstructionInputValueNode>,
+    pub default_value_strategy: SetOnce<DefaultValueStrategy>,
+}
+
+impl MetaConsumer for StructFieldMetaConsumer {
+    fn new(metas: Vec<Meta>) -> Self {
+        Self {
+            metas,
+            name: SetOnce::new("name"),
+            r#type: SetOnce::new("type"),
+            default_value: SetOnce::new("default_value"),
+            argument_default_value: SetOnce::new("default_value"),
+            default_value_strategy: SetOnce::new("default_value_strategy"),
+        }
+    }
+
+    fn metas(&self) -> &[Meta] {
+        &self.metas
+    }
+
+    fn metas_mut(&mut self) -> &mut Vec<Meta> {
+        &mut self.metas
+    }
+}
+
+impl StructFieldMetaConsumer {
+    pub fn consume_field(self) -> syn::Result<Self> {
+        self.consume_metas(|this, meta| match meta.path_str().as_str() {
+            "name" => {
+                this.name.set(String::from_meta(&meta)?.into(), meta)?;
+                Ok(None)
+            }
+            "type" => {
+                let node = TypeNode::from_meta(&meta.as_path_value()?.value)?;
+                this.r#type.set(node, meta)?;
+                Ok(None)
+            }
+            "default_value_omitted" => {
+                meta.as_path()?;
+                this.default_value_strategy
+                    .set(DefaultValueStrategy::Omitted, meta)?;
+                Ok(None)
+            }
+            _ => {
+                if let Ok(value) = String::from_meta(&meta) {
+                    this.name.set(value.into(), meta)?;
+                    return Ok(None);
+                }
+                if let Ok(node) = TypeNode::from_meta(&meta) {
+                    this.r#type.set(node, meta)?;
+                    return Ok(None);
+                }
+                Ok(Some(meta))
+            }
+        })
+    }
+
+    pub fn consume_default_value(self) -> syn::Result<Self> {
+        self.consume_metas(|this, meta| match meta.path_str().as_str() {
+            "default_value" => {
+                let node = ValueNode::from_meta(&meta.as_path_value()?.value)?;
+                this.default_value.set(node, meta)?;
+                Ok(None)
+            }
+            _ => Ok(Some(meta)),
+        })
+    }
+
+    #[allow(dead_code)]
+    pub fn consume_argument_default_value(self) -> syn::Result<Self> {
+        self.consume_metas(|this, meta| match meta.path_str().as_str() {
+            "default_value" => {
+                let node = InstructionInputValueNode::from_meta(&meta.as_path_value()?.value)?;
+                this.argument_default_value.set(node, meta)?;
+                Ok(None)
+            }
+            _ => Ok(Some(meta)),
+        })
+    }
+}

--- a/codama-attributes/src/utils/meta_consumer.rs
+++ b/codama-attributes/src/utils/meta_consumer.rs
@@ -1,0 +1,37 @@
+use crate::utils::FromMeta;
+use codama_syn_helpers::{extensions::ToTokensExtension, Meta};
+
+pub trait MetaConsumer: Sized {
+    fn new(metas: Vec<Meta>) -> Self;
+    fn metas(&self) -> &[Meta];
+    fn metas_mut(&mut self) -> &mut Vec<Meta>;
+
+    fn consume_metas(
+        mut self,
+        mut logic: impl FnMut(&mut Self, Meta) -> syn::Result<Option<Meta>>,
+    ) -> syn::Result<Self> {
+        let metas = std::mem::take(self.metas_mut());
+        let metas = metas.into_iter().try_fold(Vec::new(), |mut acc, meta| {
+            if let Some(meta) = logic(&mut self, meta)? {
+                acc.push(meta);
+            }
+            syn::Result::Ok(acc)
+        })?;
+
+        *self.metas_mut() = metas;
+        Ok(self)
+    }
+
+    fn assert_fully_consumed(self) -> syn::Result<Self> {
+        self.metas()
+            .iter()
+            .try_for_each(|meta| Err(meta.error("unrecognized attribute")))?;
+        Ok(self)
+    }
+}
+
+impl<T: MetaConsumer> FromMeta for T {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        Ok(Self::new(meta.as_path_list()?.parse_metas()?))
+    }
+}

--- a/codama-attributes/src/utils/mod.rs
+++ b/codama-attributes/src/utils/mod.rs
@@ -1,6 +1,8 @@
 mod from_meta;
 mod macros;
+mod meta_consumer;
 mod set_once;
 
 pub use from_meta::*;
+pub use meta_consumer::*;
 pub use set_once::*;


### PR DESCRIPTION
This PR adds a new `MetaConsumer` trait and a `StructFieldMetaConsumer` struct using that trait. This is to enable a builder-like pattern when gradually parsing a `Vec` of `Meta`s. As such, this PR also refactors the Meta parsing of the `StructFieldTypeNode` in preparation to the `field` and `argument` modifier directives.