### PR TITLE
Add `CodamaPdaHelpers` derive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +111,12 @@ dependencies = [
  "serde",
  "toml",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -232,9 +247,12 @@ dependencies = [
  "codama-attributes",
  "codama-errors",
  "codama-koroks",
+ "codama-nodes",
  "codama-stores",
+ "codama-syn-helpers",
  "proc-macro2",
  "quote",
+ "solana-address",
  "syn",
  "trybuild",
 ]
@@ -305,6 +323,7 @@ version = "0.8.0"
 dependencies = [
  "codama-errors",
  "derive_more",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -326,6 +345,53 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rand_core",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "derive_more"
@@ -360,6 +426,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "dissimilar"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,12 +448,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "float-cmp"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -512,6 +604,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,10 +639,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -588,10 +701,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2-const-stable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
+
+[[package]]
+name = "solana-address"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f67735365edc7fb19ed74ec950597107c8ee9cbfebac57b8868b3e78fb6df16"
+dependencies = [
+ "curve25519-dalek",
+ "sha2-const-stable",
+ "solana-define-syscall 5.0.0",
+ "solana-program-error",
+ "solana-sha256-hasher",
+]
+
+[[package]]
+name = "solana-define-syscall"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
+
+[[package]]
+name = "solana-define-syscall"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03aacdd7a61e2109887a7a7f046caebafce97ddf1150f33722eeac04f9039c73"
+
+[[package]]
+name = "solana-hash"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8064ea1d591ec791be95245058ca40f4f5345d390c200069d0f79bbf55bfae55"
+
+[[package]]
+name = "solana-program-error"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f04fa578707b3612b095f0c8e19b66a1233f7c42ca8082fcb3b745afcc0add6"
+
+[[package]]
+name = "solana-sha256-hasher"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db7dc3011ea4c0334aaaa7e7128cb390ecf546b28d412e9bf2064680f57f588f"
+dependencies = [
+ "sha2",
+ "solana-define-syscall 4.0.1",
+ "solana-hash",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -696,6 +880,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -706,6 +896,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
@@ -827,3 +1023,9 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"

--- a/codama-macros/Cargo.toml
+++ b/codama-macros/Cargo.toml
@@ -14,16 +14,19 @@ name = "tests"
 path = "tests/mod.rs"
 
 [dev-dependencies]
+solana-address = { version = "2.4.0", features = ["curve25519"] }
 trybuild = { version = "1.0.49", features = ["diff"] }
 
 [target.'cfg(not(target_os = "solana"))'.dependencies]
 codama-attributes = { version = "0.8.0", path = "../codama-attributes" }
 codama-errors = { version = "0.8.0", path = "../codama-errors" }
 codama-koroks = { version = "0.8.0", path = "../codama-koroks" }
+codama-nodes = { version = "0.8.0", path = "../codama-nodes" }
 codama-stores = { version = "0.8.0", path = "../codama-stores" }
+codama-syn-helpers = { version = "0.8.0", path = "../codama-syn-helpers" }
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "2.0", features = ["extra-traits"] }
+syn = { version = "2.0", features = ["extra-traits", "full"] }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/codama-macros/src/lib.rs
+++ b/codama-macros/src/lib.rs
@@ -3,6 +3,8 @@ use proc_macro::TokenStream;
 mod attributes;
 #[cfg(not(target_os = "solana"))]
 mod derives;
+#[cfg(not(target_os = "solana"))]
+mod pda_helpers;
 
 fn codama_derive(input: TokenStream) -> TokenStream {
     #[cfg(not(target_os = "solana"))]
@@ -55,6 +57,20 @@ pub fn codama_instructions_derive(input: TokenStream) -> TokenStream {
 #[proc_macro_derive(CodamaPda, attributes(codama))]
 pub fn codama_pda_derive(input: TokenStream) -> TokenStream {
     codama_derive(input)
+}
+
+#[proc_macro_derive(CodamaPdaHelpers, attributes(codama))]
+pub fn codama_pda_helpers_derive(input: TokenStream) -> TokenStream {
+    #[cfg(not(target_os = "solana"))]
+    {
+        pda_helpers::codama_pda_helpers_derive_impl(input.into())
+            .unwrap_or_else(codama_errors::CodamaError::into_compile_error)
+            .into()
+    }
+    #[cfg(target_os = "solana")]
+    {
+        input
+    }
 }
 
 #[proc_macro_derive(CodamaType, attributes(codama))]

--- a/codama-macros/src/pda_helpers.rs
+++ b/codama-macros/src/pda_helpers.rs
@@ -1,0 +1,502 @@
+use codama_attributes::{
+    Attribute, AttributeContext, Attributes, CodamaDirective, Resolvable, SeedDirectiveType,
+};
+use codama_errors::CodamaResult;
+use codama_nodes::{BytesEncoding, Endian, Number, NumberFormat, TypeNode, ValueNode};
+use codama_syn_helpers::{snake_case_ident, string_to_ident, to_snake_case};
+use proc_macro2::{Literal, TokenStream};
+use quote::quote;
+use std::collections::HashMap;
+
+/// The result of parsing all `#[codama(seed(...))]` attributes on a struct.
+struct ParsedSeeds {
+    /// Ordered seed expressions (constants and variable references) that map
+    /// directly to the elements of the generated `seeds()` array.
+    entries: Vec<ParsedSeedEntry>,
+    /// Deduplicated variable seed parameters that become function arguments
+    /// on the generated helper methods.
+    parameters: Vec<SeedParameter>,
+}
+
+/// A single seed entry producing a `&[u8]` expression in the generated code.
+struct ParsedSeedEntry {
+    raw_expr: TokenStream,
+}
+
+/// A variable seed that becomes a function parameter on generated methods.
+#[derive(Debug)]
+struct SeedParameter {
+    ident: syn::Ident,
+}
+
+/// Entry point for the `#[derive(CodamaPdaHelpers)]` macro. Parses seed
+/// attributes from the struct and generates an `impl` block with PDA helper methods.
+pub fn codama_pda_helpers_derive_impl(input: TokenStream) -> CodamaResult<TokenStream> {
+    let item = syn::parse2(input)?;
+    let item_struct = match &item {
+        syn::Item::Struct(item_struct) => item_struct,
+        other => {
+            return Err(syn::Error::new_spanned(
+                other,
+                "CodamaPdaHelpers currently supports structs only",
+            )
+            .into())
+        }
+    };
+
+    if !item_struct.generics.params.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &item_struct.generics,
+            "CodamaPdaHelpers does not support generic structs",
+        )
+        .into());
+    }
+
+    // Extract only the #[codama(seed(...))] attributes from the struct.
+    let attributes = Attributes::parse(&item_struct.attrs, AttributeContext::Item(&item))?;
+    let seed_attributes = attributes
+        .iter()
+        .filter_map(|attribute| match attribute {
+            Attribute::Codama(codama_attribute)
+                if matches!(
+                    codama_attribute.directive.as_ref(),
+                    CodamaDirective::Seed(_)
+                ) =>
+            {
+                Some(codama_attribute)
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    if seed_attributes.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &item_struct.ident,
+            "CodamaPdaHelpers requires at least one #[codama(seed(...))] attribute",
+        )
+        .into());
+    }
+
+    // Convert seed attributes into expressions and parameters
+    let parsed_seeds = parse_seed_sequence(&seed_attributes)?;
+
+    // generate the impl block with all helper methods.
+    Ok(generate_impl(&item_struct.ident, &parsed_seeds))
+}
+
+/// Walks the seed attributes in declaration order and builds two lists:
+/// - `entries`: one expression per seed, in order, for the generated `seeds()` array
+/// - `parameters`: deduplicated variable seeds that become function arguments
+fn parse_seed_sequence(
+    seed_attributes: &[&codama_attributes::CodamaAttribute<'_>],
+) -> CodamaResult<ParsedSeeds> {
+    let mut entries = Vec::with_capacity(seed_attributes.len());
+    let mut parameters = Vec::new();
+
+    // Maps seed name -> generated ident, for deduplicating repeated seeds
+    let mut parameters_by_name = HashMap::<String, syn::Ident>::new();
+
+    // Maps generated ident string -> original seed name, for collision detection.
+    // Pre-seeded with "bump" since the generated methods always use that name.
+    let mut generated_names = HashMap::<String, String>::new();
+    generated_names.insert("bump".to_string(), "<generated bump parameter>".to_string());
+
+    for seed_attribute in seed_attributes {
+        let CodamaDirective::Seed(seed_directive) = seed_attribute.directive.as_ref() else {
+            unreachable!("parse_seed_sequence is only called with seed directives");
+        };
+
+        let entry = match &seed_directive.seed {
+            // Constant seeds are encoded as byte literals at compile time.
+            SeedDirectiveType::Constant { r#type, value } => {
+                parse_constant_seed(seed_attribute, r#type, value)?
+            }
+            // Variable and linked seeds become runtime function parameters.
+            SeedDirectiveType::Variable { name, .. } | SeedDirectiveType::Linked(name) => {
+                // Reuse an existing parameter if this seed name was already seen,
+                // otherwise create a new one and check for identifier collisions.
+                let ident = match parameters_by_name.get(name) {
+                    Some(ident) => ident.clone(),
+                    None => {
+                        let ident = seed_name_to_ident(name, parameters.len());
+                        let ident_key = ident.to_string();
+                        if let Some(existing_name) = generated_names.get(&ident_key) {
+                            return Err(syn::Error::new_spanned(
+                                seed_attribute.ast,
+                                format!(
+                                    "CodamaPdaHelpers generated a duplicate parameter name `{ident_key}` from seed `{name}`; it conflicts with `{existing_name}`"
+                                ),
+                            )
+                            .into());
+                        }
+
+                        generated_names.insert(ident_key, name.clone());
+                        parameters_by_name.insert(name.clone(), ident.clone());
+                        parameters.push(SeedParameter {
+                            ident: ident.clone(),
+                        });
+                        ident
+                    }
+                };
+
+                ParsedSeedEntry {
+                    raw_expr: quote! { #ident.as_ref() },
+                }
+            }
+        };
+
+        entries.push(entry);
+    }
+
+    Ok(ParsedSeeds {
+        entries,
+        parameters,
+    })
+}
+
+/// Converts a constant seed's type and value into a byte-string literal
+fn parse_constant_seed(
+    seed_attribute: &codama_attributes::CodamaAttribute<'_>,
+    r#type: &Resolvable<TypeNode>,
+    value: &Resolvable<ValueNode>,
+) -> CodamaResult<ParsedSeedEntry> {
+    // Ensure both type and value are fully resolved (not plugin directives)
+    let type_node = r#type.try_resolved().map_err(|error| {
+        syn::Error::new_spanned(
+            seed_attribute.ast,
+            format!("CodamaPdaHelpers requires a resolved constant seed type: {error}"),
+        )
+    })?;
+    let value_node = value.try_resolved().map_err(|error| {
+        syn::Error::new_spanned(
+            seed_attribute.ast,
+            format!("CodamaPdaHelpers requires a resolved constant seed value: {error}"),
+        )
+    })?;
+
+    match (type_node, value_node) {
+        // UTF-8 string seeds: "vault" -> b"vault"
+        (TypeNode::String(string_type), ValueNode::String(string_value))
+            if string_type.encoding == BytesEncoding::Utf8 =>
+        {
+            let literal = Literal::byte_string(string_value.string.as_bytes());
+            Ok(ParsedSeedEntry {
+                raw_expr: quote! { #literal },
+            })
+        }
+        // Integer seeds: encode the value as bytes
+        (TypeNode::Number(number_type), ValueNode::Number(number_value)) => {
+            let bytes = encode_number_seed_bytes(number_type.format, number_type.endian, number_value.number)
+                .map_err(|message| syn::Error::new_spanned(seed_attribute.ast, message))?;
+            let literal = Literal::byte_string(&bytes);
+            Ok(ParsedSeedEntry {
+                raw_expr: quote! { #literal },
+            })
+        }
+        _ => Err(syn::Error::new_spanned(
+            seed_attribute.ast,
+            "CodamaPdaHelpers currently supports constant seeds only for string(utf8) and integer number(...) types",
+        )
+        .into()),
+    }
+}
+
+/// Encodes a numeric constant seed value into its byte representation.
+fn encode_number_seed_bytes(
+    format: NumberFormat,
+    endian: Endian,
+    number: Number,
+) -> Result<Vec<u8>, String> {
+    macro_rules! encode_unsigned {
+        ($ty:ty, $label:expr) => {{
+            let n = <$ty>::try_from(as_unsigned(number, $label)?).map_err(|_| {
+                format!(
+                    "CodamaPdaHelpers constant number({}) is out of range",
+                    $label
+                )
+            })?;
+            Ok(match endian {
+                Endian::Little => n.to_le_bytes(),
+                Endian::Big => n.to_be_bytes(),
+            }
+            .to_vec())
+        }};
+    }
+
+    macro_rules! encode_signed {
+        ($ty:ty, $label:expr) => {{
+            let n = <$ty>::try_from(as_signed(number, $label)?).map_err(|_| {
+                format!(
+                    "CodamaPdaHelpers constant number({}) is out of range",
+                    $label
+                )
+            })?;
+            Ok(match endian {
+                Endian::Little => n.to_le_bytes(),
+                Endian::Big => n.to_be_bytes(),
+            }
+            .to_vec())
+        }};
+    }
+
+    match format {
+        NumberFormat::U8 => encode_unsigned!(u8, "u8"),
+        NumberFormat::U16 => encode_unsigned!(u16, "u16"),
+        NumberFormat::U32 => encode_unsigned!(u32, "u32"),
+        NumberFormat::U64 => encode_unsigned!(u64, "u64"),
+        NumberFormat::U128 => encode_unsigned!(u128, "u128"),
+        NumberFormat::I8 => encode_signed!(i8, "i8"),
+        NumberFormat::I16 => encode_signed!(i16, "i16"),
+        NumberFormat::I32 => encode_signed!(i32, "i32"),
+        NumberFormat::I64 => encode_signed!(i64, "i64"),
+        NumberFormat::I128 => encode_signed!(i128, "i128"),
+        NumberFormat::ShortU16 => Err(
+            "CodamaPdaHelpers does not yet support constant number(short_u16) seeds".to_string(),
+        ),
+        NumberFormat::F32 | NumberFormat::F64 => {
+            Err("CodamaPdaHelpers does not support floating-point constant seeds".to_string())
+        }
+    }
+}
+
+/// Extracts the value from a `Number` as `u64`.
+fn as_unsigned(number: Number, label: &str) -> Result<u64, String> {
+    match number {
+        Number::UnsignedInteger(value) => Ok(value),
+        Number::SignedInteger(_) => Err(format!(
+            "CodamaPdaHelpers constant number({label}) must use an unsigned integer literal"
+        )),
+        Number::Float(_) => Err(format!(
+            "CodamaPdaHelpers constant number({label}) must not use a floating-point literal"
+        )),
+    }
+}
+
+/// Extracts the value from a `Number` as `i64`.
+fn as_signed(number: Number, label: &str) -> Result<i64, String> {
+    match number {
+        Number::SignedInteger(value) => Ok(value),
+        Number::UnsignedInteger(value) => i64::try_from(value)
+            .map_err(|_| format!("CodamaPdaHelpers constant number({label}) is out of range")),
+        Number::Float(_) => Err(format!(
+            "CodamaPdaHelpers constant number({label}) must not use a floating-point literal"
+        )),
+    }
+}
+
+/// Generates the `impl` block containing all PDA helper methods.
+///
+/// Each method has two variants depending on whether there are variable seed
+/// parameters:
+///
+/// ```ignore
+/// // Constant-only seeds:
+/// fn seeds() -> [&'static [u8]; 1] { [b"vault"] }
+///
+/// // With variable seeds:
+/// fn seeds<'a>(authority: &'a (impl AsRef<[u8]> + 'a)) -> [&'a [u8]; 2] {
+///     [b"vault", authority.as_ref()]
+/// }
+/// ```
+///
+/// Generated methods:
+/// - `seeds` / `seeds_with_bump`
+/// - `signer_seeds`
+///
+/// (wrapping `Address` methods)
+/// - `derive_address`
+/// - `create_program_address`
+/// - `find_program_address`
+/// - `try_find_program_address`
+/// - `derive_program_address`
+fn generate_impl(ident: &syn::Ident, parsed_seeds: &ParsedSeeds) -> TokenStream {
+    // Build reusable token fragments from the parsed seeds
+    let param_defs = parsed_seeds
+        .parameters
+        .iter()
+        .map(|parameter| {
+            let ident = &parameter.ident;
+            quote! { #ident: &'a (impl AsRef<[u8]> + 'a) }
+        })
+        .collect::<Vec<_>>();
+    let seed_exprs = parsed_seeds
+        .entries
+        .iter()
+        .map(|entry| entry.raw_expr.clone())
+        .collect::<Vec<_>>();
+    let param_idents = parsed_seeds
+        .parameters
+        .iter()
+        .map(|parameter| parameter.ident.clone())
+        .collect::<Vec<_>>();
+    let seeds_len = parsed_seeds.entries.len();
+    let seeds_with_bump_len = seeds_len + 1;
+
+    // seeds() - returns the seed byte slices as a fixed-size array, without the bump.
+    // This is the base array used by all other helpers.
+    let seeds = if parsed_seeds.parameters.is_empty() {
+        quote! {
+            pub fn seeds() -> [&'static [u8]; #seeds_len] {
+                [#(#seed_exprs),*]
+            }
+        }
+    } else {
+        quote! {
+            #[allow(clippy::needless_lifetimes)]
+            pub fn seeds<'a>(#(#param_defs),*) -> [&'a [u8]; #seeds_len] {
+                [#(#seed_exprs),*]
+            }
+        }
+    };
+
+    // seeds_with_bump() - like seeds() but appends the bump byte slice at the end.
+    // Used by create_program_address and signer_seeds.
+    let seeds_with_bump = quote! {
+        #[allow(clippy::needless_lifetimes)]
+        pub fn seeds_with_bump<'a>(#(#param_defs,)* bump: &'a [u8]) -> [&'a [u8]; #seeds_with_bump_len] {
+            [#(#seed_exprs,)* bump]
+        }
+    };
+
+    // signer_seeds() - like seeds_with_bump(), but converts each element to a
+    // generic type T (e.g. pinocchio::Seed) for use with CPI signing
+    let signer_seeds = quote! {
+        #[allow(clippy::needless_lifetimes)]
+        pub fn signer_seeds<'a, T>(#(#param_defs,)* bump: &'a [u8]) -> [T; #seeds_with_bump_len]
+        where
+            T: From<&'a [u8]>,
+        {
+            Self::seeds_with_bump(#(#param_idents,)* bump).map(T::from)
+        }
+    };
+
+    // derive_address() - computes the PDA address via SHA-256 hashing without
+    // curve validation. Wraps Address::derive_address.
+    let derive_address = quote! {
+        #[allow(clippy::needless_lifetimes)]
+        pub fn derive_address<'a>(
+            #(#param_defs,)*
+            bump: Option<u8>,
+            program_id: &::solana_address::Address,
+        ) -> ::solana_address::Address {
+            ::solana_address::Address::derive_address(
+                &Self::seeds(#(#param_idents),*),
+                bump,
+                program_id,
+            )
+        }
+    };
+
+    // create_program_address() - hashes seeds + bump and validates the result is
+    // off the ed25519 curve (a valid PDA). Wraps Address::create_program_address.
+    let create_program_address = quote! {
+        #[allow(clippy::needless_lifetimes)]
+        pub fn create_program_address<'a>(
+            #(#param_defs,)*
+            bump: u8,
+            program_id: &::solana_address::Address,
+        ) -> Result<::solana_address::Address, ::solana_address::error::AddressError> {
+            let bump_seed = [bump];
+            ::solana_address::Address::create_program_address(
+                &Self::seeds_with_bump(#(#param_idents,)* &bump_seed),
+                program_id,
+            )
+        }
+    };
+
+    // find_program_address() - searches for a valid PDA by trying bumps from 255
+    // down to 0 via create_program_address. Wraps Address::find_program_address.
+    let find_program_address = quote! {
+        #[allow(clippy::needless_lifetimes)]
+        pub fn find_program_address<'a>(
+            #(#param_defs,)*
+            program_id: &::solana_address::Address,
+        ) -> (::solana_address::Address, u8) {
+            ::solana_address::Address::find_program_address(
+                &Self::seeds(#(#param_idents),*),
+                program_id,
+            )
+        }
+    };
+
+    // try_find_program_address() - same bump search as find_program_address() but
+    // returns None instead of panicking. Wraps Address::try_find_program_address.
+    let try_find_program_address = quote! {
+        #[allow(clippy::needless_lifetimes)]
+        pub fn try_find_program_address<'a>(
+            #(#param_defs,)*
+            program_id: &::solana_address::Address,
+        ) -> Option<(::solana_address::Address, u8)> {
+            ::solana_address::Address::try_find_program_address(
+                &Self::seeds(#(#param_idents),*),
+                program_id,
+            )
+        }
+    };
+
+    // derive_program_address() - like try_find_program_address() but uses
+    // derive_address + is_on_curve internally. Wraps Address::derive_program_address.
+    let derive_program_address = quote! {
+        #[allow(clippy::needless_lifetimes)]
+        pub fn derive_program_address<'a>(
+            #(#param_defs,)*
+            program_id: &::solana_address::Address,
+        ) -> Option<(::solana_address::Address, u8)> {
+            ::solana_address::Address::derive_program_address(
+                &Self::seeds(#(#param_idents),*),
+                program_id,
+            )
+        }
+    };
+
+    quote! {
+        impl #ident {
+            #seeds
+
+            #seeds_with_bump
+
+            #signer_seeds
+
+            #derive_address
+
+            #create_program_address
+
+            #find_program_address
+
+            #try_find_program_address
+
+            #derive_program_address
+        }
+    }
+}
+
+/// Converts a seed name (e.g. "tokenProgram", "order-id") into a valid
+/// snake_case Rust identifier. Names that produce an empty result after
+/// conversion (e.g. "!!!") fall back to `seed_{index}`.
+fn seed_name_to_ident(name: &str, index: usize) -> syn::Ident {
+    let snake = to_snake_case(name);
+    if snake.is_empty() {
+        return string_to_ident(&format!("seed_{index}"));
+    }
+    snake_case_ident(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_name_to_ident_uses_snake_case() {
+        assert_eq!(
+            seed_name_to_ident("tokenProgram", 0).to_string(),
+            "token_program"
+        );
+        assert_eq!(seed_name_to_ident("order-id", 0).to_string(), "order_id");
+        assert_eq!(seed_name_to_ident("type", 0).to_string(), "r#type");
+    }
+
+    #[test]
+    fn seed_name_to_ident_falls_back_when_empty() {
+        assert_eq!(seed_name_to_ident("!!!", 3).to_string(), "seed_3");
+    }
+}

--- a/codama-macros/tests/codama_pda_helpers_derive/_pass.rs
+++ b/codama-macros/tests/codama_pda_helpers_derive/_pass.rs
@@ -1,0 +1,183 @@
+use codama_macros::{CodamaAccount, CodamaPda, CodamaPdaHelpers};
+use solana_address::Address;
+
+#[derive(CodamaAccount, CodamaPdaHelpers)]
+#[codama(seed(type = string(utf8), value = "admin_config"))]
+pub struct AdminConfig;
+
+#[derive(CodamaPda, CodamaPdaHelpers)]
+#[codama(seed(type = string(utf8), value = "vault"))]
+#[codama(seed(name = "authority", type = public_key))]
+#[codama(seed(name = "tokenProgram", type = public_key))]
+pub struct Vault;
+
+#[derive(CodamaPda, CodamaPdaHelpers)]
+#[codama(seed(name = "wallet", type = public_key))]
+#[codama(seed(name = "token_program", type = public_key))]
+#[codama(seed(name = "mint", type = public_key))]
+pub struct AssociatedTokenPda;
+
+#[derive(CodamaPda, CodamaPdaHelpers)]
+#[codama(seed(type = string(utf8), value = "prefix"))]
+#[codama(seed(name = "authority", type = public_key))]
+#[codama(seed(type = string(utf8), value = "suffix"))]
+pub struct MixedPda;
+
+#[derive(CodamaPda, CodamaPdaHelpers)]
+#[codama(seed(name = "wallet", type = public_key))]
+#[codama(seed(name = "wallet", type = public_key))]
+pub struct RepeatedWalletPda;
+
+#[derive(CodamaAccount, CodamaPdaHelpers)]
+#[codama(seed(type = string(utf8), value = "whitelist"))]
+#[codama(seed(name = "authority"))]
+pub struct Whitelist {
+    authority: [u8; 32],
+}
+
+#[derive(CodamaPda, CodamaPdaHelpers)]
+#[codama(seed(type = number(u16, le), value = 4660))]
+#[codama(seed(type = number(i16, be), value = -2))]
+#[codama(seed(name = "authority", type = public_key))]
+struct NumberConstantPda;
+
+/// Simulates a framework seed type (like pinocchio::Seed)
+struct Seed<'a>(&'a [u8]);
+impl<'a> From<&'a [u8]> for Seed<'a> {
+    fn from(s: &'a [u8]) -> Self {
+        Seed(s)
+    }
+}
+
+fn main() {
+    let admin_config = AdminConfig::seeds();
+    let _: &[&[u8]] = &admin_config;
+    assert_eq!(admin_config[0], b"admin_config");
+
+    let authority = [1u8; 32];
+    let wallet = [9u8; 32];
+    let token_program = [2u8; 32];
+    let mint = [3u8; 32];
+    let bump = [255u8];
+    let program_id = Address::new_from_array([7u8; 32]);
+
+    let vault = Vault::seeds(&authority, &token_program);
+    let _: &[&[u8]] = &vault;
+    assert_eq!(vault[0], b"vault");
+    assert_eq!(vault[1], authority.as_ref());
+    assert_eq!(vault[2], token_program.as_ref());
+
+    let vault_with_bump = Vault::seeds_with_bump(&authority, &token_program, &bump);
+    let _: &[&[u8]] = &vault_with_bump;
+    assert_eq!(vault_with_bump[3], bump.as_ref());
+
+    let raw = Vault::signer_seeds::<&[u8]>(&authority, &token_program, &bump);
+    assert_eq!(raw[0], b"vault");
+    assert_eq!(raw[3], bump.as_ref());
+
+    let seeds = Vault::signer_seeds::<Seed>(&authority, &token_program, &bump);
+    assert_eq!(seeds[0].0, b"vault");
+
+    let seeds: [Seed; 4] = Vault::signer_seeds(&authority, &token_program, &bump);
+    assert_eq!(seeds[0].0, b"vault");
+
+    let raw = AdminConfig::signer_seeds::<&[u8]>(&bump);
+    assert_eq!(raw[0], b"admin_config");
+    assert_eq!(raw[1], bump.as_ref());
+
+    let (admin_config_address, admin_config_bump) = AdminConfig::find_program_address(&program_id);
+    assert_eq!(
+        AdminConfig::derive_address(Some(admin_config_bump), &program_id),
+        Address::derive_address(&AdminConfig::seeds(), Some(admin_config_bump), &program_id)
+    );
+    assert_eq!(
+        AdminConfig::create_program_address(admin_config_bump, &program_id).unwrap(),
+        Address::create_program_address(
+            &AdminConfig::seeds_with_bump(&[admin_config_bump]),
+            &program_id
+        )
+        .unwrap()
+    );
+    assert_eq!(
+        (admin_config_address, admin_config_bump),
+        Address::find_program_address(&AdminConfig::seeds(), &program_id)
+    );
+    assert_eq!(
+        AdminConfig::try_find_program_address(&program_id),
+        Address::try_find_program_address(&AdminConfig::seeds(), &program_id)
+    );
+    assert_eq!(
+        AdminConfig::derive_program_address(&program_id),
+        Address::derive_program_address(&AdminConfig::seeds(), &program_id)
+    );
+
+    let ata = AssociatedTokenPda::seeds(&wallet, &token_program, &mint);
+    let _: &[&[u8]] = &ata;
+    assert_eq!(
+        ata,
+        [wallet.as_ref(), token_program.as_ref(), mint.as_ref()]
+    );
+
+    let (ata_address, ata_bump) =
+        AssociatedTokenPda::find_program_address(&wallet, &token_program, &mint, &program_id);
+    assert_eq!(
+        AssociatedTokenPda::derive_address(&wallet, &token_program, &mint, Some(ata_bump), &program_id),
+        Address::derive_address(
+            &AssociatedTokenPda::seeds(&wallet, &token_program, &mint),
+            Some(ata_bump),
+            &program_id
+        )
+    );
+    assert_eq!(
+        AssociatedTokenPda::create_program_address(&wallet, &token_program, &mint, ata_bump, &program_id)
+            .unwrap(),
+        Address::create_program_address(
+            &AssociatedTokenPda::seeds_with_bump(&wallet, &token_program, &mint, &[ata_bump]),
+            &program_id
+        )
+        .unwrap()
+    );
+    assert_eq!(
+        (ata_address, ata_bump),
+        Address::find_program_address(
+            &AssociatedTokenPda::seeds(&wallet, &token_program, &mint),
+            &program_id
+        )
+    );
+    assert_eq!(
+        AssociatedTokenPda::try_find_program_address(&wallet, &token_program, &mint, &program_id),
+        Address::try_find_program_address(
+            &AssociatedTokenPda::seeds(&wallet, &token_program, &mint),
+            &program_id
+        )
+    );
+    assert_eq!(
+        AssociatedTokenPda::derive_program_address(&wallet, &token_program, &mint, &program_id),
+        Address::derive_program_address(
+            &AssociatedTokenPda::seeds(&wallet, &token_program, &mint),
+            &program_id
+        )
+    );
+
+    let ata_signer =
+        AssociatedTokenPda::signer_seeds::<Seed>(&wallet, &token_program, &mint, &bump);
+    assert_eq!(ata_signer[0].0, wallet.as_ref());
+    assert_eq!(ata_signer[3].0, bump.as_ref());
+
+    let mixed = MixedPda::seeds(&authority);
+    assert_eq!(mixed[0], b"prefix");
+    assert_eq!(mixed[1], authority.as_ref());
+    assert_eq!(mixed[2], b"suffix");
+
+    let repeated = RepeatedWalletPda::seeds(&wallet);
+    assert_eq!(repeated, [wallet.as_ref(), wallet.as_ref()]);
+
+    let whitelist = Whitelist::seeds(&authority);
+    assert_eq!(whitelist[0], b"whitelist");
+    assert_eq!(whitelist[1], authority.as_ref());
+
+    let number_seeds = NumberConstantPda::seeds(&authority);
+    assert_eq!(number_seeds[0], &[0x34, 0x12]);
+    assert_eq!(number_seeds[1], &[0xff, 0xfe]);
+    assert_eq!(number_seeds[2], authority.as_ref());
+}

--- a/codama-macros/tests/codama_pda_helpers_derive/bump_collision.fail.rs
+++ b/codama-macros/tests/codama_pda_helpers_derive/bump_collision.fail.rs
@@ -1,0 +1,8 @@
+use codama_macros::{CodamaPda, CodamaPdaHelpers};
+
+#[derive(CodamaPda, CodamaPdaHelpers)]
+#[codama(seed(type = string(utf8), value = "counter"))]
+#[codama(seed(name = "bump", type = number(u8)))]
+pub struct Counter;
+
+fn main() {}

--- a/codama-macros/tests/codama_pda_helpers_derive/bump_collision.fail.stderr
+++ b/codama-macros/tests/codama_pda_helpers_derive/bump_collision.fail.stderr
@@ -1,0 +1,5 @@
+error: CodamaPdaHelpers generated a duplicate parameter name `bump` from seed `bump`; it conflicts with `<generated bump parameter>`
+ --> tests/codama_pda_helpers_derive/bump_collision.fail.rs:5:1
+  |
+5 | #[codama(seed(name = "bump", type = number(u8)))]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/codama-macros/tests/codama_pda_helpers_derive/duplicate_method.fail.rs
+++ b/codama-macros/tests/codama_pda_helpers_derive/duplicate_method.fail.rs
@@ -1,0 +1,13 @@
+use codama_macros::{CodamaAccount, CodamaPdaHelpers};
+
+#[derive(CodamaAccount, CodamaPdaHelpers)]
+#[codama(seed(type = string(utf8), value = "counter"))]
+pub struct Counter;
+
+impl Counter {
+    pub fn seeds() -> [&'static [u8]; 0] {
+        []
+    }
+}
+
+fn main() {}

--- a/codama-macros/tests/codama_pda_helpers_derive/duplicate_method.fail.stderr
+++ b/codama-macros/tests/codama_pda_helpers_derive/duplicate_method.fail.stderr
@@ -1,0 +1,28 @@
+error[E0592]: duplicate definitions with name `seeds`
+ --> tests/codama_pda_helpers_derive/duplicate_method.fail.rs:3:25
+  |
+3 | #[derive(CodamaAccount, CodamaPdaHelpers)]
+  |                         ^^^^^^^^^^^^^^^^ duplicate definitions for `seeds`
+...
+8 |     pub fn seeds() -> [&'static [u8]; 0] {
+  |     ------------------------------------ other definition for `seeds`
+  |
+  = note: this error originates in the derive macro `CodamaPdaHelpers` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0034]: multiple applicable items in scope
+ --> tests/codama_pda_helpers_derive/duplicate_method.fail.rs:3:25
+  |
+3 | #[derive(CodamaAccount, CodamaPdaHelpers)]
+  |                         ^^^^^^^^^^^^^^^^ multiple `seeds` found
+  |
+note: candidate #1 is defined in an impl for the type `Counter`
+ --> tests/codama_pda_helpers_derive/duplicate_method.fail.rs:3:25
+  |
+3 | #[derive(CodamaAccount, CodamaPdaHelpers)]
+  |                         ^^^^^^^^^^^^^^^^
+note: candidate #2 is defined in an impl for the type `Counter`
+ --> tests/codama_pda_helpers_derive/duplicate_method.fail.rs:8:5
+  |
+8 |     pub fn seeds() -> [&'static [u8]; 0] {
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  = note: this error originates in the derive macro `CodamaPdaHelpers` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/codama-macros/tests/codama_pda_helpers_derive/duplicate_param.fail.rs
+++ b/codama-macros/tests/codama_pda_helpers_derive/duplicate_param.fail.rs
@@ -1,0 +1,9 @@
+use codama_macros::{CodamaPda, CodamaPdaHelpers};
+
+#[derive(CodamaPda, CodamaPdaHelpers)]
+#[codama(seed(type = string(utf8), value = "counter"))]
+#[codama(seed(name = "token-program", type = public_key))]
+#[codama(seed(name = "token_program", type = public_key))]
+pub struct Counter;
+
+fn main() {}

--- a/codama-macros/tests/codama_pda_helpers_derive/duplicate_param.fail.stderr
+++ b/codama-macros/tests/codama_pda_helpers_derive/duplicate_param.fail.stderr
@@ -1,0 +1,5 @@
+error: CodamaPdaHelpers generated a duplicate parameter name `token_program` from seed `token_program`; it conflicts with `token-program`
+ --> tests/codama_pda_helpers_derive/duplicate_param.fail.rs:6:1
+  |
+6 | #[codama(seed(name = "token_program", type = public_key))]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/codama-macros/tests/codama_pda_helpers_derive/enum_target.fail.rs
+++ b/codama-macros/tests/codama_pda_helpers_derive/enum_target.fail.rs
@@ -1,0 +1,7 @@
+use codama_macros::{CodamaPda, CodamaPdaHelpers};
+
+#[derive(CodamaPda, CodamaPdaHelpers)]
+#[codama(seed(type = string(utf8), value = "counter"))]
+pub enum Counter {}
+
+fn main() {}

--- a/codama-macros/tests/codama_pda_helpers_derive/enum_target.fail.stderr
+++ b/codama-macros/tests/codama_pda_helpers_derive/enum_target.fail.stderr
@@ -1,0 +1,6 @@
+error: CodamaPdaHelpers currently supports structs only
+ --> tests/codama_pda_helpers_derive/enum_target.fail.rs:4:1
+  |
+4 | / #[codama(seed(type = string(utf8), value = "counter"))]
+5 | | pub enum Counter {}
+  | |___________________^

--- a/codama-macros/tests/codama_pda_helpers_derive/generic_struct.fail.rs
+++ b/codama-macros/tests/codama_pda_helpers_derive/generic_struct.fail.rs
@@ -1,0 +1,7 @@
+use codama_macros::{CodamaPda, CodamaPdaHelpers};
+
+#[derive(CodamaPda, CodamaPdaHelpers)]
+#[codama(seed(type = string(utf8), value = "counter"))]
+pub struct Counter<T>(T);
+
+fn main() {}

--- a/codama-macros/tests/codama_pda_helpers_derive/generic_struct.fail.stderr
+++ b/codama-macros/tests/codama_pda_helpers_derive/generic_struct.fail.stderr
@@ -1,0 +1,5 @@
+error: CodamaPdaHelpers does not support generic structs
+ --> tests/codama_pda_helpers_derive/generic_struct.fail.rs:5:19
+  |
+5 | pub struct Counter<T>(T);
+  |                   ^^^

--- a/codama-macros/tests/codama_pda_helpers_derive/no_seed_attributes.fail.rs
+++ b/codama-macros/tests/codama_pda_helpers_derive/no_seed_attributes.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::{CodamaPda, CodamaPdaHelpers};
+
+#[derive(CodamaPda, CodamaPdaHelpers)]
+pub struct Counter;
+
+fn main() {}

--- a/codama-macros/tests/codama_pda_helpers_derive/no_seed_attributes.fail.stderr
+++ b/codama-macros/tests/codama_pda_helpers_derive/no_seed_attributes.fail.stderr
@@ -1,0 +1,5 @@
+error: CodamaPdaHelpers requires at least one #[codama(seed(...))] attribute
+ --> tests/codama_pda_helpers_derive/no_seed_attributes.fail.rs:4:12
+  |
+4 | pub struct Counter;
+  |            ^^^^^^^

--- a/codama-macros/tests/codama_pda_helpers_derive/unsupported_constant.fail.rs
+++ b/codama-macros/tests/codama_pda_helpers_derive/unsupported_constant.fail.rs
@@ -1,0 +1,7 @@
+use codama_macros::{CodamaPda, CodamaPdaHelpers};
+
+#[derive(CodamaPda, CodamaPdaHelpers)]
+#[codama(seed(type = string(base64), value = "cHJlZml4"))]
+pub struct Counter;
+
+fn main() {}

--- a/codama-macros/tests/codama_pda_helpers_derive/unsupported_constant.fail.stderr
+++ b/codama-macros/tests/codama_pda_helpers_derive/unsupported_constant.fail.stderr
@@ -1,0 +1,5 @@
+error: CodamaPdaHelpers currently supports constant seeds only for string(utf8) and integer number(...) types
+ --> tests/codama_pda_helpers_derive/unsupported_constant.fail.rs:4:1
+  |
+4 | #[codama(seed(type = string(base64), value = "cHJlZml4"))]
+  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/codama-syn-helpers/Cargo.toml
+++ b/codama-syn-helpers/Cargo.toml
@@ -9,6 +9,7 @@ license = { workspace = true }
 [dependencies]
 codama-errors = { version = "0.8.0", path = "../codama-errors" }
 derive_more = { version = "1.0", features = ["from"] }
+heck = "0.5"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["extra-traits", "full"] }

--- a/codama-syn-helpers/src/ident.rs
+++ b/codama-syn-helpers/src/ident.rs
@@ -1,0 +1,97 @@
+use heck::ToSnakeCase;
+use proc_macro2::Span;
+
+/// Converts a string from any common casing (camelCase, kebab-case, PascalCase)
+/// to snake_case.
+pub fn to_snake_case(input: &str) -> String {
+    input.to_snake_case()
+}
+
+/// Converts a string to a valid snake_case `syn::Ident`, handling Rust
+/// keywords and leading digits.
+pub fn snake_case_ident(input: &str) -> syn::Ident {
+    let snake = to_snake_case(input);
+    string_to_ident(&snake)
+}
+
+/// Converts a string to a valid `syn::Ident`, handling Rust keywords
+/// (e.g. `type` -> `r#type`) and leading digits (e.g. `3foo` -> `_3foo`).
+/// Panics if the input is empty.
+pub fn string_to_ident(input: &str) -> syn::Ident {
+    if input.is_empty() {
+        panic!("cannot create an identifier from an empty string");
+    }
+
+    let mut ident = input.to_string();
+    if ident
+        .chars()
+        .next()
+        .is_some_and(|character| character.is_ascii_digit())
+    {
+        ident.insert(0, '_');
+    }
+
+    if syn::parse_str::<syn::Ident>(&ident).is_err() {
+        if matches!(ident.as_str(), "self" | "super" | "crate") {
+            syn::Ident::new(&format!("{ident}_"), Span::call_site())
+        } else {
+            syn::Ident::new_raw(&ident, Span::call_site())
+        }
+    } else {
+        syn::Ident::new(&ident, Span::call_site())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn to_snake_case_from_camel_case() {
+        assert_eq!(to_snake_case("tokenProgram"), "token_program");
+        assert_eq!(to_snake_case("myValue"), "my_value");
+    }
+
+    #[test]
+    fn to_snake_case_from_kebab_case() {
+        assert_eq!(to_snake_case("order-id"), "order_id");
+    }
+
+    #[test]
+    fn to_snake_case_from_snake_case() {
+        assert_eq!(to_snake_case("already_snake"), "already_snake");
+    }
+
+    #[test]
+    fn to_snake_case_strips_non_alphanumeric() {
+        assert_eq!(to_snake_case("!!!"), "");
+    }
+
+    #[test]
+    fn snake_case_ident_basic() {
+        assert_eq!(
+            snake_case_ident("tokenProgram").to_string(),
+            "token_program"
+        );
+        assert_eq!(snake_case_ident("order-id").to_string(), "order_id");
+    }
+
+    #[test]
+    fn string_to_ident_handles_keywords() {
+        assert_eq!(string_to_ident("type").to_string(), "r#type");
+        assert_eq!(string_to_ident("self").to_string(), "self_");
+        assert_eq!(string_to_ident("super").to_string(), "super_");
+        assert_eq!(string_to_ident("crate").to_string(), "crate_");
+    }
+
+    #[test]
+    fn string_to_ident_handles_leading_digit() {
+        assert_eq!(string_to_ident("3foo").to_string(), "_3foo");
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot create an identifier from an empty string")]
+    fn string_to_ident_panics_on_empty() {
+        string_to_ident("");
+    }
+}

--- a/codama-syn-helpers/src/lib.rs
+++ b/codama-syn-helpers/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod extensions;
 
+mod ident;
 mod meta;
+pub use ident::*;
 pub use meta::*;


### PR DESCRIPTION
Adds `#[derive(CodamaPdaHelpers)]` which generates runtime PDA helper methods from existing #[codama(seed(...))] attributes. This reduces repeated manual PDA boilerplate program devs are writing. 

### API

```rust
use codama::{CodamaPda, CodamaPdaHelpers};

#[derive(CodamaPda, CodamaPdaHelpers)]
#[codama(seed(type = string(utf8), value = "mint"))]
#[codama(seed(name = "unwrappedMint", type = public_key))]
#[codama(seed(name = "wrappedTokenProgram", type = public_key))]
pub struct WrappedMintPda;

// ==== In program ==== 

let (address, bump) = WrappedMintPda::derive_program_address(
    &unwrapped_mint,
    &wrapped_token_program,
    &program_id,
)?;

let signer_seeds: [Seed; 4] = WrappedMintPda::signer_seeds(
    &unwrapped_mint,
    &wrapped_token_program,
    &bump_bytes,
);
```

- Implemented macro expansion that parses struct-level `#[codama(seed(...))]` directives and generates:
  - `seeds`
  - `seeds_with_bump`
  - `signer_seeds`
  -  (wrapping Address methods below)
  - `derive_address`
  - `create_program_address`
  - `find_program_address`
  - `try_find_program_address`
  - `derive_program_address`
- Supports constant seeds (string(utf8), integer number(...)) and variable/linked seeds
- Handles seed name deduplication, identifier collision detection, reserved bump, and Rust keyword escaping

### Discussion points

- Better name?
- Should all of those `Address` methods be shipped? Aka, should we drop `find_program_address`? 
- The intention was for program usage, but might clients also need this?
- An `impl` vs external crate helpers
- How does this sit next to the CPI helpers PR (link?)