### PR TITLE
Add argument value directive

### DIFF
--- a/codama-attributes/src/codama_directives/value_nodes/argument_value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/argument_value_node.rs
@@ -1,0 +1,52 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::ArgumentValueNode;
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for ArgumentValueNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("argument")?.as_path_list()?;
+        let mut name = SetOnce::<String>::new("name");
+        pl.each(|ref meta| match meta {
+            Meta::PathValue(pv) => {
+                if !pv.path.is_strict("name") {
+                    return Err(pv.path.error("only 'name' attribute supported"));
+                };
+                name.set(String::from_meta(meta)?, meta)
+            }
+            _ => name.set(String::from_meta(meta)?, meta),
+        })?;
+
+        Ok(ArgumentValueNode::new(name.take(meta)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_value, assert_value_err};
+
+    #[test]
+    fn ok() {
+        assert_value!(
+            { argument("amount") },
+            ArgumentValueNode::new("amount").into()
+        );
+        assert_value!(
+            { argument(name = "amount") },
+            ArgumentValueNode::new("amount").into()
+        );
+    }
+
+    #[test]
+    fn wrong_name_attribute() {
+        assert_value_err!(
+            { argument(banana = "amount") },
+            "only 'name' attribute supported"
+        );
+    }
+
+    #[test]
+    fn missing_name() {
+        assert_value_err!({ argument() }, "name is missing");
+    }
+}

--- a/codama-attributes/src/codama_directives/value_nodes/instruction_input_value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/instruction_input_value_node.rs
@@ -1,11 +1,14 @@
 use crate::utils::FromMeta;
-use codama_nodes::{AccountValueNode, InstructionInputValueNode, PayerValueNode, ValueNode};
+use codama_nodes::{
+    AccountValueNode, ArgumentValueNode, InstructionInputValueNode, PayerValueNode, ValueNode,
+};
 use codama_syn_helpers::Meta;
 
 impl FromMeta for InstructionInputValueNode {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
         match meta.path_str().as_str() {
             "account" => AccountValueNode::from_meta(meta).map(Self::from),
+            "argument" => ArgumentValueNode::from_meta(meta).map(Self::from),
             "payer" => PayerValueNode::from_meta(meta).map(Self::from),
             _ => ValueNode::from_meta(meta).map(Self::from),
         }

--- a/codama-attributes/src/codama_directives/value_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/mod.rs
@@ -1,4 +1,5 @@
 mod account_value_node;
+mod argument_value_node;
 mod boolean_value_node;
 mod instruction_input_value_node;
 mod number_value_node;

--- a/codama-macros/tests/codama_attribute/values_nodes/argument_value_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/argument_value_node/_pass.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(default_value = argument(name = "amount"))]
+pub struct TestExplicit;
+
+#[codama(default_value = argument("amount"))]
+pub struct TestImplicit;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/argument_value_node/invalid_name.fail.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/argument_value_node/invalid_name.fail.rs
@@ -1,0 +1,12 @@
+use codama_macros::codama;
+
+#[codama(default_value = argument(42))]
+pub struct TestWithInteger;
+
+#[codama(default_value = argument(banana))]
+pub struct TestWithPath;
+
+#[codama(default_value = argument(banana = "authority"))]
+pub struct TestWithWrongKey;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/argument_value_node/invalid_name.fail.stderr
+++ b/codama-macros/tests/codama_attribute/values_nodes/argument_value_node/invalid_name.fail.stderr
@@ -1,0 +1,17 @@
+error: expected a string
+ --> tests/codama_attribute/values_nodes/argument_value_node/invalid_name.fail.rs:3:35
+  |
+3 | #[codama(default_value = argument(42))]
+  |                                   ^^
+
+error: expected a string
+ --> tests/codama_attribute/values_nodes/argument_value_node/invalid_name.fail.rs:6:35
+  |
+6 | #[codama(default_value = argument(banana))]
+  |                                   ^^^^^^
+
+error: only 'name' attribute supported
+ --> tests/codama_attribute/values_nodes/argument_value_node/invalid_name.fail.rs:9:35
+  |
+9 | #[codama(default_value = argument(banana = "authority"))]
+  |                                   ^^^^^^

--- a/codama-macros/tests/codama_attribute/values_nodes/argument_value_node/missing_name.fail.rs
+++ b/codama-macros/tests/codama_attribute/values_nodes/argument_value_node/missing_name.fail.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(default_value = argument)]
+pub struct Test;
+
+#[codama(default_value = argument())]
+pub struct TestWithBraces;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/values_nodes/argument_value_node/missing_name.fail.stderr
+++ b/codama-macros/tests/codama_attribute/values_nodes/argument_value_node/missing_name.fail.stderr
@@ -1,0 +1,11 @@
+error: expected a list: `argument(...)` or `argument = (...)`
+ --> tests/codama_attribute/values_nodes/argument_value_node/missing_name.fail.rs:3:26
+  |
+3 | #[codama(default_value = argument)]
+  |                          ^^^^^^^^
+
+error: name is missing
+ --> tests/codama_attribute/values_nodes/argument_value_node/missing_name.fail.rs:6:26
+  |
+6 | #[codama(default_value = argument())]
+  |                          ^^^^^^^^^^


### PR DESCRIPTION
This PR adds a new `argument` directive in the context of value nodes. This means you can now set the default value of an argument to another argument like so.


```rs
#[derive(CodamaInstruction)]
#[codama(argument("capacity", number(u64)))]
#[codama(argument("max_capacity", number(u64), default_value = argument("capacity")))]
struct Initialize;
```