### PR TITLE
Add argument directive

### DIFF
--- a/codama-attributes/src/codama_directives/argument_directive.rs
+++ b/codama-attributes/src/codama_directives/argument_directive.rs
@@ -1,0 +1,106 @@
+use crate::{
+    codama_directives::type_nodes::StructFieldMetaConsumer,
+    utils::{FromMeta, MetaConsumer},
+    Attribute, CodamaAttribute, CodamaDirective,
+};
+use codama_errors::CodamaError;
+use codama_nodes::{Docs, InstructionArgumentNode};
+use codama_syn_helpers::Meta;
+
+#[derive(Debug, PartialEq)]
+pub struct ArgumentDirective {
+    pub after: bool,
+    pub argument: InstructionArgumentNode,
+}
+
+impl ArgumentDirective {
+    pub fn parse(meta: &Meta) -> syn::Result<Self> {
+        meta.assert_directive("argument")?;
+        let consumer = StructFieldMetaConsumer::from_meta(meta)?
+            .consume_field()?
+            .consume_argument_default_value()?
+            .consume_after()?
+            .assert_fully_consumed()?;
+
+        Ok(ArgumentDirective {
+            after: consumer.after.option().unwrap_or(false),
+            argument: InstructionArgumentNode {
+                name: consumer.name.take(meta)?,
+                r#type: consumer.r#type.take(meta)?,
+                docs: Docs::default(),
+                default_value: consumer.argument_default_value.option(),
+                default_value_strategy: consumer.default_value_strategy.option(),
+            },
+        })
+    }
+}
+
+impl<'a> TryFrom<&'a CodamaAttribute<'a>> for &'a ArgumentDirective {
+    type Error = CodamaError;
+
+    fn try_from(attribute: &'a CodamaAttribute) -> Result<Self, Self::Error> {
+        match attribute.directive {
+            CodamaDirective::Argument(ref a) => Ok(a),
+            _ => Err(CodamaError::InvalidCodamaDirective {
+                expected: "argument".to_string(),
+                actual: attribute.directive.name().to_string(),
+            }),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a Attribute<'a>> for &'a ArgumentDirective {
+    type Error = CodamaError;
+
+    fn try_from(attribute: &'a Attribute) -> Result<Self, Self::Error> {
+        <&CodamaAttribute>::try_from(attribute)?.try_into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codama_nodes::{NumberFormat::U8, NumberTypeNode, PayerValueNode};
+
+    #[test]
+    fn ok() {
+        let meta: Meta = syn::parse_quote! { argument("age", number(u8)) };
+        let directive = ArgumentDirective::parse(&meta).unwrap();
+        assert_eq!(
+            directive,
+            ArgumentDirective {
+                after: false,
+                argument: InstructionArgumentNode::new("age", NumberTypeNode::le(U8)),
+            }
+        );
+    }
+
+    #[test]
+    fn after() {
+        let meta: Meta = syn::parse_quote! { argument(after, "age", number(u8)) };
+        let directive = ArgumentDirective::parse(&meta).unwrap();
+        assert_eq!(
+            directive,
+            ArgumentDirective {
+                after: true,
+                argument: InstructionArgumentNode::new("age", NumberTypeNode::le(U8)),
+            }
+        );
+    }
+
+    #[test]
+    fn with_default_value() {
+        let meta: Meta = syn::parse_quote! { argument("age", number(u8), default_value = payer) };
+        let directive = ArgumentDirective::parse(&meta).unwrap();
+        assert_eq!(
+            directive,
+            ArgumentDirective {
+                after: false,
+                argument: InstructionArgumentNode {
+                    default_value: Some(PayerValueNode::new().into()),
+                    ..InstructionArgumentNode::new("age", NumberTypeNode::le(U8))
+                },
+            }
+        );
+    }
+}

--- a/codama-attributes/src/codama_directives/codama_directive.rs
+++ b/codama-attributes/src/codama_directives/codama_directive.rs
@@ -1,7 +1,7 @@
 use crate::{
-    AccountDirective, AttributeContext, DefaultValueDirective, DiscriminatorDirective,
-    EncodingDirective, EnumDiscriminatorDirective, ErrorDirective, FieldDirective,
-    FixedSizeDirective, NameDirective, SizePrefixDirective, TypeDirective,
+    AccountDirective, ArgumentDirective, AttributeContext, DefaultValueDirective,
+    DiscriminatorDirective, EncodingDirective, EnumDiscriminatorDirective, ErrorDirective,
+    FieldDirective, FixedSizeDirective, NameDirective, SizePrefixDirective, TypeDirective,
 };
 use codama_syn_helpers::{extensions::*, Meta};
 use derive_more::derive::From;
@@ -23,6 +23,7 @@ pub enum CodamaDirective {
 
     // Instruction directives.
     Account(AccountDirective),
+    Argument(ArgumentDirective),
 
     // Error directives.
     Error(ErrorDirective),
@@ -47,6 +48,7 @@ impl CodamaDirective {
 
             // Instruction directives.
             "account" => Ok(AccountDirective::parse(meta, ctx)?.into()),
+            "argument" => Ok(ArgumentDirective::parse(meta)?.into()),
 
             // Error directives.
             "error" => Ok(ErrorDirective::parse(meta)?.into()),
@@ -72,6 +74,7 @@ impl CodamaDirective {
 
             // Instruction directives.
             Self::Account(_) => "account",
+            Self::Argument(_) => "argument",
 
             // Error directives.
             Self::Error(_) => "error",

--- a/codama-attributes/src/codama_directives/mod.rs
+++ b/codama-attributes/src/codama_directives/mod.rs
@@ -2,6 +2,7 @@ mod type_nodes;
 mod value_nodes;
 
 mod account_directive;
+mod argument_directive;
 mod codama_directive;
 mod default_value_directive;
 mod discriminator_directive;
@@ -15,6 +16,7 @@ mod size_prefix_directive;
 mod type_directive;
 
 pub use account_directive::*;
+pub use argument_directive::*;
 pub use codama_directive::*;
 pub use default_value_directive::*;
 pub use discriminator_directive::*;

--- a/codama-attributes/src/codama_directives/type_nodes/struct_field_meta_consumer.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/struct_field_meta_consumer.rs
@@ -9,7 +9,6 @@ pub(crate) struct StructFieldMetaConsumer {
     pub name: SetOnce<CamelCaseString>,
     pub r#type: SetOnce<TypeNode>,
     pub default_value: SetOnce<ValueNode>,
-    #[allow(dead_code)]
     pub argument_default_value: SetOnce<InstructionInputValueNode>,
     pub default_value_strategy: SetOnce<DefaultValueStrategy>,
     pub after: SetOnce<bool>,
@@ -80,7 +79,6 @@ impl StructFieldMetaConsumer {
         })
     }
 
-    #[allow(dead_code)]
     pub fn consume_argument_default_value(self) -> syn::Result<Self> {
         self.consume_metas(|this, meta| match meta.path_str().as_str() {
             "default_value" => {

--- a/codama-korok-visitors/tests/set_instructions_visitor/from_codama_instructions.rs
+++ b/codama-korok-visitors/tests/set_instructions_visitor/from_codama_instructions.rs
@@ -634,3 +634,123 @@ fn with_enum_discriminator_directive() -> CodamaResult<()> {
     );
     Ok(())
 }
+
+#[test]
+fn with_argument_attributes_only() -> CodamaResult<()> {
+    let item: syn::Item = syn::parse_quote! {
+        #[derive(CodamaInstructions)]
+        enum MyProgramInstructions {
+            #[codama(argument("space", number(u64)))]
+            #[codama(argument("lamports", number(u64)))]
+            Initialize,
+        }
+    };
+    let mut korok = EnumKorok::parse(&item)?;
+
+    assert_eq!(korok.node, None);
+    korok.accept(&mut SetInstructionsVisitor::new())?;
+    assert_eq!(
+        korok.node,
+        Some(
+            ProgramNode {
+                instructions: vec![InstructionNode {
+                    name: "initialize".into(),
+                    arguments: vec![
+                        InstructionArgumentNode {
+                            default_value: Some(NumberValueNode::new(0u64).into()),
+                            default_value_strategy: Some(DefaultValueStrategy::Omitted),
+                            ..InstructionArgumentNode::new("discriminator", NumberTypeNode::le(U8))
+                        },
+                        InstructionArgumentNode::new("space", NumberTypeNode::le(U64)),
+                        InstructionArgumentNode::new("lamports", NumberTypeNode::le(U64))
+                    ],
+                    discriminators: vec![FieldDiscriminatorNode::new("discriminator", 0).into()],
+                    ..InstructionNode::default()
+                }],
+                ..ProgramNode::default()
+            }
+            .into()
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn with_prepended_argument_attributes() -> CodamaResult<()> {
+    let item: syn::Item = syn::parse_quote! {
+        #[derive(CodamaInstructions)]
+        enum MyProgramInstructions {
+            #[codama(argument("space", number(u64)))]
+            Initialize { lamports: u64 },
+        }
+    };
+    let mut korok = EnumKorok::parse(&item)?;
+
+    assert_eq!(korok.node, None);
+    korok.accept(&mut SetBorshTypesVisitor::new())?;
+    korok.accept(&mut SetInstructionsVisitor::new())?;
+    assert_eq!(
+        korok.node,
+        Some(
+            ProgramNode {
+                instructions: vec![InstructionNode {
+                    name: "initialize".into(),
+                    arguments: vec![
+                        InstructionArgumentNode {
+                            default_value: Some(NumberValueNode::new(0u64).into()),
+                            default_value_strategy: Some(DefaultValueStrategy::Omitted),
+                            ..InstructionArgumentNode::new("discriminator", NumberTypeNode::le(U8))
+                        },
+                        InstructionArgumentNode::new("space", NumberTypeNode::le(U64)),
+                        InstructionArgumentNode::new("lamports", NumberTypeNode::le(U64))
+                    ],
+                    discriminators: vec![FieldDiscriminatorNode::new("discriminator", 0).into()],
+                    ..InstructionNode::default()
+                }],
+                ..ProgramNode::default()
+            }
+            .into()
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn with_appended_argument_attributes() -> CodamaResult<()> {
+    let item: syn::Item = syn::parse_quote! {
+        #[derive(CodamaInstructions)]
+        enum MyProgramInstructions {
+            #[codama(argument(after, "space", number(u64)))]
+            Initialize { lamports: u64 },
+        }
+    };
+    let mut korok = EnumKorok::parse(&item)?;
+
+    assert_eq!(korok.node, None);
+    korok.accept(&mut SetBorshTypesVisitor::new())?;
+    korok.accept(&mut SetInstructionsVisitor::new())?;
+    assert_eq!(
+        korok.node,
+        Some(
+            ProgramNode {
+                instructions: vec![InstructionNode {
+                    name: "initialize".into(),
+                    arguments: vec![
+                        InstructionArgumentNode {
+                            default_value: Some(NumberValueNode::new(0u64).into()),
+                            default_value_strategy: Some(DefaultValueStrategy::Omitted),
+                            ..InstructionArgumentNode::new("discriminator", NumberTypeNode::le(U8))
+                        },
+                        InstructionArgumentNode::new("lamports", NumberTypeNode::le(U64)),
+                        InstructionArgumentNode::new("space", NumberTypeNode::le(U64)),
+                    ],
+                    discriminators: vec![FieldDiscriminatorNode::new("discriminator", 0).into()],
+                    ..InstructionNode::default()
+                }],
+                ..ProgramNode::default()
+            }
+            .into()
+        )
+    );
+    Ok(())
+}

--- a/codama-macros/tests/codama_attribute/argument_directive/_pass.rs
+++ b/codama-macros/tests/codama_attribute/argument_directive/_pass.rs
@@ -1,0 +1,8 @@
+use codama_macros::codama;
+
+#[codama(argument("age", number(u8), default_value = 42))]
+#[codama(argument(after, "name", string(utf8)))]
+#[codama(argument(after, "wallet", public_key, default_value = payer))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/argument_directive/invalid_argument.fail.rs
+++ b/codama-macros/tests/codama_attribute/argument_directive/invalid_argument.fail.rs
@@ -1,0 +1,12 @@
+use codama_macros::codama;
+
+#[codama(argument())]
+pub struct EmptyTest;
+
+#[codama(argument(number(u8)))]
+pub struct NameMissingTest;
+
+#[codama(argument("age"))]
+pub struct TypeMissingTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/argument_directive/invalid_argument.fail.stderr
+++ b/codama-macros/tests/codama_attribute/argument_directive/invalid_argument.fail.stderr
@@ -1,0 +1,17 @@
+error: name is missing
+ --> tests/codama_attribute/argument_directive/invalid_argument.fail.rs:3:10
+  |
+3 | #[codama(argument())]
+  |          ^^^^^^^^^^
+
+error: name is missing
+ --> tests/codama_attribute/argument_directive/invalid_argument.fail.rs:6:10
+  |
+6 | #[codama(argument(number(u8)))]
+  |          ^^^^^^^^^^^^^^^^^^^^
+
+error: type is missing
+ --> tests/codama_attribute/argument_directive/invalid_argument.fail.rs:9:10
+  |
+9 | #[codama(argument("age"))]
+  |          ^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR adds the `argument` directive which can be used to add additional arguments to instruction nodes via macros. This works similarly to the `field` directive (introduced in #46).

Here are some examples.

### Prepending arguments to struct instructions

```rs
#[derive(CodamaInstruction)]
#[codama(argument("discriminator", number(u8), default_value = 0, default_value_omitted))]
struct Initialize {
  space: u64,
}
```

### Appending arguments to struct instructions

```rs
#[derive(CodamaInstruction)]
#[codama(argument(after, "lamports", number(u64)))]
struct Initialize {
  space: u64,
}
```

### Adding arguments to empty struct instructions

```rs
#[derive(CodamaInstruction)]
#[codama(argument("discriminator", number(u8), default_value = 0, default_value_omitted))]
#[codama(argument("space", number(u64)))]
struct Initialize;
```

### Adding arguments to enum variant instructions

```rs
#[derive(CodamaInstructions)]
enum MyProgramInstructions {
  #[codama(argument(after, "lamports", number(u64)))]
  Initialize {
    space: u64,
  },
  #[codama(argument("amount", number(u64)))]
  Transfer,
}
```