### PR TITLE
Add `value` alias directive as omitted default value

### DIFF
--- a/codama-attributes/src/codama_directives/argument_directive.rs
+++ b/codama-attributes/src/codama_directives/argument_directive.rs
@@ -22,14 +22,17 @@ impl ArgumentDirective {
             .consume_after()?
             .assert_fully_consumed()?;
 
+        let default_value = consumer.default_instruction_input_value_node();
+        let default_value_strategy = consumer.default_value_strategy();
+
         Ok(ArgumentDirective {
             after: consumer.after.option().unwrap_or(false),
             argument: InstructionArgumentNode {
                 name: consumer.name.take(meta)?,
                 r#type: consumer.r#type.take(meta)?,
                 docs: Docs::default(),
-                default_value: consumer.argument_default_value.option(),
-                default_value_strategy: consumer.default_value_strategy.option(),
+                default_value,
+                default_value_strategy,
             },
         })
     }

--- a/codama-attributes/src/codama_directives/codama_directive.rs
+++ b/codama-attributes/src/codama_directives/codama_directive.rs
@@ -11,11 +11,13 @@ use derive_more::derive::From;
 pub enum CodamaDirective {
     // Type directives.
     Type(TypeDirective),
-    DefaultValue(DefaultValueDirective),
     Encoding(EncodingDirective),
     Field(FieldDirective),
     FixedSize(FixedSizeDirective),
     SizePrefix(SizePrefixDirective),
+
+    // Default value directive.
+    DefaultValue(DefaultValueDirective),
 
     // Multi-purpose directives.
     Discriminator(DiscriminatorDirective),
@@ -40,11 +42,14 @@ impl CodamaDirective {
         match path.to_string().as_str() {
             // Type directives.
             "type" => Ok(TypeDirective::parse(meta)?.into()),
-            "default_value" => Ok(DefaultValueDirective::parse(meta)?.into()),
             "encoding" => Ok(EncodingDirective::parse(meta)?.into()),
             "field" => Ok(FieldDirective::parse(meta)?.into()),
             "fixed_size" => Ok(FixedSizeDirective::parse(meta)?.into()),
             "size_prefix" => Ok(SizePrefixDirective::parse(meta)?.into()),
+
+            // Default value directive.
+            "default_value" => Ok(DefaultValueDirective::parse(meta)?.into()),
+            "value" => Ok(DefaultValueDirective::parse(meta)?.into()),
 
             // Multi-purpose directives.
             "discriminator" => Ok(DiscriminatorDirective::parse(meta)?.into()),
@@ -70,11 +75,13 @@ impl CodamaDirective {
         match self {
             // Type directives.
             Self::Type(_) => "type",
-            Self::DefaultValue(_) => "default_value",
             Self::Encoding(_) => "encoding",
             Self::Field(_) => "field",
             Self::FixedSize(_) => "fixed_size",
             Self::SizePrefix(_) => "size_prefix",
+
+            // Default value directive.
+            Self::DefaultValue(_) => "default_value | value",
 
             // Multi-purpose directives.
             Self::Discriminator(_) => "discriminator",

--- a/codama-attributes/src/codama_directives/default_value_directive.rs
+++ b/codama-attributes/src/codama_directives/default_value_directive.rs
@@ -1,18 +1,47 @@
 use crate::{utils::FromMeta, Attribute, CodamaAttribute, CodamaDirective};
 use codama_errors::CodamaError;
-use codama_nodes::InstructionInputValueNode;
-use codama_syn_helpers::Meta;
+use codama_nodes::{DefaultValueStrategy, InstructionInputValueNode, ValueNode};
+use codama_syn_helpers::{extensions::*, Meta};
 
 #[derive(Debug, PartialEq)]
 pub struct DefaultValueDirective {
     pub node: InstructionInputValueNode,
+    pub default_value_strategy: Option<DefaultValueStrategy>,
 }
 
 impl DefaultValueDirective {
     pub fn parse(meta: &Meta) -> syn::Result<Self> {
-        let pv = meta.assert_directive("default_value")?.as_path_value()?;
-        let node = InstructionInputValueNode::from_meta(&pv.value)?;
-        Ok(Self { node })
+        Self::parse_logic(meta, false)
+    }
+
+    pub fn parse_value_nodes_only(meta: &Meta) -> syn::Result<Self> {
+        Self::parse_logic(meta, true)
+    }
+
+    fn parse_logic(meta: &Meta, value_nodes_only: bool) -> syn::Result<Self> {
+        let pv = meta.as_path_value()?;
+        let is_default_value = pv.path.is_strict("default_value");
+        let is_value = pv.path.is_strict("value");
+        if !is_default_value && !is_value {
+            return Err(pv
+                .path
+                .error("expected #[codama(default_value)] or #[codama(value)] attributes"));
+        };
+
+        let node = match value_nodes_only {
+            true => ValueNode::from_meta(&pv.value)?.into(),
+            false => InstructionInputValueNode::from_meta(&pv.value)?,
+        };
+
+        let default_value_strategy = match is_value {
+            true => Some(DefaultValueStrategy::Omitted),
+            false => None,
+        };
+
+        Ok(Self {
+            node,
+            default_value_strategy,
+        })
     }
 }
 
@@ -41,15 +70,56 @@ impl<'a> TryFrom<&'a Attribute<'a>> for &'a DefaultValueDirective {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use codama_nodes::BooleanValueNode;
+    use codama_nodes::{BooleanValueNode, PayerValueNode};
     use syn::parse_quote;
 
     #[test]
-    fn ok() {
-        let meta: Meta = parse_quote! { default_value = true };
-        let node = DefaultValueDirective::parse(&meta).unwrap().node;
+    fn default_value_ok() {
+        let meta: Meta = parse_quote! { default_value = payer };
+        let directive = DefaultValueDirective::parse(&meta).unwrap();
 
-        assert_eq!(node, BooleanValueNode::new(true).into());
+        assert_eq!(
+            directive,
+            DefaultValueDirective {
+                node: PayerValueNode::new().into(),
+                default_value_strategy: None,
+            }
+        );
+    }
+
+    #[test]
+    fn value_ok() {
+        let meta: Meta = parse_quote! { value = payer };
+        let directive = DefaultValueDirective::parse(&meta).unwrap();
+
+        assert_eq!(
+            directive,
+            DefaultValueDirective {
+                node: PayerValueNode::new().into(),
+                default_value_strategy: Some(DefaultValueStrategy::Omitted),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_value_nodes_only_ok() {
+        let meta: Meta = parse_quote! { value = true };
+        let directive = DefaultValueDirective::parse_value_nodes_only(&meta).unwrap();
+
+        assert_eq!(
+            directive,
+            DefaultValueDirective {
+                node: BooleanValueNode::new(true).into(),
+                default_value_strategy: Some(DefaultValueStrategy::Omitted),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_value_nodes_only_err() {
+        let meta: Meta = parse_quote! { value = payer };
+        let error = DefaultValueDirective::parse_value_nodes_only(&meta).unwrap_err();
+        assert_eq!(error.to_string(), "unrecognized value");
     }
 
     #[test]

--- a/codama-attributes/src/codama_directives/field_directive.rs
+++ b/codama-attributes/src/codama_directives/field_directive.rs
@@ -22,14 +22,17 @@ impl FieldDirective {
             .consume_after()?
             .assert_fully_consumed()?;
 
+        let default_value = consumer.default_value_node();
+        let default_value_strategy = consumer.default_value_strategy();
+
         Ok(FieldDirective {
             after: consumer.after.option().unwrap_or(false),
             field: StructFieldTypeNode {
                 name: consumer.name.take(meta)?,
                 r#type: consumer.r#type.take(meta)?,
                 docs: Docs::default(),
-                default_value: consumer.default_value.option(),
-                default_value_strategy: consumer.default_value_strategy.option(),
+                default_value,
+                default_value_strategy,
             },
         })
     }

--- a/codama-attributes/src/codama_directives/type_nodes/struct_field_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/struct_field_type_node.rs
@@ -13,11 +13,14 @@ impl FromMeta for StructFieldTypeNode {
             .consume_default_value()?
             .assert_fully_consumed()?;
 
+        let default_value = consumer.default_value_node();
+        let default_value_strategy = consumer.default_value_strategy();
+
         Ok(StructFieldTypeNode {
             name: consumer.name.take(meta)?,
             r#type: consumer.r#type.take(meta)?,
-            default_value: consumer.default_value.option(),
-            default_value_strategy: consumer.default_value_strategy.option(),
+            default_value,
+            default_value_strategy,
             docs: Docs::default(),
         })
     }
@@ -58,16 +61,9 @@ mod tests {
     }
 
     #[test]
-    fn with_default_value_strategy() {
+    fn with_omitted_value() {
         assert_type!(
-            {
-                field(
-                    "age",
-                    number(u32),
-                    default_value = 42,
-                    default_value_omitted,
-                )
-            },
+            { field("age", number(u32), value = 42) },
             StructFieldTypeNode {
                 default_value: Some(NumberValueNode::new(42u32).into()),
                 default_value_strategy: Some(DefaultValueStrategy::Omitted),

--- a/codama-attributes/src/utils/set_once.rs
+++ b/codama-attributes/src/utils/set_once.rs
@@ -38,6 +38,10 @@ impl<T> SetOnce<T> {
         self.value
     }
 
+    pub fn option_ref(&self) -> Option<&T> {
+        self.value.as_ref()
+    }
+
     pub fn take<U: ToTokens>(mut self, tokens: U) -> syn::Result<T> {
         match self.value.take() {
             Some(value) => Ok(value),

--- a/codama-korok-visitors/src/set_default_values_visitor.rs
+++ b/codama-korok-visitors/src/set_default_values_visitor.rs
@@ -96,6 +96,7 @@ fn get_node_with_default_value(node: &Option<Node>, attributes: &Attributes) -> 
             Some(
                 StructFieldTypeNode {
                     default_value: Some(value),
+                    default_value_strategy: directive.default_value_strategy,
                     ..field.clone()
                 }
                 .into(),
@@ -105,6 +106,7 @@ fn get_node_with_default_value(node: &Option<Node>, attributes: &Attributes) -> 
         Some(Node::InstructionArgument(argument)) => Some(
             InstructionArgumentNode {
                 default_value: Some(directive.node.clone()),
+                default_value_strategy: directive.default_value_strategy,
                 ..argument.clone()
             }
             .into(),

--- a/codama-korok-visitors/src/set_instructions_visitors.rs
+++ b/codama-korok-visitors/src/set_instructions_visitors.rs
@@ -222,6 +222,7 @@ fn parse_arguments(
 
                 InstructionArgumentNode {
                     default_value: Some(directive.node.clone()),
+                    default_value_strategy: directive.default_value_strategy,
                     ..argument
                 }
             });

--- a/codama-korok-visitors/tests/combine_types_visitor/enum_variant_korok.rs
+++ b/codama-korok-visitors/tests/combine_types_visitor/enum_variant_korok.rs
@@ -190,7 +190,7 @@ fn it_adds_attribute_fields_to_empty_enum_variants() -> CodamaResult<()> {
 #[test]
 fn it_prepends_attribute_fields_to_enum_variants() -> CodamaResult<()> {
     let ast: syn::Variant = syn::parse_quote! {
-        #[codama(field("discriminator", number(u8), default_value = 0, default_value_omitted))]
+        #[codama(field("discriminator", number(u8), value = 0))]
         #[codama(field("age", number(u8)))]
         Person {
             name: String,

--- a/codama-korok-visitors/tests/combine_types_visitor/struct_korok.rs
+++ b/codama-korok-visitors/tests/combine_types_visitor/struct_korok.rs
@@ -186,7 +186,7 @@ fn it_adds_attribute_fields_to_empty_structs() -> CodamaResult<()> {
 #[test]
 fn it_prepends_attribute_fields_to_structs() -> CodamaResult<()> {
     let item: syn::Item = syn::parse_quote! {
-        #[codama(field("discriminator", number(u8), default_value = 0, default_value_omitted))]
+        #[codama(field("discriminator", number(u8), value = 0))]
         #[codama(field("age", number(u8)))]
         struct Person {
             name: String,

--- a/codama-korok-visitors/tests/set_instructions_visitor/from_codama_instruction.rs
+++ b/codama-korok-visitors/tests/set_instructions_visitor/from_codama_instruction.rs
@@ -223,7 +223,7 @@ fn from_struct_with_default_values_in_arguments() -> CodamaResult<()> {
             capacity: u64,
             #[codama(default_value = argument("capacity"))]
             max_capacity: u64,
-            #[codama(default_value = false)]
+            #[codama(value = false)]
             with_metadata: bool,
         }
     };
@@ -250,6 +250,7 @@ fn from_struct_with_default_values_in_arguments() -> CodamaResult<()> {
                     },
                     InstructionArgumentNode {
                         default_value: Some(BooleanValueNode::new(false).into()),
+                        default_value_strategy: Some(DefaultValueStrategy::Omitted),
                         ..InstructionArgumentNode::new("with_metadata", BooleanTypeNode::default())
                     }
                 ],
@@ -472,7 +473,7 @@ fn with_argument_attributes_only() -> CodamaResult<()> {
 fn with_prepended_argument_attributes() -> CodamaResult<()> {
     let item: syn::Item = syn::parse_quote! {
         #[derive(CodamaInstruction)]
-        #[codama(argument("discriminator", number(u8), default_value = 0, default_value_omitted))]
+        #[codama(argument("discriminator", number(u8), value = 0))]
         #[codama(argument("name", string(utf8)))]
         struct MyInstruction {
             age: u8,

--- a/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/struct_field_type_node/_pass.rs
@@ -9,7 +9,7 @@ pub struct ExplicitTest;
 #[codama(type = field("age", number(u32), default_value = 42))]
 pub struct TestWithDefaultValue;
 
-#[codama(type = field("age", number(u32), default_value = 42, default_value_omitted))]
+#[codama(type = field("age", number(u32), value = 42))]
 pub struct TestWithDefaultValueStrategy;
 
 fn main() {}


### PR DESCRIPTION
This PR adds an alias to the `default_value` directive called `value`. When `value` is used instead of `default_value` it will also set the `default_value_strategy` of the node to `Omitted`. This means we can now remove the redundant `default_value_omitted` directive which is also done in this PR.

Here are a few example:

### In value directives

Here the `discriminator` is an optional default value that can be overridden by the user.

```rs
#[derive(CodamaInstruction)]
pub struct Initialize {
  #[default_value = 42]
  pub discriminator: u8;
  pub capacity: u64;
}
```

Here the `discriminator` is an omitted default value.

```rs
#[derive(CodamaInstruction)]
pub struct Initialize {
  #[value = 42]
  pub discriminator: u8;
  pub capacity: u64;
}
```

### In field directives

```rs
#[derive(CodamaInstruction)]
#[field("discriminator", number(u8), value = 42)]
pub struct Initialize {
  pub capacity: u64;
}
```

### In argument directives

```rs
#[derive(CodamaInstruction)]
#[argument(after, "max_capacity", number(u64), value = argument("capacity"))]
pub struct Initialize {
  pub capacity: u64;
}
```