### PR TITLE
Expose `get_type_node` method

### DIFF
--- a/codama-korok-visitors/src/identify_field_types_visitor.rs
+++ b/codama-korok-visitors/src/identify_field_types_visitor.rs
@@ -28,7 +28,7 @@ impl KorokVisitor for IdentifyFieldTypesVisitor {
     }
 }
 
-fn get_type_node(ty: &syn::Type) -> Option<TypeNode> {
+pub fn get_type_node(ty: &syn::Type) -> Option<TypeNode> {
     match ty {
         syn::Type::Path(syn::TypePath { path, .. }) => {
             if path.leading_colon.is_some() {


### PR DESCRIPTION
This change makes the method public so it can be used by other visitors or when working directly with raw `syn::Type`.