### PR TITLE
Add support for constant nodes

### DIFF
--- a/codama-attributes/src/codama_directives/program_directive.rs
+++ b/codama-attributes/src/codama_directives/program_directive.rs
@@ -54,6 +54,13 @@ impl ProgramDirective {
                 ..ProgramNode::default()
             }
             .into(),
+            Node::Constant(constant) => ProgramNode {
+                name: self.name.clone(),
+                public_key: self.address.clone(),
+                constants: vec![constant],
+                ..ProgramNode::default()
+            }
+            .into(),
             Node::Instruction(instruction) => ProgramNode {
                 name: self.name.clone(),
                 public_key: self.address.clone(),

--- a/codama-korok-visitors/src/combine_modules_visitor.rs
+++ b/codama-korok-visitors/src/combine_modules_visitor.rs
@@ -125,6 +125,10 @@ fn get_scraps_root_node(nodes: Vec<Node>) -> Option<RootNode> {
                 add_or_replace_node_with_name(&mut root.program.accounts, node);
                 has_scraps = true
             }
+            Node::Constant(node) => {
+                add_or_replace_node_with_name(&mut root.program.constants, node);
+                has_scraps = true
+            }
             Node::Instruction(node) => {
                 add_or_replace_node_with_name(&mut root.program.instructions, node);
                 has_scraps = true
@@ -217,6 +221,7 @@ fn merge_program_nodes(this: &mut ProgramNode, that: ProgramNode) {
     merge_nodes_with_name(&mut this.pdas, that.pdas);
     merge_nodes_with_name(&mut this.events, that.events);
     merge_nodes_with_name(&mut this.errors, that.errors);
+    merge_nodes_with_name(&mut this.constants, that.constants);
 }
 
 fn merge_nodes_with_name<T>(nodes: &mut Vec<T>, new_nodes: Vec<T>)

--- a/codama-korok-visitors/tests/combine_modules_visitor/constant_node.rs
+++ b/codama-korok-visitors/tests/combine_modules_visitor/constant_node.rs
@@ -1,0 +1,130 @@
+use super::utils::{combine_modules, CombineModulesInput};
+use codama_nodes::{ConstantNode, NumberTypeNode, NumberValueNode, ProgramNode, RootNode, U64};
+
+#[test]
+fn it_merges_constants_into_root_nodes() {
+    let max_items = ConstantNode::new(
+        "maxItems",
+        NumberTypeNode::le(U64),
+        NumberValueNode::new(10u64),
+    );
+    let max_size = ConstantNode::new(
+        "maxSize",
+        NumberTypeNode::le(U64),
+        NumberValueNode::new(20u64),
+    );
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(max_items.clone())
+                .add_node(max_size.clone())
+        ),
+        Some(
+            RootNode::new(
+                ProgramNode::default()
+                    .add_constant(max_items)
+                    .add_constant(max_size)
+            )
+            .into()
+        )
+    );
+}
+
+#[test]
+fn it_merges_constants_inside_programs_into_root_nodes() {
+    let constant_a = ConstantNode::new("foo", NumberTypeNode::le(U64), NumberValueNode::new(1u64));
+    let constant_b = ConstantNode::new("bar", NumberTypeNode::le(U64), NumberValueNode::new(2u64));
+    let program_a = ProgramNode::default().add_constant(constant_a.clone());
+    let program_b = ProgramNode::default().add_constant(constant_b.clone());
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(program_a)
+                .add_node(program_b)
+        ),
+        Some(
+            RootNode::new(
+                ProgramNode::default()
+                    .add_constant(constant_a)
+                    .add_constant(constant_b)
+            )
+            .into()
+        )
+    );
+}
+
+#[test]
+fn it_deduplicates_constants_with_identical_names_by_using_the_last_one() {
+    let first_constant = ConstantNode::new(
+        "duplicated",
+        NumberTypeNode::le(U64),
+        NumberValueNode::new(1u64),
+    );
+    let second_constant = ConstantNode::new(
+        "duplicated",
+        NumberTypeNode::le(U64),
+        NumberValueNode::new(2u64),
+    );
+    let third_constant = ConstantNode::new(
+        "duplicated",
+        NumberTypeNode::le(U64),
+        NumberValueNode::new(3u64),
+    );
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(first_constant)
+                .add_node(second_constant)
+                .add_node(third_constant.clone())
+        ),
+        Some(RootNode::new(ProgramNode::default().add_constant(third_constant)).into())
+    );
+}
+
+#[test]
+fn it_deduplicates_constants_with_identical_names_inside_programs() {
+    let first_constant = ConstantNode::new(
+        "duplicated",
+        NumberTypeNode::le(U64),
+        NumberValueNode::new(1u64),
+    );
+    let second_constant = ConstantNode::new(
+        "duplicated",
+        NumberTypeNode::le(U64),
+        NumberValueNode::new(2u64),
+    );
+    let program_a = ProgramNode::default().add_constant(first_constant);
+    let program_b = ProgramNode::default().add_constant(second_constant.clone());
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .add_node(program_a)
+                .add_node(program_b)
+        ),
+        Some(RootNode::new(ProgramNode::default().add_constant(second_constant)).into())
+    );
+}
+
+#[test]
+fn it_deduplicates_constants_with_identical_names_with_an_initial_program_node() {
+    let first_constant = ConstantNode::new(
+        "duplicated",
+        NumberTypeNode::le(U64),
+        NumberValueNode::new(1u64),
+    );
+    let second_constant = ConstantNode::new(
+        "duplicated",
+        NumberTypeNode::le(U64),
+        NumberValueNode::new(2u64),
+    );
+    let program_a = ProgramNode::default().add_constant(first_constant);
+    let program_b = ProgramNode::default().add_constant(second_constant.clone());
+    assert_eq!(
+        combine_modules(
+            CombineModulesInput::new()
+                .set_initial_node(program_a)
+                .add_node(program_b)
+        ),
+        Some(RootNode::new(ProgramNode::default().add_constant(second_constant)).into())
+    );
+}

