### PR TITLE
Fix large size difference between variants

### DIFF
--- a/codama-attributes/src/attributes.rs
+++ b/codama-attributes/src/attributes.rs
@@ -26,7 +26,7 @@ impl<'a> Attributes<'a> {
 
         for attribute in self.0.iter().rev() {
             if let Attribute::Codama(attribute) = attribute {
-                match &attribute.directive {
+                match attribute.directive.as_ref() {
                     CodamaDirective::Type(_) if !has_seen_type => has_seen_type = true,
                     CodamaDirective::Type(_)
                     | CodamaDirective::Encoding(_)

--- a/codama-attributes/src/codama_attribute.rs
+++ b/codama-attributes/src/codama_attribute.rs
@@ -5,7 +5,7 @@ use codama_syn_helpers::extensions::*;
 #[derive(Debug, PartialEq)]
 pub struct CodamaAttribute<'a> {
     pub ast: &'a syn::Attribute,
-    pub directive: CodamaDirective,
+    pub directive: Box<CodamaDirective>,
 }
 
 impl<'a> CodamaAttribute<'a> {
@@ -24,7 +24,7 @@ impl<'a> CodamaAttribute<'a> {
         list.each(|ref meta| directive.set(CodamaDirective::parse(meta, ctx)?, meta))?;
         Ok(Self {
             ast,
-            directive: directive.take(attr)?,
+            directive: Box::new(directive.take(attr)?),
         })
     }
 }
@@ -56,7 +56,10 @@ mod tests {
         let attribute = CodamaAttribute::parse(&ast, &ctx).unwrap();
 
         assert_eq!(attribute.ast, &ast);
-        assert!(matches!(attribute.directive, CodamaDirective::Type(_)));
+        assert!(matches!(
+            attribute.directive.as_ref(),
+            CodamaDirective::Type(_)
+        ));
     }
 
     #[test]
@@ -67,6 +70,9 @@ mod tests {
         let attribute = CodamaAttribute::parse(&ast, &ctx).unwrap();
 
         assert_eq!(attribute.ast, &ast);
-        assert!(matches!(attribute.directive, CodamaDirective::Type(_)));
+        assert!(matches!(
+            attribute.directive.as_ref(),
+            CodamaDirective::Type(_)
+        ));
     }
 }

--- a/codama-attributes/src/codama_directives/account_directive.rs
+++ b/codama-attributes/src/codama_directives/account_directive.rs
@@ -61,7 +61,7 @@ impl<'a> TryFrom<&'a CodamaAttribute<'a>> for &'a AccountDirective {
     type Error = CodamaError;
 
     fn try_from(attribute: &'a CodamaAttribute) -> Result<Self, Self::Error> {
-        match attribute.directive {
+        match attribute.directive.as_ref() {
             CodamaDirective::Account(ref a) => Ok(a),
             _ => Err(CodamaError::InvalidCodamaDirective {
                 expected: "account".to_string(),

--- a/codama-attributes/src/codama_directives/argument_directive.rs
+++ b/codama-attributes/src/codama_directives/argument_directive.rs
@@ -42,7 +42,7 @@ impl<'a> TryFrom<&'a CodamaAttribute<'a>> for &'a ArgumentDirective {
     type Error = CodamaError;
 
     fn try_from(attribute: &'a CodamaAttribute) -> Result<Self, Self::Error> {
-        match attribute.directive {
+        match attribute.directive.as_ref() {
             CodamaDirective::Argument(ref a) => Ok(a),
             _ => Err(CodamaError::InvalidCodamaDirective {
                 expected: "argument".to_string(),

--- a/codama-attributes/src/codama_directives/default_value_directive.rs
+++ b/codama-attributes/src/codama_directives/default_value_directive.rs
@@ -49,7 +49,7 @@ impl<'a> TryFrom<&'a CodamaAttribute<'a>> for &'a DefaultValueDirective {
     type Error = CodamaError;
 
     fn try_from(attribute: &'a CodamaAttribute) -> Result<Self, Self::Error> {
-        match attribute.directive {
+        match attribute.directive.as_ref() {
             CodamaDirective::DefaultValue(ref a) => Ok(a),
             _ => Err(CodamaError::InvalidCodamaDirective {
                 expected: "default_value".to_string(),

--- a/codama-attributes/src/codama_directives/discriminator_directive.rs
+++ b/codama-attributes/src/codama_directives/discriminator_directive.rs
@@ -103,7 +103,7 @@ impl<'a> TryFrom<&'a CodamaAttribute<'a>> for &'a DiscriminatorDirective {
     type Error = CodamaError;
 
     fn try_from(attribute: &'a CodamaAttribute) -> Result<Self, Self::Error> {
-        match attribute.directive {
+        match attribute.directive.as_ref() {
             CodamaDirective::Discriminator(ref a) => Ok(a),
             _ => Err(CodamaError::InvalidCodamaDirective {
                 expected: "discriminator".to_string(),

--- a/codama-attributes/src/codama_directives/encoding_directive.rs
+++ b/codama-attributes/src/codama_directives/encoding_directive.rs
@@ -22,7 +22,7 @@ impl<'a> TryFrom<&'a CodamaAttribute<'a>> for &'a EncodingDirective {
     type Error = CodamaError;
 
     fn try_from(attribute: &'a CodamaAttribute) -> Result<Self, Self::Error> {
-        match attribute.directive {
+        match attribute.directive.as_ref() {
             CodamaDirective::Encoding(ref a) => Ok(a),
             _ => Err(CodamaError::InvalidCodamaDirective {
                 expected: "encoding".to_string(),

--- a/codama-attributes/src/codama_directives/enum_discriminator_directive.rs
+++ b/codama-attributes/src/codama_directives/enum_discriminator_directive.rs
@@ -53,7 +53,7 @@ impl<'a> TryFrom<&'a CodamaAttribute<'a>> for &'a EnumDiscriminatorDirective {
     type Error = CodamaError;
 
     fn try_from(attribute: &'a CodamaAttribute) -> Result<Self, Self::Error> {
-        match attribute.directive {
+        match attribute.directive.as_ref() {
             CodamaDirective::EnumDiscriminator(ref a) => Ok(a),
             _ => Err(CodamaError::InvalidCodamaDirective {
                 expected: "enum_discriminator".to_string(),

--- a/codama-attributes/src/codama_directives/error_directive.rs
+++ b/codama-attributes/src/codama_directives/error_directive.rs
@@ -48,7 +48,7 @@ impl<'a> TryFrom<&'a CodamaAttribute<'a>> for &'a ErrorDirective {
     type Error = CodamaError;
 
     fn try_from(attribute: &'a CodamaAttribute) -> Result<Self, Self::Error> {
-        match attribute.directive {
+        match attribute.directive.as_ref() {
             CodamaDirective::Error(ref a) => Ok(a),
             _ => Err(CodamaError::InvalidCodamaDirective {
                 expected: "error".to_string(),

--- a/codama-attributes/src/codama_directives/field_directive.rs
+++ b/codama-attributes/src/codama_directives/field_directive.rs
@@ -42,7 +42,7 @@ impl<'a> TryFrom<&'a CodamaAttribute<'a>> for &'a FieldDirective {
     type Error = CodamaError;
 
     fn try_from(attribute: &'a CodamaAttribute) -> Result<Self, Self::Error> {
-        match attribute.directive {
+        match attribute.directive.as_ref() {
             CodamaDirective::Field(ref a) => Ok(a),
             _ => Err(CodamaError::InvalidCodamaDirective {
                 expected: "field".to_string(),

--- a/codama-attributes/src/codama_directives/fixed_size_directive.rs
+++ b/codama-attributes/src/codama_directives/fixed_size_directive.rs
@@ -20,7 +20,7 @@ impl<'a> TryFrom<&'a CodamaAttribute<'a>> for &'a FixedSizeDirective {
     type Error = CodamaError;
 
     fn try_from(attribute: &'a CodamaAttribute) -> Result<Self, Self::Error> {
-        match attribute.directive {
+        match attribute.directive.as_ref() {
             CodamaDirective::FixedSize(ref a) => Ok(a),
             _ => Err(CodamaError::InvalidCodamaDirective {
                 expected: "fixed_size".to_string(),

--- a/codama-attributes/src/codama_directives/name_directive.rs
+++ b/codama-attributes/src/codama_directives/name_directive.rs
@@ -21,7 +21,7 @@ impl<'a> TryFrom<&'a CodamaAttribute<'a>> for &'a NameDirective {
     type Error = CodamaError;
 
     fn try_from(attribute: &'a CodamaAttribute) -> Result<Self, Self::Error> {
-        match attribute.directive {
+        match attribute.directive.as_ref() {
             CodamaDirective::Name(ref a) => Ok(a),
             _ => Err(CodamaError::InvalidCodamaDirective {
                 expected: "name".to_string(),

--- a/codama-attributes/src/codama_directives/pda_directive.rs
+++ b/codama-attributes/src/codama_directives/pda_directive.rs
@@ -25,7 +25,7 @@ impl<'a> TryFrom<&'a CodamaAttribute<'a>> for &'a PdaDirective {
     type Error = CodamaError;
 
     fn try_from(attribute: &'a CodamaAttribute) -> Result<Self, Self::Error> {
-        match attribute.directive {
+        match attribute.directive.as_ref() {
             CodamaDirective::Pda(ref a) => Ok(a),
             _ => Err(CodamaError::InvalidCodamaDirective {
                 expected: "seed".to_string(),

--- a/codama-attributes/src/codama_directives/seed_directive.rs
+++ b/codama-attributes/src/codama_directives/seed_directive.rs
@@ -86,7 +86,7 @@ impl<'a> TryFrom<&'a CodamaAttribute<'a>> for &'a SeedDirective {
     type Error = CodamaError;
 
     fn try_from(attribute: &'a CodamaAttribute) -> Result<Self, Self::Error> {
-        match attribute.directive {
+        match attribute.directive.as_ref() {
             CodamaDirective::Seed(ref a) => Ok(a),
             _ => Err(CodamaError::InvalidCodamaDirective {
                 expected: "seed".to_string(),

--- a/codama-attributes/src/codama_directives/size_prefix_directive.rs
+++ b/codama-attributes/src/codama_directives/size_prefix_directive.rs
@@ -24,7 +24,7 @@ impl<'a> TryFrom<&'a CodamaAttribute<'a>> for &'a SizePrefixDirective {
     type Error = CodamaError;
 
     fn try_from(attribute: &'a CodamaAttribute) -> Result<Self, Self::Error> {
-        match attribute.directive {
+        match attribute.directive.as_ref() {
             CodamaDirective::SizePrefix(ref a) => Ok(a),
             _ => Err(CodamaError::InvalidCodamaDirective {
                 expected: "size_prefix".to_string(),

--- a/codama-attributes/src/codama_directives/type_directive.rs
+++ b/codama-attributes/src/codama_directives/type_directive.rs
@@ -21,7 +21,7 @@ impl<'a> TryFrom<&'a CodamaAttribute<'a>> for &'a TypeDirective {
     type Error = CodamaError;
 
     fn try_from(attribute: &'a CodamaAttribute) -> Result<Self, Self::Error> {
-        match attribute.directive {
+        match attribute.directive.as_ref() {
             CodamaDirective::Type(ref a) => Ok(a),
             _ => Err(CodamaError::InvalidCodamaDirective {
                 expected: "type".to_string(),

--- a/codama-korok-visitors/src/apply_type_modifiers_visitor.rs
+++ b/codama-korok-visitors/src/apply_type_modifiers_visitor.rs
@@ -107,7 +107,7 @@ fn apply_type_modifiers(mut korok: KorokMut) -> CodamaResult<()> {
 }
 
 fn apply_type_modifier(input: ApplyAttributeInput) -> CodamaResult<Option<Node>> {
-    match &input.attribute.directive {
+    match input.attribute.directive.as_ref() {
         CodamaDirective::Encoding(directive) => apply_encoding_directive(directive, input),
         CodamaDirective::FixedSize(directive) => apply_fixed_size_directive(directive, input),
         CodamaDirective::SizePrefix(directive) => apply_size_prefix_directive(directive, input),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.91.1"


### PR DESCRIPTION
This PR fixes a clippy error that complains about a large size difference in the variances of the `Attribute` enum.