### PR TITLE
Identify argument default values in SetInstructionsVisitor

### DIFF
--- a/codama-korok-visitors/src/combine_types_visitor.rs
+++ b/codama-korok-visitors/src/combine_types_visitor.rs
@@ -129,16 +129,8 @@ impl CombineTypesVisitor {
             .get_all(FieldDirective::filter)
             .into_iter()
             .partition(|attr| !attr.after);
-
-        let before = before
-            .into_iter()
-            .map(|attr| attr.field.clone())
-            .collect::<Vec<_>>();
-
-        let after = after
-            .into_iter()
-            .map(|attr| attr.field.clone())
-            .collect::<Vec<_>>();
+        let before = before.into_iter().map(|attr| attr.field.clone());
+        let after = after.into_iter().map(|attr| attr.field.clone());
 
         Ok(before.into_iter().chain(fields).chain(after).collect())
     }


### PR DESCRIPTION
This PR ensures default values that are specific to instruction arguments (such as the `PayerValueNode` or linking to another account/argument within the instruction) are properly identified when elevating a `StructTypeNode` into an array of `InstructionArgumentNode` in the `SetInstructionsVisitor`.

This means the default value in the following example will properly be identified.

```rs
#[derive(CodamaInstruction)]
struct Initialize {
    capacity: u64,
    #[codama(default_value = argument("capacity"))]
    max_capacity: u64,
}
```