### PR TITLE
Add account value directive

### DIFF
--- a/codama-attributes/src/codama_directives/value_nodes/account_value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/account_value_node.rs
@@ -1,0 +1,52 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::AccountValueNode;
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for AccountValueNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("account")?.as_path_list()?;
+        let mut name = SetOnce::<String>::new("name");
+        pl.each(|ref meta| match meta {
+            Meta::PathValue(pv) => {
+                if !pv.path.is_strict("name") {
+                    return Err(pv.path.error("only 'name' attribute supported"));
+                };
+                name.set(String::from_meta(meta)?, meta)
+            }
+            _ => name.set(String::from_meta(meta)?, meta),
+        })?;
+
+        Ok(AccountValueNode::new(name.take(meta)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_value, assert_value_err};
+
+    #[test]
+    fn ok() {
+        assert_value!(
+            { account("authority") },
+            AccountValueNode::new("authority").into()
+        );
+        assert_value!(
+            { account(name = "authority") },
+            AccountValueNode::new("authority").into()
+        );
+    }
+
+    #[test]
+    fn wrong_name_attribute() {
+        assert_value_err!(
+            { account(banana = "authority") },
+            "only 'name' attribute supported"
+        );
+    }
+
+    #[test]
+    fn missing_name() {
+        assert_value_err!({ account() }, "name is missing");
+    }
+}

--- a/codama-attributes/src/codama_directives/value_nodes/instruction_input_value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/instruction_input_value_node.rs
@@ -1,10 +1,11 @@
 use crate::utils::FromMeta;
-use codama_nodes::{InstructionInputValueNode, PayerValueNode, ValueNode};
+use codama_nodes::{AccountValueNode, InstructionInputValueNode, PayerValueNode, ValueNode};
 use codama_syn_helpers::Meta;
 
 impl FromMeta for InstructionInputValueNode {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
         match meta.path_str().as_str() {
+            "account" => AccountValueNode::from_meta(meta).map(Self::from),
             "payer" => PayerValueNode::from_meta(meta).map(Self::from),
             _ => ValueNode::from_meta(meta).map(Self::from),
         }

--- a/codama-attributes/src/codama_directives/value_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/mod.rs
@@ -1,3 +1,4 @@
+mod account_value_node;
 mod boolean_value_node;
 mod instruction_input_value_node;
 mod number_value_node;

--- a/codama-macros/tests/codama_attribute/values_nodes/account_value_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/account_value_node/_pass.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(default_value = account(name = "authority"))]
+pub struct TestExplicit;
+
+#[codama(default_value = account("authority"))]
+pub struct TestImplicit;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/account_value_node/invalid_name.fail.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/account_value_node/invalid_name.fail.rs
@@ -1,0 +1,12 @@
+use codama_macros::codama;
+
+#[codama(default_value = account(42))]
+pub struct TestWithInteger;
+
+#[codama(default_value = account(banana))]
+pub struct TestWithPath;
+
+#[codama(default_value = account(banana = "authority"))]
+pub struct TestWithWrongKey;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/account_value_node/invalid_name.fail.stderr
+++ b/codama-macros/tests/codama_attribute/values_nodes/account_value_node/invalid_name.fail.stderr
@@ -1,0 +1,17 @@
+error: expected a string
+ --> tests/codama_attribute/values_nodes/account_value_node/invalid_name.fail.rs:3:34
+  |
+3 | #[codama(default_value = account(42))]
+  |                                  ^^
+
+error: expected a string
+ --> tests/codama_attribute/values_nodes/account_value_node/invalid_name.fail.rs:6:34
+  |
+6 | #[codama(default_value = account(banana))]
+  |                                  ^^^^^^
+
+error: only 'name' attribute supported
+ --> tests/codama_attribute/values_nodes/account_value_node/invalid_name.fail.rs:9:34
+  |
+9 | #[codama(default_value = account(banana = "authority"))]
+  |                                  ^^^^^^

--- a/codama-macros/tests/codama_attribute/values_nodes/account_value_node/missing_name.fail.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/account_value_node/missing_name.fail.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(default_value = account)]
+pub struct Test;
+
+#[codama(default_value = account())]
+pub struct TestWithBraces;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/account_value_node/missing_name.fail.stderr
+++ b/codama-macros/tests/codama_attribute/values_nodes/account_value_node/missing_name.fail.stderr
@@ -1,0 +1,11 @@
+error: expected a list: `account(...)` or `account = (...)`
+ --> tests/codama_attribute/values_nodes/account_value_node/missing_name.fail.rs:3:26
+  |
+3 | #[codama(default_value = account)]
+  |                          ^^^^^^^
+
+error: name is missing
+ --> tests/codama_attribute/values_nodes/account_value_node/missing_name.fail.rs:6:26
+  |
+6 | #[codama(default_value = account())]
+  |                          ^^^^^^^^^


### PR DESCRIPTION
This PR adds a new `account` directive in the context of value nodes. This means you can now set the default value of an account to another account like so.


```rs
#[derive(CodamaInstruction)]
#[codama(account(name = "authority"))]
#[codama(account(name = "payer", default_value = account("authority")))]
struct Initialize;
```