### PR TITLE
Identify PDAs in SetAccountsVisitor

### DIFF
--- a/codama-attributes/src/attribute_context.rs
+++ b/codama-attributes/src/attribute_context.rs
@@ -8,3 +8,22 @@ pub enum AttributeContext<'a> {
     Field(&'a syn::Field),
     ImplItem(&'a syn::ImplItem),
 }
+
+impl<'a> AttributeContext<'a> {
+    pub fn get_fields(&self) -> Option<&'a syn::Fields> {
+        match self {
+            AttributeContext::Item(syn::Item::Struct(syn::ItemStruct { fields, .. })) => {
+                Some(fields)
+            }
+            AttributeContext::Variant(syn::Variant { fields, .. }) => Some(fields),
+            _ => None,
+        }
+    }
+
+    pub fn get_named_fields(&self) -> Option<&'a syn::FieldsNamed> {
+        match self.get_fields() {
+            Some(syn::Fields::Named(fields)) => Some(fields),
+            _ => None,
+        }
+    }
+}

--- a/codama-korok-visitors/src/set_pdas_visitor.rs
+++ b/codama-korok-visitors/src/set_pdas_visitor.rs
@@ -3,7 +3,8 @@ use codama_attributes::{Attributes, SeedDirective, SeedDirectiveType, TryFromFil
 use codama_errors::CodamaResult;
 use codama_koroks::FieldKorok;
 use codama_nodes::{
-    Docs, Node, PdaNode, PdaSeedNode, RegisteredTypeNode, TypeNode, VariablePdaSeedNode,
+    CamelCaseString, Docs, Node, PdaNode, PdaSeedNode, RegisteredTypeNode, TypeNode,
+    VariablePdaSeedNode,
 };
 
 #[derive(Default)]
@@ -22,15 +23,7 @@ impl KorokVisitor for SetPdasVisitor {
             return Ok(());
         };
 
-        korok.node = Some(
-            PdaNode {
-                name: korok.name(),
-                seeds: get_pda_seed_nodes(&korok.attributes, &korok.fields),
-                docs: Docs::default(),
-                program_id: None,
-            }
-            .into(),
-        );
+        korok.node = Some(parse_pda_node(korok.name(), &korok.attributes, &korok.fields).into());
         Ok(())
     }
 
@@ -40,20 +33,25 @@ impl KorokVisitor for SetPdasVisitor {
             return Ok(());
         };
 
-        korok.node = Some(
-            PdaNode {
-                name: korok.name(),
-                seeds: get_pda_seed_nodes(&korok.attributes, &[]),
-                docs: Docs::default(),
-                program_id: None,
-            }
-            .into(),
-        );
+        korok.node = Some(parse_pda_node(korok.name(), &korok.attributes, &[]).into());
         Ok(())
     }
 }
 