--- a/codama-korok-visitors/tests/combine_modules_visitor/mod.rs
+++ b/codama-korok-visitors/tests/combine_modules_visitor/mod.rs
@@ -1,4 +1,5 @@
 mod account_node;
+mod constant_node;
 mod defined_type_node;
 mod error_node;
 mod event_node;

--- a/codama-korok-visitors/tests/combine_modules_visitor/program_node.rs
+++ b/codama-korok-visitors/tests/combine_modules_visitor/program_node.rs
@@ -1,7 +1,7 @@
 use super::utils::{combine_modules, CombineModulesInput};
 use codama_nodes::{
-    AccountNode, DefinedTypeNode, Docs, ErrorNode, EventNode, InstructionNode, Node, PdaNode,
-    ProgramNode, RootNode, StructTypeNode,
+    AccountNode, ConstantNode, DefinedTypeNode, Docs, ErrorNode, EventNode, InstructionNode, Node,
+    NumberTypeNode, NumberValueNode, PdaNode, ProgramNode, RootNode, StructTypeNode, U8,
 };
 
 #[test]
@@ -32,6 +32,10 @@ fn it_merges_node_arrays_together() {
     assert_eq!(program.pdas, concat(program_a.pdas, program_b.pdas));
     assert_eq!(program.events, concat(program_a.events, program_b.events));
     assert_eq!(program.errors, concat(program_a.errors, program_b.errors));
+    assert_eq!(
+        program.constants,
+        concat(program_a.constants, program_b.constants)
+    );
 }
 
 #[test]
@@ -107,6 +111,11 @@ fn get_mock_program(identifier: &str, public_key: &str) -> ProgramNode {
             format!("error_{}", identifier),
             42,
             format!("message_{}", identifier),
+        )],
+        constants: vec![ConstantNode::new(
+            format!("constant_{}", identifier),
+            NumberTypeNode::le(U8),
+            NumberValueNode::new(42u8),
         )],
     }
 }

