### PR TITLE
feat: add copy derives to codama-nodes

### DIFF
--- a/codama-nodes/src/contextual_value_nodes/identity_value_node.rs
+++ b/codama-nodes/src/contextual_value_nodes/identity_value_node.rs
@@ -1,7 +1,7 @@
 use codama_nodes_derive::node;
 
 #[node]
-#[derive(Default)]
+#[derive(Copy, Default)]
 pub struct IdentityValueNode {}
 
 impl From<IdentityValueNode> for crate::Node {

--- a/codama-nodes/src/contextual_value_nodes/payer_value_node.rs
+++ b/codama-nodes/src/contextual_value_nodes/payer_value_node.rs
@@ -1,7 +1,7 @@
 use codama_nodes_derive::node;
 
 #[node]
-#[derive(Default)]
+#[derive(Copy, Default)]
 pub struct PayerValueNode {}
 
 impl From<PayerValueNode> for crate::Node {

--- a/codama-nodes/src/contextual_value_nodes/program_id_value_node.rs
+++ b/codama-nodes/src/contextual_value_nodes/program_id_value_node.rs
@@ -1,7 +1,7 @@
 use codama_nodes_derive::node;
 
 #[node]
-#[derive(Default)]
+#[derive(Copy, Default)]
 pub struct ProgramIdValueNode {}
 
 impl From<ProgramIdValueNode> for crate::Node {

--- a/codama-nodes/src/count_nodes/fixed_count_node.rs
+++ b/codama-nodes/src/count_nodes/fixed_count_node.rs
@@ -1,6 +1,7 @@
 use codama_nodes_derive::node;
 
 #[node]
+#[derive(Copy)]
 pub struct FixedCountNode {
     // Data.
     pub value: usize,

--- a/codama-nodes/src/count_nodes/remainder_count_node.rs
+++ b/codama-nodes/src/count_nodes/remainder_count_node.rs
@@ -1,7 +1,7 @@
 use codama_nodes_derive::node;
 
 #[node]
-#[derive(Default)]
+#[derive(Copy, Default)]
 pub struct RemainderCountNode {}
 
 impl From<RemainderCountNode> for crate::Node {

--- a/codama-nodes/src/discriminator_nodes/size_discriminator_node.rs
+++ b/codama-nodes/src/discriminator_nodes/size_discriminator_node.rs
@@ -1,6 +1,7 @@
 use codama_nodes_derive::node;
 
 #[node]
+#[derive(Copy)]
 pub struct SizeDiscriminatorNode {
     // Data.
     pub size: usize,

--- a/codama-nodes/src/lib.rs
+++ b/codama-nodes/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(missing_copy_implementations)]
+
 mod account_node;
 mod contextual_value_nodes;
 mod count_nodes;

--- a/codama-nodes/src/type_nodes/bytes_type_node.rs
+++ b/codama-nodes/src/type_nodes/bytes_type_node.rs
@@ -1,7 +1,7 @@
 use codama_nodes_derive::type_node;
 
 #[type_node]
-#[derive(Default)]
+#[derive(Copy, Default)]
 pub struct BytesTypeNode {}
 
 impl BytesTypeNode {

--- a/codama-nodes/src/type_nodes/number_type_node.rs
+++ b/codama-nodes/src/type_nodes/number_type_node.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub use NumberFormat::*;
 
 #[type_node]
+#[derive(Copy)]
 pub struct NumberTypeNode {
     // Data.
     pub format: NumberFormat,

--- a/codama-nodes/src/type_nodes/public_key_type_node.rs
+++ b/codama-nodes/src/type_nodes/public_key_type_node.rs
@@ -1,7 +1,7 @@
 use codama_nodes_derive::type_node;
 
 #[type_node]
-#[derive(Default)]
+#[derive(Copy, Default)]
 pub struct PublicKeyTypeNode {}
 
 impl From<PublicKeyTypeNode> for crate::Node {

--- a/codama-nodes/src/type_nodes/string_type_node.rs
+++ b/codama-nodes/src/type_nodes/string_type_node.rs
@@ -2,6 +2,7 @@ use crate::BytesEncoding;
 use codama_nodes_derive::type_node;
 
 #[type_node]
+#[derive(Copy)]
 pub struct StringTypeNode {
     // Data.
     pub encoding: BytesEncoding,

--- a/codama-nodes/src/value_nodes/boolean_value_node.rs
+++ b/codama-nodes/src/value_nodes/boolean_value_node.rs
@@ -1,6 +1,7 @@
 use codama_nodes_derive::node;
 
 #[node]
+#[derive(Copy)]
 pub struct BooleanValueNode {
     // Data.
     pub boolean: bool,

--- a/codama-nodes/src/value_nodes/none_value_node.rs
+++ b/codama-nodes/src/value_nodes/none_value_node.rs
@@ -1,7 +1,7 @@
 use codama_nodes_derive::node;
 
 #[node]
-#[derive(Default)]
+#[derive(Copy, Default)]
 pub struct NoneValueNode {}
 
 impl From<NoneValueNode> for crate::Node {

--- a/codama-nodes/src/value_nodes/number_value_node.rs
+++ b/codama-nodes/src/value_nodes/number_value_node.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Number as JsonNumber;
 
 #[node]
+#[derive(Copy)]
 pub struct NumberValueNode {
     // Data.
     pub number: Number,


### PR DESCRIPTION
Many types that could derive `Copy` currently don't. This PR adds a clippy lint for it in `codama-nodes` and adds all the derives. 