-fn get_pda_seed_nodes(attributes: &Attributes, fields: &[FieldKorok]) -> Vec<PdaSeedNode> {
+pub fn parse_pda_node(
+    name: CamelCaseString,
+    attributes: &Attributes,
+    fields: &[FieldKorok],
+) -> PdaNode {
+    PdaNode {
+        name,
+        seeds: parse_pda_seed_nodes(attributes, fields),
+        docs: Docs::default(),
+        program_id: None,
+    }
+}
+
+pub fn parse_pda_seed_nodes(attributes: &Attributes, fields: &[FieldKorok]) -> Vec<PdaSeedNode> {
     attributes
         .iter()
         .filter_map(SeedDirective::filter)

--- a/codama-korok-visitors/tests/set_accounts_visitor/from_codama_accounts.rs
+++ b/codama-korok-visitors/tests/set_accounts_visitor/from_codama_accounts.rs
@@ -2,11 +2,12 @@ use codama_errors::CodamaResult;
 use codama_korok_visitors::{IdentifyFieldTypesVisitor, KorokVisitable, SetAccountsVisitor};
 use codama_koroks::{EnumKorok, StructKorok};
 use codama_nodes::{
-    AccountNode, BooleanTypeNode, BytesEncoding, ConstantDiscriminatorNode, ConstantValueNode,
-    DefaultValueStrategy, Docs, FieldDiscriminatorNode,
+    AccountNode, BooleanTypeNode, BytesEncoding, ConstantDiscriminatorNode, ConstantPdaSeedNode,
+    ConstantValueNode, DefaultValueStrategy, Docs, FieldDiscriminatorNode,
     NumberFormat::{U32, U64, U8},
-    NumberTypeNode, NumberValueNode, OptionTypeNode, ProgramNode, PublicKeyTypeNode,
-    SizeDiscriminatorNode, StructFieldTypeNode, StructTypeNode,
+    NumberTypeNode, NumberValueNode, OptionTypeNode, PdaLinkNode, PdaNode, ProgramNode,
+    PublicKeyTypeNode, SizeDiscriminatorNode, StringTypeNode, StringValueNode, StructFieldTypeNode,
+    StructTypeNode, VariablePdaSeedNode,
 };
 
 #[test]
@@ -450,6 +451,91 @@ fn with_enum_discriminator_directive() -> CodamaResult<()> {
                     pda: None,
                     discriminators: vec![FieldDiscriminatorNode::new("banana", 0).into()],
                 }],
+                ..ProgramNode::default()
+            }
+            .into()
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn with_seed_directives() -> CodamaResult<()> {
+    let item: syn::Item = syn::parse_quote! {
+        #[derive(CodamaAccounts)]
+        enum MyProgramAccounts {
+            #[codama(seed(type = string(utf8), value = "counter_pda"))]
+            #[codama(seed(name = "authority"))]
+            Counter {
+                authority: Pubkey,
+            },
+            #[codama(seed(name = "owner", type = public_key))]
+            #[codama(seed(name = "mint", type = public_key))]
+            Token,
+        }
+    };
+    let mut korok = EnumKorok::parse(&item)?;
+
+    assert_eq!(korok.node, None);
+    korok.accept(&mut IdentifyFieldTypesVisitor::new())?;
+    korok.accept(&mut SetAccountsVisitor::new())?;
+    assert_eq!(
+        korok.node,
+        Some(
+            ProgramNode {
+                accounts: vec![
+                    AccountNode {
+                        pda: Some(PdaLinkNode::new("counter")),
+                        discriminators: vec![FieldDiscriminatorNode::new("discriminator", 0).into()],
+                        ..AccountNode::new(
+                            "counter",
+                            StructTypeNode::new(vec![
+                                StructFieldTypeNode {
+                                    name: "discriminator".into(),
+                                    default_value_strategy: Some(DefaultValueStrategy::Omitted),
+                                    docs: Docs::default(),
+                                    r#type: NumberTypeNode::le(U8).into(),
+                                    default_value: Some(NumberValueNode::new(0u8).into()),
+                                },
+                                StructFieldTypeNode::new("authority", PublicKeyTypeNode::new()),
+                            ])
+                        )
+                    },
+                    AccountNode {
+                        pda: Some(PdaLinkNode::new("token")),
+                        discriminators: vec![FieldDiscriminatorNode::new("discriminator", 0).into()],
+                        ..AccountNode::new(
+                            "token",
+                            StructTypeNode::new(vec![StructFieldTypeNode {
+                                name: "discriminator".into(),
+                                default_value_strategy: Some(DefaultValueStrategy::Omitted),
+                                docs: Docs::default(),
+                                r#type: NumberTypeNode::le(U8).into(),
+                                default_value: Some(NumberValueNode::new(1u8).into()),
+                            },])
+                        )
+                    }
+                ],
+                pdas: vec![
+                    PdaNode::new(
+                        "counter",
+                        vec![
+                            ConstantPdaSeedNode::new(
+                                StringTypeNode::utf8(),
+                                StringValueNode::new("counter_pda")
+                            )
+                            .into(),
+                            VariablePdaSeedNode::new("authority", PublicKeyTypeNode::new()).into(),
+                        ]
+                    ),
+                    PdaNode::new(
+                        "token",
+                        vec![
+                            VariablePdaSeedNode::new("owner", PublicKeyTypeNode::new()).into(),
+                            VariablePdaSeedNode::new("mint", PublicKeyTypeNode::new()).into(),
+                        ]
+                    )
+                ],
                 ..ProgramNode::default()
             }
             .into()

--- a/codama-macros/tests/codama_attribute/seed_directive/invalid_linked_seed.fail.stderr
+++ b/codama-macros/tests/codama_attribute/seed_directive/invalid_linked_seed.fail.stderr
@@ -1,10 +1,10 @@
-error: Could not find field "missing_field". Either specify a `type` for the seed or use a name that matches a struct field.
+error: Could not find field "missing_field". Either specify a `type` for the seed or use a name that matches a struct or variant field.
  --> tests/codama_attribute/seed_directive/invalid_linked_seed.fail.rs:3:10
   |
 3 | #[codama(seed(name = "missing_field"))]
   |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: Could not find field "missing_field". Either specify a `type` for the seed or use a name that matches a struct field.
+error: Could not find field "missing_field". Either specify a `type` for the seed or use a name that matches a struct or variant field.
  --> tests/codama_attribute/seed_directive/invalid_linked_seed.fail.rs:6:10
   |
 6 | #[codama(seed(name = "missing_field"))]

--- a/codama/tests/membership/crate/src/person.rs
+++ b/codama/tests/membership/crate/src/person.rs
@@ -1,6 +1,9 @@
 use super::Membership;
 
 #[derive(CodamaAccount)]
+#[codama(seed(type = string(utf8), value = "person_pda"))]
+#[codama(seed(name = "wallet", type = public_key))]
+#[codama(seed(name = "name", type = string(utf8)))]
 pub struct Person {
     pub name: String,
     pub age: u8,
@@ -8,9 +11,3 @@ pub struct Person {
     #[codama(type = public_key)]
     pub wallet: [u8; 32],
 }
-
-#[derive(CodamaPda)]
-#[codama(seed(type = string(utf8), value = "person_pda"))]
-#[codama(seed(name = "authority", type = public_key))]
-#[codama(seed(name = "name", type = string(utf8)))]
-pub struct PersonPda;

--- a/codama/tests/membership/mod.rs
+++ b/codama/tests/membership/mod.rs
@@ -65,6 +65,10 @@ fn get_idl() {
               }
             }
           ]
+        },
+        "pda": {
+          "kind": "pdaLinkNode",
+          "name": "person"
         }
       }
     ],
