### PR TITLE
Use consistent Meta parsing

### DIFF
--- a/codama-attributes/src/codama_directives/account_directive.rs
+++ b/codama-attributes/src/codama_directives/account_directive.rs
@@ -32,14 +32,14 @@ impl AccountDirective {
             false => meta
                 .as_path_list()?
                 .each(|ref meta| match meta.path_str().as_str() {
-                    "name" => name.set(String::from_meta(meta)?.into(), meta),
+                    "name" => name.set(meta.as_value()?.as_expr()?.as_string()?.into(), meta),
                     "writable" => is_writable.set(bool::from_meta(meta)?, meta),
                     "signer" => is_signer.set(IsAccountSigner::from_meta(meta)?, meta),
                     "optional" => is_optional.set(bool::from_meta(meta)?, meta),
-                    "default_value" => {
-                        let value = &meta.as_path_value()?.value;
-                        default_value.set(InstructionInputValueNode::from_meta(value)?, meta)
-                    }
+                    "default_value" => default_value.set(
+                        InstructionInputValueNode::from_meta(meta.as_value()?)?,
+                        meta,
+                    ),
                     _ => Err(meta.error("unrecognized attribute")),
                 })?,
         }

--- a/codama-attributes/src/codama_directives/encoding_directive.rs
+++ b/codama-attributes/src/codama_directives/encoding_directive.rs
@@ -10,11 +10,10 @@ pub struct EncodingDirective {
 
 impl EncodingDirective {
     pub fn parse(meta: &Meta) -> syn::Result<Self> {
-        let pv = meta.assert_directive("encoding")?.as_path_value()?;
-        let value = pv.value.as_path()?;
-        match BytesEncoding::try_from(value.to_string()) {
+        let path = meta.assert_directive("encoding")?.as_value()?.as_path()?;
+        match BytesEncoding::try_from(path.to_string()) {
             Ok(encoding) => Ok(Self { encoding }),
-            _ => Err(value.error("invalid encoding")),
+            _ => Err(path.error("invalid encoding")),
         }
     }
 }

--- a/codama-attributes/src/codama_directives/enum_discriminator_directive.rs
+++ b/codama-attributes/src/codama_directives/enum_discriminator_directive.rs
@@ -25,9 +25,9 @@ impl EnumDiscriminatorDirective {
         let mut size: SetOnce<NestedTypeNode<NumberTypeNode>> =
             SetOnce::<NestedTypeNode<NumberTypeNode>>::new("size");
         pl.each(|ref meta| match meta.path_str().as_str() {
-            "name" => name.set(String::from_meta(meta)?.into(), meta),
+            "name" => name.set(meta.as_value()?.as_expr()?.as_string()?.into(), meta),
             "size" => {
-                let node = TypeNode::from_meta(&meta.as_path_value()?.value)?;
+                let node = TypeNode::from_meta(meta.as_value()?)?;
                 match NestedTypeNode::<NumberTypeNode>::try_from(node) {
                     Ok(node) => size.set(node, meta),
                     _ => Err(meta.error("size must be a NumberTypeNode")),

--- a/codama-attributes/src/codama_directives/fixed_size_directive.rs
+++ b/codama-attributes/src/codama_directives/fixed_size_directive.rs
@@ -1,6 +1,6 @@
-use crate::{utils::FromMeta, Attribute, CodamaAttribute, CodamaDirective};
+use crate::{Attribute, CodamaAttribute, CodamaDirective};
 use codama_errors::CodamaError;
-use codama_syn_helpers::Meta;
+use codama_syn_helpers::{extensions::ExprExtension, Meta};
 
 #[derive(Debug, PartialEq)]
 pub struct FixedSizeDirective {
@@ -11,7 +11,7 @@ impl FixedSizeDirective {
     pub fn parse(meta: &Meta) -> syn::Result<Self> {
         meta.assert_directive("fixed_size")?;
         Ok(Self {
-            size: usize::from_meta(meta)?,
+            size: meta.as_value()?.as_expr()?.as_unsigned_integer()?,
         })
     }
 }

--- a/codama-attributes/src/codama_directives/name_directive.rs
+++ b/codama-attributes/src/codama_directives/name_directive.rs
@@ -1,7 +1,7 @@
-use crate::{utils::FromMeta, Attribute, CodamaAttribute, CodamaDirective};
+use crate::{Attribute, CodamaAttribute, CodamaDirective};
 use codama_errors::CodamaError;
 use codama_nodes::CamelCaseString;
-use codama_syn_helpers::Meta;
+use codama_syn_helpers::{extensions::*, Meta};
 
 #[derive(Debug, PartialEq)]
 pub struct NameDirective {
@@ -12,7 +12,7 @@ impl NameDirective {
     pub fn parse(meta: &Meta) -> syn::Result<Self> {
         meta.assert_directive("name")?;
         Ok(Self {
-            name: String::from_meta(meta)?.into(),
+            name: meta.as_value()?.as_expr()?.as_string()?.into(),
         })
     }
 }

--- a/codama-attributes/src/codama_directives/pda_directive.rs
+++ b/codama-attributes/src/codama_directives/pda_directive.rs
@@ -1,7 +1,7 @@
-use crate::{utils::FromMeta, Attribute, CodamaAttribute, CodamaDirective};
+use crate::{Attribute, CodamaAttribute, CodamaDirective};
 use codama_errors::CodamaError;
 use codama_nodes::PdaLinkNode;
-use codama_syn_helpers::Meta;
+use codama_syn_helpers::{extensions::*, Meta};
 
 #[derive(Debug, PartialEq)]
 pub struct PdaDirective {
@@ -10,8 +10,11 @@ pub struct PdaDirective {
 
 impl PdaDirective {
     pub fn parse(meta: &Meta) -> syn::Result<Self> {
-        let pv = meta.assert_directive("pda")?.as_path_value()?;
-        let name = String::from_meta(&pv.value)?;
+        let name = meta
+            .assert_directive("pda")?
+            .as_value()?
+            .as_expr()?
+            .as_string()?;
         Ok(Self {
             pda: PdaLinkNode::new(name),
         })

--- a/codama-attributes/src/codama_directives/seed_directive.rs
+++ b/codama-attributes/src/codama_directives/seed_directive.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use codama_errors::CodamaError;
 use codama_nodes::{ConstantPdaSeedNode, PdaSeedNode, TypeNode, ValueNode, VariablePdaSeedNode};
-use codama_syn_helpers::{extensions::ToTokensExtension, Meta};
+use codama_syn_helpers::{extensions::*, Meta};
 
 #[derive(Debug, PartialEq)]
 pub struct SeedDirective {
@@ -37,10 +37,10 @@ impl SeedDirective {
 
         pl.each(|ref meta| match (meta.path_str().as_str(), constant_seed) {
             ("name", true) => Err(meta.error("constant seeds cannot specify name")),
-            ("name", false) => name.set(String::from_meta(meta)?, meta),
-            ("value", true) => value.set(ValueNode::from_meta(&meta.as_path_value()?.value)?, meta),
+            ("name", false) => name.set(meta.as_value()?.as_expr()?.as_string()?, meta),
+            ("value", true) => value.set(ValueNode::from_meta(meta.as_value()?)?, meta),
             ("value", false) => Err(meta.error("variable seeds cannot specify value")),
-            ("type", _) => r#type.set(TypeNode::from_meta(&meta.as_path_value()?.value)?, meta),
+            ("type", _) => r#type.set(TypeNode::from_meta(meta.as_value()?)?, meta),
             _ => Err(meta.error("unrecognized attribute")),
         })?;
 

--- a/codama-attributes/src/codama_directives/size_prefix_directive.rs
+++ b/codama-attributes/src/codama_directives/size_prefix_directive.rs
@@ -10,11 +10,11 @@ pub struct SizePrefixDirective {
 
 impl SizePrefixDirective {
     pub fn parse(meta: &Meta) -> syn::Result<Self> {
-        let pv = meta.assert_directive("size_prefix")?.as_path_value()?;
-        let node = TypeNode::from_meta(&pv.value)?;
+        let value = meta.assert_directive("size_prefix")?.as_value()?;
+        let node = TypeNode::from_meta(value)?;
         let prefix = match NestedTypeNode::<NumberTypeNode>::try_from(node) {
             Ok(node) => node,
-            Err(_) => return Err(pv.value.error("prefix must be a NumberTypeNode")),
+            Err(_) => return Err(value.error("prefix must be a NumberTypeNode")),
         };
         Ok(Self { prefix })
     }

--- a/codama-attributes/src/codama_directives/type_directive.rs
+++ b/codama-attributes/src/codama_directives/type_directive.rs
@@ -10,9 +10,10 @@ pub struct TypeDirective {
 
 impl TypeDirective {
     pub fn parse(meta: &Meta) -> syn::Result<Self> {
-        let pv = meta.assert_directive("type")?.as_path_value()?;
-        let node = RegisteredTypeNode::from_meta(&pv.value)?;
-        Ok(Self { node })
+        let value = meta.assert_directive("type")?.as_value()?;
+        Ok(Self {
+            node: RegisteredTypeNode::from_meta(value)?,
+        })
     }
 }
 

--- a/codama-attributes/src/codama_directives/type_nodes/boolean_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/boolean_type_node.rs
@@ -11,13 +11,14 @@ impl FromMeta for BooleanTypeNode {
         }
 
         meta.as_path_list()?
-            .each(|ref meta| match (meta.path_str().as_str(), meta) {
-                ("size", _) => {
-                    let node = TypeNode::from_meta(&meta.as_path_value()?.value)?;
-                    size.set(node, meta)
+            .each(|ref meta| match meta.path_str().as_str() {
+                "size" => size.set(TypeNode::from_meta(meta.as_value()?)?, meta),
+                _ => {
+                    if meta.is_path_or_list() {
+                        return size.set(TypeNode::from_meta(meta)?, meta);
+                    }
+                    Err(meta.error("unrecognized attribute"))
                 }
-                (_, m) if m.is_path_or_list() => size.set(TypeNode::from_meta(meta)?, meta),
-                _ => Err(meta.error("unrecognized attribute")),
             })?;
 
         let size = match NestedTypeNode::<NumberTypeNode>::try_from(size.take(meta)?) {

--- a/codama-attributes/src/codama_directives/type_nodes/struct_field_meta_consumer.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/struct_field_meta_consumer.rs
@@ -5,7 +5,7 @@ use crate::{
 use codama_nodes::{
     CamelCaseString, DefaultValueStrategy, InstructionInputValueNode, TypeNode, ValueNode,
 };
-use codama_syn_helpers::Meta;
+use codama_syn_helpers::{extensions::*, Meta};
 
 pub(crate) struct StructFieldMetaConsumer {
     pub metas: Vec<Meta>,
@@ -39,16 +39,17 @@ impl StructFieldMetaConsumer {
     pub fn consume_field(self) -> syn::Result<Self> {
         self.consume_metas(|this, meta| match meta.path_str().as_str() {
             "name" => {
-                this.name.set(String::from_meta(&meta)?.into(), meta)?;
+                this.name
+                    .set(meta.as_value()?.as_expr()?.as_string()?.into(), meta)?;
                 Ok(None)
             }
             "type" => {
-                let node = TypeNode::from_meta(&meta.as_path_value()?.value)?;
-                this.r#type.set(node, meta)?;
+                this.r#type
+                    .set(TypeNode::from_meta(meta.as_value()?)?, meta)?;
                 Ok(None)
             }
             _ => {
-                if let Ok(value) = String::from_meta(&meta) {
+                if let Ok(value) = meta.as_expr().and_then(|e| e.as_string()) {
                     this.name.set(value.into(), meta)?;
                     return Ok(None);
                 }

--- a/codama-attributes/src/codama_directives/value_nodes/account_value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/account_value_node.rs
@@ -11,9 +11,9 @@ impl FromMeta for AccountValueNode {
                 if !pv.path.is_strict("name") {
                     return Err(pv.path.error("only 'name' attribute supported"));
                 };
-                name.set(String::from_meta(meta)?, meta)
+                name.set(pv.value.as_expr()?.as_string()?, meta)
             }
-            _ => name.set(String::from_meta(meta)?, meta),
+            _ => name.set(meta.as_expr()?.as_string()?, meta),
         })?;
 
         Ok(AccountValueNode::new(name.take(meta)?))

--- a/codama-attributes/src/codama_directives/value_nodes/argument_value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/argument_value_node.rs
@@ -11,9 +11,9 @@ impl FromMeta for ArgumentValueNode {
                 if !pv.path.is_strict("name") {
                     return Err(pv.path.error("only 'name' attribute supported"));
                 };
-                name.set(String::from_meta(meta)?, meta)
+                name.set(pv.value.as_expr()?.as_string()?, meta)
             }
-            _ => name.set(String::from_meta(meta)?, meta),
+            _ => name.set(meta.as_expr()?.as_string()?, meta),
         })?;
 
         Ok(ArgumentValueNode::new(name.take(meta)?))

--- a/codama-attributes/src/codama_directives/value_nodes/pda_seed_value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/pda_seed_value_node.rs
@@ -32,16 +32,10 @@ impl FromMeta for PdaSeedValueNode {
             SetOnce::<PdaSeedValueValueNode>::new("value");
 
         pl.each(|ref meta| match meta.path_str().as_str() {
-            "name" => name.set(
-                String::from_meta(&meta.as_path_value()?.value)?.into(),
-                meta,
-            ),
-            "value" => value.set(
-                PdaSeedValueValueNode::from_meta(&meta.as_path_value()?.value)?,
-                meta,
-            ),
+            "name" => name.set(meta.as_value()?.as_expr()?.as_string()?.into(), meta),
+            "value" => value.set(PdaSeedValueValueNode::from_meta(meta.as_value()?)?, meta),
             _ => {
-                if let Ok(seed_name) = String::from_meta(meta) {
+                if let Ok(seed_name) = meta.as_expr().and_then(|e| e.as_string()) {
                     match name.is_set() {
                         false => return name.set(seed_name.into(), meta),
                         true => return value.set(StringValueNode::new(seed_name).into(), meta),

--- a/codama-attributes/src/codama_directives/value_nodes/pda_value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/pda_value_node.rs
@@ -11,17 +11,11 @@ impl FromMeta for PdaValueNode {
         let mut seeds = SetOnce::<Vec<PdaSeedValueNode>>::new("seeds");
 
         pl.each(|ref meta| match meta.path_str().as_str() {
-            "name" => name.set(
-                String::from_meta(&meta.as_path_value()?.value)?.into(),
-                meta,
-            ),
-            "program" => program.set(
-                String::from_meta(&meta.as_path_value()?.value)?.into(),
-                meta,
-            ),
+            "name" => name.set(meta.as_value()?.as_expr()?.as_string()?.into(), meta),
+            "program" => program.set(meta.as_value()?.as_expr()?.as_string()?.into(), meta),
             "seeds" => seeds.set(parse_seed_value_nodes(meta.as_path_list()?)?, meta),
             _ => {
-                if let Ok(seed_name) = meta.as_expr().and_then(ExprExtension::as_string) {
+                if let Ok(seed_name) = meta.as_expr().and_then(|e| e.as_string()) {
                     return name.set(seed_name.into(), meta);
                 }
                 if let Meta::Expr(syn::Expr::Array(array)) = meta {

--- a/codama-attributes/src/utils/from_meta.rs
+++ b/codama-attributes/src/utils/from_meta.rs
@@ -9,26 +9,14 @@ where
     fn from_meta(meta: &Meta) -> syn::Result<Self>;
 }
 
-impl FromMeta for String {
-    fn from_meta(meta: &Meta) -> syn::Result<Self> {
-        get_expr_from_meta(meta)?.as_string()
-    }
-}
-
 impl FromMeta for bool {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
         match meta {
             // This is to allow attributes like `#[account(signer)]`
             // where `signer` is interpreted as `signer = true`.
             Meta::Expr(Expr::Path(_)) => Ok(true),
-            _ => get_expr_from_meta(meta)?.as_bool(),
+            _ => meta.as_expr_or_value_expr()?.as_bool(),
         }
-    }
-}
-
-impl FromMeta for usize {
-    fn from_meta(meta: &Meta) -> syn::Result<Self> {
-        get_expr_from_meta(meta)?.as_unsigned_integer()
     }
 }
 
@@ -37,7 +25,7 @@ impl FromMeta for IsAccountSigner {
         if let Ok(value) = bool::from_meta(meta) {
             return Ok(value.into());
         }
-        let expr = get_expr_from_meta(meta)?;
+        let expr = meta.as_expr_or_value_expr()?;
         match expr.as_string() {
             Ok(value) if value == "either" => Ok(Self::Either),
             _ => Err(expr.error("expected boolean or `\"either\"`")),
@@ -47,27 +35,12 @@ impl FromMeta for IsAccountSigner {
 
 impl FromMeta for BytesEncoding {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
-        let expr = get_expr_from_meta(meta)?;
+        let expr = meta.as_expr_or_value_expr()?;
         if let Ok(value) = expr.as_string() {
             if let Ok(encoding) = Self::try_from(value) {
                 return Ok(encoding);
             }
         }
         Err(expr.error("expected one of: \"base16\", \"base58\", \"base64\", \"utf8\""))
-    }
-}
-
-pub fn get_expr_from_meta(meta: &Meta) -> syn::Result<&Expr> {
-    match meta {
-        Meta::Expr(expr) => Ok(expr),
-        _ => meta.as_path_value()?.value.as_expr(),
-    }
-}
-
-pub fn get_expr_from_meta_with_path_lists_as_arrays(meta: &Meta) -> syn::Result<Expr> {
-    match meta {
-        Meta::Expr(expr) => Ok(expr.clone()),
-        Meta::PathList(pl) => Ok(pl.as_expr_array()?.into()),
-        _ => meta.as_path_value()?.value.as_expr().cloned(),
     }
 }

--- a/codama-syn-helpers/src/meta.rs
+++ b/codama-syn-helpers/src/meta.rs
@@ -117,6 +117,14 @@ impl Meta {
         }
     }
 
+    pub fn as_value(&self) -> syn::Result<&Meta> {
+        self.as_path_value().map(|pv| pv.value.as_ref())
+    }
+
+    pub fn as_expr_or_value_expr(&self) -> syn::Result<&Expr> {
+        self.as_expr().or_else(|_| self.as_value()?.as_expr())
+    }
+
     pub fn as_expr(&self) -> syn::Result<&Expr> {
         match self {
             Meta::Expr(expr) => Ok(expr),


### PR DESCRIPTION
This PR refactors some of the meta helpers to be more explicit about what we expect the format of the attribute to be when parsing it.