### PR TITLE
Add `bytes` type directive

### DIFF
--- a/codama-attributes/src/codama_directives/type_nodes/bytes_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/bytes_type_node.rs
@@ -1,0 +1,31 @@
+use crate::utils::FromMeta;
+use codama_nodes::BytesTypeNode;
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for BytesTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        meta.assert_directive("bytes")?;
+        if !meta.is_path_or_empty_list() {
+            return Err(meta.error("bytes does not accept any input"));
+        }
+        Ok(Self::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+
+    #[test]
+    fn ok() {
+        assert_type!({ bytes }, BytesTypeNode::new().into());
+        assert_type!({ bytes() }, BytesTypeNode::new().into());
+    }
+
+    #[test]
+    fn unexpected_input() {
+        assert_type_err!({ bytes(unexpected) }, "bytes does not accept any input");
+        assert_type_err!({ bytes(foo = 42) }, "bytes does not accept any input");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/mod.rs
@@ -1,4 +1,5 @@
 mod boolean_type_node;
+mod bytes_type_node;
 mod fixed_size_type_node;
 mod number_type_node;
 mod public_key_type_node;

--- a/codama-attributes/src/codama_directives/type_nodes/type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/type_node.rs
@@ -1,7 +1,7 @@
 use crate::utils::FromMeta;
 use codama_nodes::{
-    BooleanTypeNode, FixedSizeTypeNode, NumberTypeNode, PublicKeyTypeNode, RegisteredTypeNode,
-    StringTypeNode, StructFieldTypeNode, StructTypeNode, TypeNode,
+    BooleanTypeNode, BytesTypeNode, FixedSizeTypeNode, NumberTypeNode, PublicKeyTypeNode,
+    RegisteredTypeNode, StringTypeNode, StructFieldTypeNode, StructTypeNode, TypeNode,
 };
 use codama_syn_helpers::{extensions::*, Meta};
 
@@ -9,6 +9,7 @@ impl FromMeta for RegisteredTypeNode {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
         match meta.path_str().as_str() {
             "boolean" => BooleanTypeNode::from_meta(meta).map(Self::from),
+            "bytes" => BytesTypeNode::from_meta(meta).map(Self::from),
             "field" => StructFieldTypeNode::from_meta(meta).map(Self::from),
             "fixed_size" => FixedSizeTypeNode::from_meta(meta).map(Self::from),
             "number" => NumberTypeNode::from_meta(meta).map(Self::from),

--- a/codama-macros/tests/codama_attribute/type_nodes/bytes_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/bytes_type_node/_pass.rs
@@ -1,0 +1,7 @@
+use codama_macros::codama;
+
+#[codama(type = bytes)]
+#[codama(type = bytes())]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/bytes_type_node/with_input.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/bytes_type_node/with_input.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = bytes(foo = 42))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/bytes_type_node/with_input.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/bytes_type_node/with_input.fail.stderr
@@ -1,0 +1,5 @@
+error: bytes does not accept any input
+ --> tests/codama_attribute/type_nodes/bytes_type_node/with_input.fail.rs:3:17
+  |
+3 | #[codama(type = bytes(foo = 42))]
+  |                 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR adds a type directive for `BytesTypeNodes`. Here are some examples.


### Bytes with no size constraint

```rs
pub struct Buffer<'a> {
  pub authority: Pubkey,
  #[codama(type = bytes)]
  pub data: &'a [u8],
}
```

### Bytes with size prefix

```rs
pub struct Buffer<'a> {
  pub authority: Pubkey,
  #[codama(type = bytes)]
  #[codama(size_prefix = number(u32))]
  pub data: &'a [u8],
}
```