@@ -100,7 +104,7 @@ fn get_idl() {
     "pdas": [
       {
         "kind": "pdaNode",
-        "name": "personPda",
+        "name": "person",
         "seeds": [
           {
             "kind": "constantPdaSeedNode",
@@ -115,7 +119,7 @@ fn get_idl() {
           },
           {
             "kind": "variablePdaSeedNode",
-            "name": "authority",
+            "name": "wallet",
             "type": {
               "kind": "publicKeyTypeNode"
             }


### PR DESCRIPTION
This PR updates the `SetAccountsVisitor` to process `seed` directives in order to add and link `PdaNodes` to the created `AccountNodes`. The PR also makes it possible for accounts defined in an enum via the `CodamaAccounts` derive to each define their own PDA.

Here are some examples.

### In a `CodamaAccount` struct.

```rs
#[derive(CodamaAccount)]
#[codama(seed(type = string(utf8), value = "counter_pda"))]
#[codama(seed(name = "authority"))]
#[codama(seed(name = "identifier", type = number(u8)))]
struct Counter {
    authority: Pubkey,
}
```

### In a `CodamaAccounts` enum.

```rs
#[derive(CodamaAccounts)]
enum MyProgramAccounts {
    #[codama(seed(type = string(utf8), value = "counter_pda"))]
    #[codama(seed(name = "authority"))]
    Counter {
        authority: Pubkey,
    },

    #[codama(seed(name = "owner", type = public_key))]
    #[codama(seed(name = "mint", type = public_key))]
    Token,
}
```