--- a/codama-nodes/src/constant_node.rs
+++ b/codama-nodes/src/constant_node.rs
@@ -1,0 +1,113 @@
+use crate::{CamelCaseString, Docs, HasName, TypeNode, ValueNode};
+use codama_nodes_derive::node;
+
+#[node]
+pub struct ConstantNode {
+    // data.
+    pub name: CamelCaseString,
+    #[serde(default, skip_serializing_if = "crate::is_default")]
+    pub docs: Docs,
+
+    // children.
+    pub r#type: TypeNode,
+    pub value: ValueNode,
+}
+
+impl ConstantNode {
+    pub fn new<T, U, V>(name: T, r#type: U, value: V) -> Self
+    where
+        T: Into<CamelCaseString>,
+        U: Into<TypeNode>,
+        V: Into<ValueNode>,
+    {
+        Self {
+            name: name.into(),
+            docs: Docs::default(),
+            r#type: r#type.into(),
+            value: value.into(),
+        }
+    }
+}
+
+impl HasName for ConstantNode {
+    fn name(&self) -> &CamelCaseString {
+        &self.name
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{NumberTypeNode, NumberValueNode, StringTypeNode, StringValueNode, U64};
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn new() {
+        let node = ConstantNode::new(
+            "max_items",
+            NumberTypeNode::le(U64),
+            NumberValueNode::new(100u64),
+        );
+        assert_eq!(node.name, CamelCaseString::new("maxItems"));
+        assert_eq!(node.docs, Docs::default());
+        assert_eq!(node.r#type, TypeNode::Number(NumberTypeNode::le(U64)));
+        assert_eq!(node.value, ValueNode::Number(NumberValueNode::new(100u64)));
+    }
+
+    #[test]
+    fn direct_instantiation() {
+        let node = ConstantNode {
+            name: "appName".into(),
+            docs: Docs::default(),
+            r#type: StringTypeNode::utf8().into(),
+            value: StringValueNode::new("MyApp").into(),
+        };
+        assert_eq!(node.name, CamelCaseString::new("appName"));
+        assert_eq!(node.docs, Docs::default());
+        assert_eq!(node.r#type, TypeNode::String(StringTypeNode::utf8()));
+        assert_eq!(node.value, ValueNode::String(StringValueNode::new("MyApp")));
+    }
+
+    #[test]
+    fn to_json() {
+        let node = ConstantNode::new(
+            "maxItems",
+            NumberTypeNode::le(U64),
+            NumberValueNode::new(100u64),
+        );
+        let json = serde_json::to_string(&node).unwrap();
+        assert_eq!(
+            json,
+            r#"{"kind":"constantNode","name":"maxItems","type":{"kind":"numberTypeNode","format":"u64","endian":"le"},"value":{"kind":"numberValueNode","number":100}}"#
+        );
+    }
+
+    #[test]
+    fn from_json() {
+        let json = r#"{"kind":"constantNode","name":"maxItems","type":{"kind":"numberTypeNode","format":"u64","endian":"le"},"value":{"kind":"numberValueNode","number":100}}"#;
+        let node: ConstantNode = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            node,
+            ConstantNode::new(
+                "maxItems",
+                NumberTypeNode::le(U64),
+                NumberValueNode::new(100u64)
+            )
+        );
+    }
+
+    #[test]
+    fn to_json_with_docs() {
+        let mut node = ConstantNode::new(
+            "maxItems",
+            NumberTypeNode::le(U64),
+            NumberValueNode::new(100u64),
+        );
+        node.docs = Docs::new().add_doc("Maximum number of items.");
+        let json = serde_json::to_string(&node).unwrap();
+        assert_eq!(
+            json,
+            r#"{"kind":"constantNode","name":"maxItems","docs":["Maximum number of items."],"type":{"kind":"numberTypeNode","format":"u64","endian":"le"},"value":{"kind":"numberValueNode","number":100}}"#
+        );
+    }
+}

--- a/codama-nodes/src/lib.rs
+++ b/codama-nodes/src/lib.rs
@@ -1,4 +1,5 @@
 mod account_node;
+mod constant_node;
 mod contextual_value_nodes;
 mod count_nodes;
 mod defined_type_node;
@@ -23,6 +24,7 @@ mod type_nodes;
 mod value_nodes;
 
 pub use account_node::*;
+pub use constant_node::*;
 pub use contextual_value_nodes::*;
 pub use count_nodes::*;
 pub use defined_type_node::*;

--- a/codama-nodes/src/node.rs
+++ b/codama-nodes/src/node.rs
@@ -1,9 +1,10 @@
 use crate::{
-    AccountNode, ContextualValueNode, CountNode, DefinedTypeNode, DiscriminatorNode, ErrorNode,
-    EventNode, HasKind, InstructionAccountNode, InstructionArgumentNode, InstructionByteDeltaNode,
-    InstructionNode, InstructionRemainingAccountsNode, InstructionStatusNode, LinkNode,
-    NodeUnionTrait, PdaNode, PdaSeedNode, ProgramNode, RegisteredContextualValueNode,
-    RegisteredTypeNode, RegisteredValueNode, RootNode, TypeNode, ValueNode,
+    AccountNode, ConstantNode, ContextualValueNode, CountNode, DefinedTypeNode, DiscriminatorNode,
+    ErrorNode, EventNode, HasKind, InstructionAccountNode, InstructionArgumentNode,
+    InstructionByteDeltaNode, InstructionNode, InstructionRemainingAccountsNode,
+    InstructionStatusNode, LinkNode, NodeUnionTrait, PdaNode, PdaSeedNode, ProgramNode,
+    RegisteredContextualValueNode, RegisteredTypeNode, RegisteredValueNode, RootNode, TypeNode,
+    ValueNode,
 };
 use derive_more::derive::From;
 use serde::{Deserialize, Serialize};
@@ -22,6 +23,7 @@ pub enum Node {
 
     // Nodes.
     Account(AccountNode),
+    Constant(ConstantNode),
     DefinedType(DefinedTypeNode),
     Error(ErrorNode),
     Event(EventNode),
@@ -69,6 +71,7 @@ impl HasKind for Node {
             Node::Type(node) => node.kind(),
             Node::Value(node) => node.kind(),
             Node::Account(node) => node.kind(),
+            Node::Constant(node) => node.kind(),
             Node::DefinedType(node) => node.kind(),
             Node::Error(node) => node.kind(),
             Node::Event(node) => node.kind(),
@@ -97,7 +100,7 @@ impl HasKind for Option<Node> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{NumberTypeNode, U32};
+    use crate::{NumberTypeNode, NumberValueNode, U32};
 
     #[test]
     fn kind() {
@@ -142,6 +145,35 @@ mod tests {
         assert_eq!(
             node,
             Node::DefinedType(DefinedTypeNode::new("myType", NumberTypeNode::le(U32)))
+        );
+    }
+
+    #[test]
+    fn constant_to_json() {
+        let node: Node = ConstantNode::new(
+            "myConstant",
+            NumberTypeNode::le(U32),
+            NumberValueNode::new(42u32),
+        )
+        .into();
+        let json = serde_json::to_string(&node).unwrap();
+        assert_eq!(
+            json,
+            r#"{"kind":"constantNode","name":"myConstant","type":{"kind":"numberTypeNode","format":"u32","endian":"le"},"value":{"kind":"numberValueNode","number":42}}"#
+        );
+    }
+
+    #[test]
+    fn constant_from_json() {
+        let json = r#"{"kind":"constantNode","name":"myConstant","type":{"kind":"numberTypeNode","format":"u32","endian":"le"},"value":{"kind":"numberValueNode","number":42}}"#;
+        let node: Node = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            node,
+            Node::Constant(ConstantNode::new(
+                "myConstant",
+                NumberTypeNode::le(U32),
+                NumberValueNode::new(42u32)
+            ))
         );
     }
 }

--- a/codama-nodes/src/program_node.rs
+++ b/codama-nodes/src/program_node.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AccountNode, CamelCaseString, DefinedTypeNode, Docs, ErrorNode, EventNode, HasName,
-    InstructionNode, PdaNode,
+    AccountNode, CamelCaseString, ConstantNode, DefinedTypeNode, Docs, ErrorNode, EventNode,
+    HasName, InstructionNode, PdaNode,
 };
 use codama_nodes_derive::node;
 
@@ -29,6 +29,8 @@ pub struct ProgramNode {
     pub events: Vec<EventNode>,
     #[serde(default)]
     pub errors: Vec<ErrorNode>,
+    #[serde(default)]
+    pub constants: Vec<ConstantNode>,
 }
 
 impl ProgramNode {
@@ -74,6 +76,11 @@ impl ProgramNode {
         self.errors.push(error);
         self
     }
+
+    pub fn add_constant(mut self, constant: ConstantNode) -> Self {
+        self.constants.push(constant);
+        self
+    }
 }
 
 impl HasName for ProgramNode {
@@ -101,6 +108,7 @@ mod tests {
         assert_eq!(node.pdas, vec![]);
         assert_eq!(node.events, vec![]);
         assert_eq!(node.errors, vec![]);
+        assert_eq!(node.constants, vec![]);
     }
 
     #[test]
@@ -117,6 +125,7 @@ mod tests {
         assert_eq!(node.pdas, vec![]);
         assert_eq!(node.events, vec![]);
         assert_eq!(node.errors, vec![]);
+        assert_eq!(node.constants, vec![]);
     }
 
     #[test]
@@ -138,6 +147,7 @@ mod tests {
         assert_eq!(node.pdas, vec![]);
         assert_eq!(node.events, vec![]);
         assert_eq!(node.errors, vec![]);
+        assert_eq!(node.constants, vec![]);
     }
 
     #[test]
@@ -151,7 +161,7 @@ mod tests {
         let json = serde_json::to_string(&node).unwrap();
         assert_eq!(
             json,
-            r#"{"kind":"programNode","name":"myProgram","publicKey":"1234..5678","version":"1.2.3","accounts":[],"instructions":[],"definedTypes":[],"pdas":[],"events":[],"errors":[]}"#
+            r#"{"kind":"programNode","name":"myProgram","publicKey":"1234..5678","version":"1.2.3","accounts":[],"instructions":[],"definedTypes":[],"pdas":[],"events":[],"errors":[],"constants":[]}"#
         );
     }
 

--- a/codama-nodes/src/root_node.rs
+++ b/codama-nodes/src/root_node.rs
@@ -113,7 +113,7 @@ mod tests {
         let json = serde_json::to_string(&node).unwrap();
         assert_eq!(
             json,
-            r#"{"kind":"rootNode","standard":"codama","version":"1.0.0","program":{"kind":"programNode","name":"myProgram","publicKey":"1234..5678","version":"1.2.3","accounts":[],"instructions":[],"definedTypes":[],"pdas":[],"events":[],"errors":[]},"additionalPrograms":[]}"#
+            r#"{"kind":"rootNode","standard":"codama","version":"1.0.0","program":{"kind":"programNode","name":"myProgram","publicKey":"1234..5678","version":"1.2.3","accounts":[],"instructions":[],"definedTypes":[],"pdas":[],"events":[],"errors":[],"constants":[]},"additionalPrograms":[]}"#
         );
     }
 

--- a/codama/tests/membership/mod.rs
+++ b/codama/tests/membership/mod.rs
@@ -136,7 +136,8 @@ fn get_idl() {
       }
     ],
     "events": [],
-    "errors": []
+    "errors": [],
+    "constants": []
   },
   "additionalPrograms": []
 }"#

--- a/codama/tests/system/mod.rs
+++ b/codama/tests/system/mod.rs
@@ -974,7 +974,8 @@ fn get_idl() {
         "code": 8,
         "message": "specified nonce does not match stored nonce"
       }
-    ]
+    ],
+    "constants": []
   },
   "additionalPrograms": []
 }"#


### PR DESCRIPTION
Adds constant nodes to the Rust AST and wires them into program nodes, node serialization, and module merging.

This mirrors the recent Codama change by allowing constants to be represented alongside accounts, instructions, defined types, PDAs, events, and errors.
