### PR TITLE
Add seed directive

### DIFF
--- a/codama-attributes/src/codama_directives/codama_directive.rs
+++ b/codama-attributes/src/codama_directives/codama_directive.rs
@@ -1,7 +1,8 @@
 use crate::{
     AccountDirective, ArgumentDirective, AttributeContext, DefaultValueDirective,
     DiscriminatorDirective, EncodingDirective, EnumDiscriminatorDirective, ErrorDirective,
-    FieldDirective, FixedSizeDirective, NameDirective, SizePrefixDirective, TypeDirective,
+    FieldDirective, FixedSizeDirective, NameDirective, SeedDirective, SizePrefixDirective,
+    TypeDirective,
 };
 use codama_syn_helpers::{extensions::*, Meta};
 use derive_more::derive::From;
@@ -20,6 +21,7 @@ pub enum CodamaDirective {
     Discriminator(DiscriminatorDirective),
     EnumDiscriminator(EnumDiscriminatorDirective),
     Name(NameDirective),
+    Seed(SeedDirective),
 
     // Instruction directives.
     Account(AccountDirective),
@@ -45,6 +47,7 @@ impl CodamaDirective {
             "discriminator" => Ok(DiscriminatorDirective::parse(meta)?.into()),
             "enum_discriminator" => Ok(EnumDiscriminatorDirective::parse(meta)?.into()),
             "name" => Ok(NameDirective::parse(meta)?.into()),
+            "seed" => Ok(SeedDirective::parse(meta, ctx)?.into()),
 
             // Instruction directives.
             "account" => Ok(AccountDirective::parse(meta, ctx)?.into()),
@@ -71,6 +74,7 @@ impl CodamaDirective {
             Self::Discriminator(_) => "discriminator",
             Self::EnumDiscriminator(_) => "enum_discriminator",
             Self::Name(_) => "name",
+            Self::Seed(_) => "seed",
 
             // Instruction directives.
             Self::Account(_) => "account",

--- a/codama-attributes/src/codama_directives/mod.rs
+++ b/codama-attributes/src/codama_directives/mod.rs
@@ -12,6 +12,7 @@ mod error_directive;
 mod field_directive;
 mod fixed_size_directive;
 mod name_directive;
+mod seed_directive;
 mod size_prefix_directive;
 mod type_directive;
 
@@ -26,5 +27,6 @@ pub use error_directive::*;
 pub use field_directive::*;
 pub use fixed_size_directive::*;
 pub use name_directive::*;
+pub use seed_directive::*;
 pub use size_prefix_directive::*;
 pub use type_directive::*;

--- a/codama-attributes/src/codama_directives/seed_directive.rs
+++ b/codama-attributes/src/codama_directives/seed_directive.rs
@@ -1,0 +1,197 @@
+use crate::{
+    utils::{FromMeta, SetOnce},
+    Attribute, AttributeContext, CodamaAttribute, CodamaDirective,
+};
+use codama_errors::CodamaError;
+use codama_nodes::{ConstantPdaSeedNode, PdaSeedNode, TypeNode, ValueNode, VariablePdaSeedNode};
+use codama_syn_helpers::{extensions::ToTokensExtension, Meta};
+
+#[derive(Debug, PartialEq)]
+pub struct SeedDirective {
+    pub seed: SeedDirectiveType,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum SeedDirectiveType {
+    Linked(String),
+    Defined(PdaSeedNode),
+}
+
+impl SeedDirective {
+    pub fn parse(meta: &Meta, ctx: &AttributeContext) -> syn::Result<Self> {
+        let pl = meta.assert_directive("seed")?.as_path_list()?;
+
+        let constant_seed = pl
+            .parse_metas()?
+            .iter()
+            .find_map(|m| match m.path_str().as_str() {
+                "name" => Some(false),
+                "value" => Some(true),
+                _ => None,
+            })
+            .ok_or_else(|| meta.error("seed must at least specify `name` for variable seeds or `type` and `value` for constant seeds"))?;
+
+        let mut name = SetOnce::<String>::new("name");
+        let mut r#type = SetOnce::<TypeNode>::new("type");
+        let mut value = SetOnce::<ValueNode>::new("value");
+
+        pl.each(|ref meta| match (meta.path_str().as_str(), constant_seed) {
+            ("name", true) => Err(meta.error("constant seeds cannot specify name")),
+            ("name", false) => name.set(String::from_meta(meta)?, meta),
+            ("value", true) => value.set(ValueNode::from_meta(&meta.as_path_value()?.value)?, meta),
+            ("value", false) => Err(meta.error("variable seeds cannot specify value")),
+            ("type", _) => r#type.set(TypeNode::from_meta(&meta.as_path_value()?.value)?, meta),
+            _ => Err(meta.error("unrecognized attribute")),
+        })?;
+
+        // Resolve linked seed if possible.
+        if !constant_seed && !r#type.is_set() {
+            let name = name.take(meta)?;
+            if let AttributeContext::Item(syn::Item::Struct(syn::ItemStruct {
+                fields: syn::Fields::Named(fields),
+                ..
+            })) = ctx
+            {
+                let has_matching_field = fields
+                    .named
+                    .iter()
+                    .any(|f| f.ident.as_ref().is_some_and(|id| id == &name));
+                if has_matching_field {
+                    return Ok(Self {
+                        seed: SeedDirectiveType::Linked(name),
+                    });
+                }
+            };
+            let message = format!("Could not find field \"{name}\". Either specify a `type` for the seed or use a name that matches a struct field.");
+            return Err(meta.error(message));
+        }
+
+        match constant_seed {
+            true => Ok(Self {
+                seed: SeedDirectiveType::Defined(
+                    ConstantPdaSeedNode::new(r#type.take(meta)?, value.take(meta)?).into(),
+                ),
+            }),
+            false => Ok(Self {
+                seed: SeedDirectiveType::Defined(
+                    VariablePdaSeedNode::new(name.take(meta)?, r#type.take(meta)?).into(),
+                ),
+            }),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a CodamaAttribute<'a>> for &'a SeedDirective {
+    type Error = CodamaError;
+
+    fn try_from(attribute: &'a CodamaAttribute) -> Result<Self, Self::Error> {
+        match attribute.directive {
+            CodamaDirective::Seed(ref a) => Ok(a),
+            _ => Err(CodamaError::InvalidCodamaDirective {
+                expected: "seed".to_string(),
+                actual: attribute.directive.name().to_string(),
+            }),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a Attribute<'a>> for &'a SeedDirective {
+    type Error = CodamaError;
+
+    fn try_from(attribute: &'a Attribute) -> Result<Self, Self::Error> {
+        <&CodamaAttribute>::try_from(attribute)?.try_into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use codama_nodes::{NumberFormat::U8, NumberTypeNode, NumberValueNode, PublicKeyTypeNode};
+
+    use super::*;
+
+    #[test]
+    fn defined_constant() {
+        let meta: Meta = syn::parse_quote! { seed(type = number(u8), value = 42) };
+        let item = syn::parse_quote! { struct Foo; };
+        let ctx = AttributeContext::Item(&item);
+        let directive = SeedDirective::parse(&meta, &ctx).unwrap();
+        assert_eq!(
+            directive,
+            SeedDirective {
+                seed: SeedDirectiveType::Defined(
+                    ConstantPdaSeedNode::new(NumberTypeNode::le(U8), NumberValueNode::new(42u8))
+                        .into()
+                ),
+            }
+        );
+    }
+
+    #[test]
+    fn defined_variable() {
+        let meta: Meta = syn::parse_quote! { seed(name = "authority", type = public_key) };
+        let item = syn::parse_quote! { struct Foo; };
+        let ctx = AttributeContext::Item(&item);
+        let directive = SeedDirective::parse(&meta, &ctx).unwrap();
+        assert_eq!(
+            directive,
+            SeedDirective {
+                seed: SeedDirectiveType::Defined(
+                    VariablePdaSeedNode::new("authority", PublicKeyTypeNode::new()).into()
+                ),
+            }
+        );
+    }
+
+    #[test]
+    fn linked_seed() {
+        let meta: Meta = syn::parse_quote! { seed(name = "authority") };
+        let item = syn::parse_quote! { struct Foo { authority: PubKey } };
+        let ctx = AttributeContext::Item(&item);
+        let directive = SeedDirective::parse(&meta, &ctx).unwrap();
+        assert_eq!(
+            directive,
+            SeedDirective {
+                seed: SeedDirectiveType::Linked("authority".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn cannot_identify_seed_type() {
+        let meta: Meta = syn::parse_quote! { seed(type = public_key) };
+        let item = syn::parse_quote! { struct Foo; };
+        let ctx = AttributeContext::Item(&item);
+        let error = SeedDirective::parse(&meta, &ctx).unwrap_err();
+        assert_eq!(error.to_string(), "seed must at least specify `name` for variable seeds or `type` and `value` for constant seeds");
+    }
+
+    #[test]
+    fn cannot_find_linked_field() {
+        let meta: Meta = syn::parse_quote! { seed(name = "authority") };
+        let item = syn::parse_quote! { struct Foo { owner: PubKey } };
+        let ctx = AttributeContext::Item(&item);
+        let error = SeedDirective::parse(&meta, &ctx).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "Could not find field \"authority\". Either specify a `type` for the seed or use a name that matches a struct field."
+        );
+    }
+
+    #[test]
+    fn value_with_name() {
+        let meta: Meta = syn::parse_quote! { seed(name = "amount", value = 42) };
+        let item = syn::parse_quote! { struct Foo; };
+        let ctx = AttributeContext::Item(&item);
+        let error = SeedDirective::parse(&meta, &ctx).unwrap_err();
+        assert_eq!(error.to_string(), "variable seeds cannot specify value");
+    }
+
+    #[test]
+    fn name_with_value() {
+        let meta: Meta = syn::parse_quote! { seed(value = 42, name = "amount") };
+        let item = syn::parse_quote! { struct Foo; };
+        let ctx = AttributeContext::Item(&item);
+        let error = SeedDirective::parse(&meta, &ctx).unwrap_err();
+        assert_eq!(error.to_string(), "constant seeds cannot specify name");
+    }
+}

--- a/codama-attributes/src/utils/set_once.rs
+++ b/codama-attributes/src/utils/set_once.rs
@@ -16,6 +16,10 @@ impl<T> SetOnce<T> {
         }
     }
 
+    pub fn is_set(&self) -> bool {
+        self.is_set
+    }
+
     pub fn initial_value(mut self, value: T) -> Self {
         self.value = Some(value);
         self

--- a/codama-macros/tests/codama_attribute/seed_directive/_pass.rs
+++ b/codama-macros/tests/codama_attribute/seed_directive/_pass.rs
@@ -1,0 +1,14 @@
+use codama_macros::codama;
+
+#[codama(seed(name = "authority", type = public_key))]
+pub struct TestWithDefinedVariableSeed;
+
+#[codama(seed(type = string(utf8), value = "counter"))]
+pub struct TestWithDefinedConstantSeed;
+
+#[codama(seed(name = "authority"))]
+pub struct TestWithLinkedSeed {
+    authority: String,
+}
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/seed_directive/invalid_constant_seed.fail.rs
+++ b/codama-macros/tests/codama_attribute/seed_directive/invalid_constant_seed.fail.rs
@@ -1,0 +1,12 @@
+use codama_macros::codama;
+
+#[codama(seed(type = number(u8), value = 42, name = "amount"))]
+pub struct TestWithName;
+
+#[codama(seed(type = invalid_type, value = 42))]
+pub struct TestWithInvalidType;
+
+#[codama(seed(type = number(u8), value = invalid_value))]
+pub struct TestWithInvalidValue;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/seed_directive/invalid_constant_seed.fail.stderr
+++ b/codama-macros/tests/codama_attribute/seed_directive/invalid_constant_seed.fail.stderr
@@ -1,0 +1,17 @@
+error: constant seeds cannot specify name
+ --> tests/codama_attribute/seed_directive/invalid_constant_seed.fail.rs:3:46
+  |
+3 | #[codama(seed(type = number(u8), value = 42, name = "amount"))]
+  |                                              ^^^^^^^^^^^^^^^
+
+error: unrecognized type
+ --> tests/codama_attribute/seed_directive/invalid_constant_seed.fail.rs:6:22
+  |
+6 | #[codama(seed(type = invalid_type, value = 42))]
+  |                      ^^^^^^^^^^^^
+
+error: unrecognized value
+ --> tests/codama_attribute/seed_directive/invalid_constant_seed.fail.rs:9:42
+  |
+9 | #[codama(seed(type = number(u8), value = invalid_value))]
+  |                                          ^^^^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/seed_directive/invalid_linked_seed.fail.rs
+++ b/codama-macros/tests/codama_attribute/seed_directive/invalid_linked_seed.fail.rs
@@ -1,0 +1,12 @@
+use codama_macros::codama;
+
+#[codama(seed(name = "missing_field"))]
+pub struct TestWithNoFields;
+
+#[codama(seed(name = "missing_field"))]
+pub struct TestWithFields {
+    field1: u8,
+    field2: u32,
+}
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/seed_directive/invalid_linked_seed.fail.stderr
+++ b/codama-macros/tests/codama_attribute/seed_directive/invalid_linked_seed.fail.stderr
@@ -1,0 +1,11 @@
+error: Could not find field "missing_field". Either specify a `type` for the seed or use a name that matches a struct field.
+ --> tests/codama_attribute/seed_directive/invalid_linked_seed.fail.rs:3:10
+  |
+3 | #[codama(seed(name = "missing_field"))]
+  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: Could not find field "missing_field". Either specify a `type` for the seed or use a name that matches a struct field.
+ --> tests/codama_attribute/seed_directive/invalid_linked_seed.fail.rs:6:10
+  |
+6 | #[codama(seed(name = "missing_field"))]
+  |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/seed_directive/invalid_variable_seed.fail.rs
+++ b/codama-macros/tests/codama_attribute/seed_directive/invalid_variable_seed.fail.rs
@@ -1,0 +1,12 @@
+use codama_macros::codama;
+
+#[codama(seed(name = "amount", value = 42))]
+pub struct TestWithValue;
+
+#[codama(seed(name = 42, type = number(u8)))]
+pub struct TestWithInvalidName;
+
+#[codama(seed(name = "authority", type = invalid_type))]
+pub struct TestWithInvalidType;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/seed_directive/invalid_variable_seed.fail.stderr
+++ b/codama-macros/tests/codama_attribute/seed_directive/invalid_variable_seed.fail.stderr
@@ -1,0 +1,17 @@
+error: variable seeds cannot specify value
+ --> tests/codama_attribute/seed_directive/invalid_variable_seed.fail.rs:3:32
+  |
+3 | #[codama(seed(name = "amount", value = 42))]
+  |                                ^^^^^^^^^^
+
+error: expected a string
+ --> tests/codama_attribute/seed_directive/invalid_variable_seed.fail.rs:6:22
+  |
+6 | #[codama(seed(name = 42, type = number(u8)))]
+  |                      ^^
+
+error: unrecognized type
+ --> tests/codama_attribute/seed_directive/invalid_variable_seed.fail.rs:9:42
+  |
+9 | #[codama(seed(name = "authority", type = invalid_type))]
+  |                                          ^^^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/seed_directive/unrecognized_seed.fail.rs
+++ b/codama-macros/tests/codama_attribute/seed_directive/unrecognized_seed.fail.rs
@@ -1,0 +1,12 @@
+use codama_macros::codama;
+
+#[codama(seed)]
+pub struct EmptyTest;
+
+#[codama(seed())]
+pub struct EmptyTestWithBraces;
+
+#[codama(seed(type = number(u8)))]
+pub struct TestWithTypeOnly;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/seed_directive/unrecognized_seed.fail.stderr
+++ b/codama-macros/tests/codama_attribute/seed_directive/unrecognized_seed.fail.stderr
@@ -1,0 +1,17 @@
+error: expected a list: `seed(...)` or `seed = (...)`
+ --> tests/codama_attribute/seed_directive/unrecognized_seed.fail.rs:3:10
+  |
+3 | #[codama(seed)]
+  |          ^^^^
+
+error: seed must at least specify `name` for variable seeds or `type` and `value` for constant seeds
+ --> tests/codama_attribute/seed_directive/unrecognized_seed.fail.rs:6:10
+  |
+6 | #[codama(seed())]
+  |          ^^^^^^
+
+error: seed must at least specify `name` for variable seeds or `type` and `value` for constant seeds
+ --> tests/codama_attribute/seed_directive/unrecognized_seed.fail.rs:9:10
+  |
+9 | #[codama(seed(type = number(u8)))]
+  |          ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR adds a new `seed` directive that can be used to define constant or variable PDA seeds. It also allows the user to "link" the seed to an existing field in order to avoid repeating its type. Here is an example showcasing all three use-cases:

```rs
#[codama(seed(type = string(utf8), value = "counter_pda"))]
#[codama(seed(name = "authority", type = public_key))]
#[codama(seed(name = "value"))]
pub struct Counter {
  pub value: u32,
}
```

This new directive will be used in subsequent PRs when defining accounts and PDAs.