### PR TITLE
Add inline-union support and complete pdaSeed generation

### DIFF
--- a/codama-nodes/src/generated/mod.rs
+++ b/codama-nodes/src/generated/mod.rs
@@ -1,7 +1,9 @@
 mod count_nodes;
 mod discriminator_nodes;
 mod link_nodes;
+mod pda_seed_nodes;
 
 pub use count_nodes::*;
 pub use discriminator_nodes::*;
 pub use link_nodes::*;
+pub use pda_seed_nodes::*;

--- a/codama-nodes/src/generated/pda_seed_nodes/constant_pda_seed_node.rs
+++ b/codama-nodes/src/generated/pda_seed_nodes/constant_pda_seed_node.rs
@@ -1,0 +1,15 @@
+use crate::{ConstantPdaSeedValue, TypeNode};
+use codama_nodes_derive::node;
+
+#[node]
+pub struct ConstantPdaSeedNode {
+    // Children.
+    pub r#type: Box<TypeNode>,
+    pub value: Box<ConstantPdaSeedValue>,
+}
+
+impl From<ConstantPdaSeedNode> for crate::Node {
+    fn from(val: ConstantPdaSeedNode) -> Self {
+        crate::Node::PdaSeed(val.into())
+    }
+}

--- a/codama-nodes/src/generated/pda_seed_nodes/constant_pda_seed_value.rs
+++ b/codama-nodes/src/generated/pda_seed_nodes/constant_pda_seed_value.rs
@@ -1,0 +1,25 @@
+use crate::{
+    ArrayValueNode, BooleanValueNode, BytesValueNode, ConstantValueNode, EnumValueNode,
+    MapValueNode, NoneValueNode, NumberValueNode, ProgramIdValueNode, PublicKeyValueNode,
+    SetValueNode, SomeValueNode, StringValueNode, StructValueNode, TupleValueNode,
+};
+use codama_nodes_derive::node_union;
+
+#[node_union]
+pub enum ConstantPdaSeedValue {
+    Array(ArrayValueNode),
+    Boolean(BooleanValueNode),
+    Bytes(BytesValueNode),
+    Constant(ConstantValueNode),
+    Enum(EnumValueNode),
+    Map(MapValueNode),
+    None(NoneValueNode),
+    Number(NumberValueNode),
+    ProgramId(ProgramIdValueNode),
+    PublicKey(PublicKeyValueNode),
+    Set(SetValueNode),
+    Some(SomeValueNode),
+    String(StringValueNode),
+    Struct(StructValueNode),
+    Tuple(TupleValueNode),
+}

--- a/codama-nodes/src/generated/pda_seed_nodes/mod.rs
+++ b/codama-nodes/src/generated/pda_seed_nodes/mod.rs
@@ -1,0 +1,9 @@
+mod constant_pda_seed_node;
+mod constant_pda_seed_value;
+mod pda_seed_node;
+mod variable_pda_seed_node;
+
+pub use constant_pda_seed_node::*;
+pub use constant_pda_seed_value::*;
+pub use pda_seed_node::*;
+pub use variable_pda_seed_node::*;

--- a/codama-nodes/src/generated/pda_seed_nodes/pda_seed_node.rs
+++ b/codama-nodes/src/generated/pda_seed_nodes/pda_seed_node.rs
@@ -1,0 +1,8 @@
+use crate::{ConstantPdaSeedNode, VariablePdaSeedNode};
+use codama_nodes_derive::node_union;
+
+#[node_union]
+pub enum PdaSeedNode {
+    Constant(ConstantPdaSeedNode),
+    Variable(VariablePdaSeedNode),
+}

--- a/codama-nodes/src/generated/pda_seed_nodes/variable_pda_seed_node.rs
+++ b/codama-nodes/src/generated/pda_seed_nodes/variable_pda_seed_node.rs
@@ -1,0 +1,25 @@
+use crate::{CamelCaseString, Docs, HasName, TypeNode};
+use codama_nodes_derive::node;
+
+#[node]
+pub struct VariablePdaSeedNode {
+    // Data.
+    pub name: CamelCaseString,
+    #[serde(default, skip_serializing_if = "crate::is_default")]
+    pub docs: Docs,
+
+    // Children.
+    pub r#type: Box<TypeNode>,
+}
+
+impl From<VariablePdaSeedNode> for crate::Node {
+    fn from(val: VariablePdaSeedNode) -> Self {
+        crate::Node::PdaSeed(val.into())
+    }
+}
+
+impl HasName for VariablePdaSeedNode {
+    fn name(&self) -> &CamelCaseString {
+        &self.name
+    }
+}

--- a/codama-nodes/src/lib.rs
+++ b/codama-nodes/src/lib.rs
@@ -41,7 +41,6 @@ pub use instruction_remaining_accounts_node::*;
 pub use instruction_status_node::*;
 pub use node::*;
 pub use pda_node::*;
-pub use pda_seed_nodes::*;
 pub use program_node::*;
 pub use root_node::*;
 pub use shared::*;

--- a/codama-nodes/src/pda_seed_nodes/constant_pda_seed_node.rs
+++ b/codama-nodes/src/pda_seed_nodes/constant_pda_seed_node.rs
@@ -1,28 +1,39 @@
-use crate::{TypeNode, ValueNode};
-use codama_nodes_derive::node;
-
-#[node]
-pub struct ConstantPdaSeedNode {
-    // Children.
-    pub r#type: TypeNode,
-    pub value: ValueNode,
-}
-
-impl From<ConstantPdaSeedNode> for crate::Node {
-    fn from(val: ConstantPdaSeedNode) -> Self {
-        crate::Node::PdaSeed(val.into())
-    }
-}
+use crate::{ConstantPdaSeedNode, ConstantPdaSeedValue, TypeNode, ValueNode};
 
 impl ConstantPdaSeedNode {
     pub fn new<T, U>(r#type: T, value: U) -> Self
     where
         T: Into<TypeNode>,
-        U: Into<ValueNode>,
+        U: Into<ConstantPdaSeedValue>,
     {
         Self {
-            r#type: r#type.into(),
-            value: value.into(),
+            r#type: Box::new(r#type.into()),
+            value: Box::new(value.into()),
+        }
+    }
+}
+
+/// Bridge from the broader value-node union into a `constantPdaSeedNode`
+/// value. The spec union `constantPdaSeedValue` is `programIdValueNode |
+/// valueNode`, so every `ValueNode` cleanly maps to its same-named
+/// `ConstantPdaSeedValue` variant.
+impl From<ValueNode> for ConstantPdaSeedValue {
+    fn from(value: ValueNode) -> Self {
+        match value {
+            ValueNode::Array(n) => Self::Array(n),
+            ValueNode::Boolean(n) => Self::Boolean(n),
+            ValueNode::Bytes(n) => Self::Bytes(n),
+            ValueNode::Constant(n) => Self::Constant(n),
+            ValueNode::Enum(n) => Self::Enum(n),
+            ValueNode::Map(n) => Self::Map(n),
+            ValueNode::None(n) => Self::None(n),
+            ValueNode::Number(n) => Self::Number(n),
+            ValueNode::PublicKey(n) => Self::PublicKey(n),
+            ValueNode::Set(n) => Self::Set(n),
+            ValueNode::Some(n) => Self::Some(n),
+            ValueNode::String(n) => Self::String(n),
+            ValueNode::Struct(n) => Self::Struct(n),
+            ValueNode::Tuple(n) => Self::Tuple(n),
         }
     }
 }
@@ -35,8 +46,11 @@ mod tests {
     #[test]
     fn new() {
         let node = ConstantPdaSeedNode::new(NumberTypeNode::le(U64), NumberValueNode::new(42u64));
-        assert_eq!(node.r#type, TypeNode::Number(NumberTypeNode::le(U64)));
-        assert_eq!(node.value, ValueNode::Number(NumberValueNode::new(42u64)));
+        assert_eq!(*node.r#type, TypeNode::Number(NumberTypeNode::le(U64)));
+        assert_eq!(
+            *node.value,
+            ConstantPdaSeedValue::Number(NumberValueNode::new(42u64))
+        );
     }
 
     #[test]

--- a/codama-nodes/src/pda_seed_nodes/mod.rs
+++ b/codama-nodes/src/pda_seed_nodes/mod.rs
@@ -1,7 +1,3 @@
 mod constant_pda_seed_node;
 mod pda_seed_node;
 mod variable_pda_seed_node;
-
-pub use constant_pda_seed_node::*;
-pub use pda_seed_node::*;
-pub use variable_pda_seed_node::*;

--- a/codama-nodes/src/pda_seed_nodes/pda_seed_node.rs
+++ b/codama-nodes/src/pda_seed_nodes/pda_seed_node.rs
@@ -1,16 +1,6 @@
-use crate::{ConstantPdaSeedNode, VariablePdaSeedNode};
-use codama_nodes_derive::node_union;
-
-#[node_union]
-pub enum PdaSeedNode {
-    Constant(ConstantPdaSeedNode),
-    Variable(VariablePdaSeedNode),
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::{HasKind, NumberTypeNode, NumberValueNode, U8};
+    use crate::{ConstantPdaSeedNode, HasKind, NumberTypeNode, NumberValueNode, PdaSeedNode, U8};
 
     #[test]
     fn kind() {

--- a/codama-nodes/src/pda_seed_nodes/variable_pda_seed_node.rs
+++ b/codama-nodes/src/pda_seed_nodes/variable_pda_seed_node.rs
@@ -1,22 +1,4 @@
-use crate::{CamelCaseString, Docs, HasName, TypeNode};
-use codama_nodes_derive::node;
-
-#[node]
-pub struct VariablePdaSeedNode {
-    // Data.
-    pub name: CamelCaseString,
-    #[serde(default, skip_serializing_if = "crate::is_default")]
-    pub docs: Docs,
-
-    // Children.
-    pub r#type: TypeNode,
-}
-
-impl From<VariablePdaSeedNode> for crate::Node {
-    fn from(val: VariablePdaSeedNode) -> Self {
-        crate::Node::PdaSeed(val.into())
-    }
-}
+use crate::{CamelCaseString, Docs, TypeNode, VariablePdaSeedNode};
 
 impl VariablePdaSeedNode {
     pub fn new<T, U>(name: T, r#type: U) -> Self
@@ -27,14 +9,8 @@ impl VariablePdaSeedNode {
         Self {
             name: name.into(),
             docs: Docs::default(),
-            r#type: r#type.into(),
+            r#type: Box::new(r#type.into()),
         }
-    }
-}
-
-impl HasName for VariablePdaSeedNode {
-    fn name(&self) -> &CamelCaseString {
-        &self.name
     }
 }
 
@@ -47,7 +23,7 @@ mod tests {
     fn new() {
         let node = VariablePdaSeedNode::new("my_seed", NumberTypeNode::le(U32));
         assert_eq!(node.name, CamelCaseString::new("mySeed"));
-        assert_eq!(node.r#type, TypeNode::Number(NumberTypeNode::le(U32)));
+        assert_eq!(*node.r#type, TypeNode::Number(NumberTypeNode::le(U32)));
     }
 
     #[test]
@@ -55,11 +31,11 @@ mod tests {
         let node = VariablePdaSeedNode {
             name: "mySeed".into(),
             docs: vec!["Hello".to_string()].into(),
-            r#type: NumberTypeNode::le(U32).into(),
+            r#type: Box::new(NumberTypeNode::le(U32).into()),
         };
         assert_eq!(node.name, CamelCaseString::new("mySeed"));
         assert_eq!(*node.docs, vec!["Hello".to_string()]);
-        assert_eq!(node.r#type, TypeNode::Number(NumberTypeNode::le(U32)));
+        assert_eq!(*node.r#type, TypeNode::Number(NumberTypeNode::le(U32)));
     }
 
     #[test]

--- a/spec-generators/src/defaults.ts
+++ b/spec-generators/src/defaults.ts
@@ -26,6 +26,7 @@ export const CATEGORY_ROUTING: ReadonlyMap<string, CategoryRouting> = new Map([
     ['count', { nodeVariant: 'Count' }],
     ['discriminator', { nodeVariant: 'Discriminator' }],
     ['link', { nodeVariant: 'Link' }],
+    ['pdaSeed', { nodeVariant: 'PdaSeed' }],
 ]);
 
 /**
@@ -78,4 +79,32 @@ export const UNION_NAME_OVERRIDES: ReadonlyMap<string, string> = new Map([
 export const ENUMERATION_NAME_OVERRIDES: ReadonlyMap<string, string> = new Map([
     ['endianness', 'Endian'],
     ['optionalAccountStrategy', 'InstructionOptionalAccountStrategy'],
+]);
+
+/**
+ * Per-inline-union configuration.
+ *
+ * Most emittable unions are the category-main union (the standalone
+ * twin of a `registered…`); those have an obvious variant-naming
+ * rule (strip the category suffix). Inline / synthetic unions —
+ * unions used in a single attribute, with no registered twin — need
+ * an explicit allowlist so the generator knows to emit them, plus
+ * their own variant-naming convention.
+ *
+ * Each entry's key is the spec union name; the value carries:
+ *
+ *   - `stripSuffix`: the PascalCase suffix to strip from each leaf
+ *     node's kind when deriving its Rust variant name. For example,
+ *     `constantPdaSeedValue`'s flattened members include
+ *     `numberValueNode`, `programIdValueNode`, …; stripping the
+ *     `ValueNode` suffix yields variant names `Number`, `ProgramId`,
+ *     etc. — matching the convention used by today's hand-written
+ *     inline unions in the same category family.
+ */
+export interface InlineUnionConfig {
+    readonly stripSuffix?: string;
+}
+
+export const INLINE_UNIONS: ReadonlyMap<string, InlineUnionConfig> = new Map([
+    ['constantPdaSeedValue', { stripSuffix: 'ValueNode' }],
 ]);

--- a/spec-generators/src/fragments/attributeBodyLine.ts
+++ b/spec-generators/src/fragments/attributeBodyLine.ts
@@ -19,11 +19,19 @@ const RUST_KEYWORDS: ReadonlySet<string> = new Set(['type']);
  *   - Optional single              → `Option<T>` + `#[serde(skip_serializing_if = "crate::is_default")]`.
  *   - Optional Vec                 → bare `Vec<T>` + `#[serde(default, skip_serializing_if = "crate::is_default")]`.
  *   - `docs` field                 → `Docs` + `#[serde(default, skip_serializing_if = "crate::is_default")]`.
+ *
+ * Box rule (box-all-union): every direct (non-`Vec`) field whose type
+ * is a `union` is wrapped in `Box<…>`. Required → `Box<T>`; optional
+ * → `Box<Option<T>>` (box outside Option). This keeps every
+ * category-union variant pointer-sized for its union fields, which is
+ * what `clippy::large_enum_variant` actually cares about. `array(…)`,
+ * `nestedUnion`, `node`, and scalar fields are never boxed.
  */
 export function getAttributeBodyLineFragment(attr: AttributeSpec): Fragment {
     const inner = getTypeExprFragment(attr.type);
     const isOptional = attr.optional === true;
     const isVecLike = isVecLikeType(attr.type);
+    const isUnion = isUnionType(attr.type);
 
     let typeFragment: Fragment;
     let serdeAttr: string;
@@ -39,10 +47,17 @@ export function getAttributeBodyLineFragment(attr: AttributeSpec): Fragment {
         if (isVecLike) {
             typeFragment = inner;
             serdeAttr = '#[serde(default, skip_serializing_if = "crate::is_default")]';
+        } else if (isUnion) {
+            // Optional union → `Box<Option<T>>` (box outside Option).
+            typeFragment = fragment`Box<Option<${inner}>>`;
+            serdeAttr = '#[serde(skip_serializing_if = "crate::is_default")]';
         } else {
             typeFragment = fragment`Option<${inner}>`;
             serdeAttr = '#[serde(skip_serializing_if = "crate::is_default")]';
         }
+    } else if (isUnion) {
+        typeFragment = fragment`Box<${inner}>`;
+        serdeAttr = '';
     } else {
         typeFragment = inner;
         serdeAttr = '';
@@ -56,6 +71,10 @@ export function getAttributeBodyLineFragment(attr: AttributeSpec): Fragment {
 
 function isVecLikeType(type: TypeExpr): boolean {
     return type.kind === 'array';
+}
+
+function isUnionType(type: TypeExpr): boolean {
+    return type.kind === 'union';
 }
 
 function isDocsType(type: TypeExpr): boolean {

--- a/spec-generators/src/fragments/unionPage.ts
+++ b/spec-generators/src/fragments/unionPage.ts
@@ -2,7 +2,7 @@ import { pascalCase } from '@codama/fragments';
 import { type Fragment, fragment, mergeFragments } from '@codama/fragments/rust';
 import type { NodeSpec, Spec, UnionSpec } from '@codama/spec';
 
-import { UNION_NAME_OVERRIDES } from '../defaults';
+import { INLINE_UNIONS, UNION_NAME_OVERRIDES } from '../defaults';
 import { flattenNodeUnion } from '../unions';
 import { getUnionHasNameImplFragment } from './hasNameImpl';
 import { use } from './helpers';
@@ -37,21 +37,39 @@ interface UnionVariant {
 }
 
 function buildVariants(union: UnionSpec, spec: Spec): readonly UnionVariant[] {
-    const suffix = pascalCase(union.name);
+    const suffix = variantStripSuffix(union);
     return [...flattenNodeUnion(union, spec)]
         .map(node => ({ name: variantNameForNode(node.kind, suffix), node }))
         .toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
 /**
- * Variant name = pascalCase(kind) minus the union's implied suffix.
+ * The PascalCase suffix to strip from each leaf node's kind when
+ * deriving variant names. For category-main unions it defaults to
+ * `pascalCase(union.name)` (e.g. `LinkNode`, `CountNode`). For inline
+ * unions, the suffix is taken from {@link INLINE_UNIONS}; inline
+ * unions whose members don't share a common suffix can omit
+ * `stripSuffix` (no stripping happens then).
+ */
+function variantStripSuffix(union: UnionSpec): string {
+    const inline = INLINE_UNIONS.get(union.name);
+    if (inline !== undefined) return inline.stripSuffix ?? '';
+    return pascalCase(union.name);
+}
+
+/**
+ * Variant name = pascalCase(kind) minus the implied suffix.
  *
- *   - `accountLinkNode`     in union `linkNode`    → `Account`
- *   - `fixedCountNode`      in union `countNode`   → `Fixed`
- *   - `variablePdaSeedNode` in union `pdaSeedNode` → `Variable`
+ *   - `accountLinkNode`      in union `linkNode`             → `Account`
+ *   - `fixedCountNode`       in union `countNode`            → `Fixed`
+ *   - `numberValueNode`      in inline `constantPdaSeedValue`
+ *     (stripSuffix = `ValueNode`)                            → `Number`
+ *   - `programIdValueNode`   in inline `constantPdaSeedValue`
+ *     (stripSuffix = `ValueNode`)                            → `ProgramId`
  */
 function variantNameForNode(nodeKind: string, suffix: string): string {
     const pascal = pascalCase(nodeKind);
+    if (suffix === '') return pascal;
     return pascal.endsWith(suffix) ? pascal.slice(0, pascal.length - suffix.length) : pascal;
 }
 

--- a/spec-generators/src/index.ts
+++ b/spec-generators/src/index.ts
@@ -28,6 +28,8 @@ export {
     type CategoryRouting,
     CATEGORY_ROUTING,
     ENUMERATION_NAME_OVERRIDES,
+    type InlineUnionConfig,
+    INLINE_UNIONS,
     UNION_NAME_OVERRIDES,
 } from './defaults';
 export {

--- a/spec-generators/src/unions.ts
+++ b/spec-generators/src/unions.ts
@@ -1,6 +1,8 @@
 import { pascalCase } from '@codama/fragments';
 import type { NodeSpec, Spec, UnionSpec } from '@codama/spec';
 
+import { INLINE_UNIONS } from './defaults';
+
 /**
  * Spec unions starting with `registered` are category-registry unions
  * (e.g. `registeredLinkNode`); the Rust crate exposes one flattened
@@ -11,19 +13,22 @@ const REGISTERED_UNION_PREFIX = 'registered';
 
 /**
  * The spec unions in a category that the generator emits Rust enums
- * for. A union is "emittable" when it has a `registered<PascalCase>`
- * sibling in the same category — i.e. it's the category's main union
- * (the standalone twin of a registered/dispatch union). Inline /
- * synthetic unions (e.g. `constantPdaSeedValue`) don't have a twin
- * and aren't emitted as Rust enums; they're either name-aliased to an
- * existing type (via {@link UNION_NAME_OVERRIDES}) or handled
- * bespoke. Sorted alphabetically by name for stable output.
+ * for. A union is "emittable" when:
+ *
+ *   - It has a `registered<PascalCase>` sibling in the same category —
+ *     i.e. it's the category's main union (the standalone twin of a
+ *     registered/dispatch union); OR
+ *   - It appears in the {@link INLINE_UNIONS} allowlist — an
+ *     opt-in registry of inline / synthetic unions the generator
+ *     should emit despite not having a registered twin.
+ *
+ * Sorted alphabetically by name for stable output.
  */
 export function getEmittableUnions(category: Spec['categories'][number]): readonly UnionSpec[] {
     const unionNames = new Set(category.unions.map(u => u.name));
     return category.unions
         .filter(u => !u.name.startsWith(REGISTERED_UNION_PREFIX))
-        .filter(u => unionNames.has(`${REGISTERED_UNION_PREFIX}${pascalCase(u.name)}`))
+        .filter(u => unionNames.has(`${REGISTERED_UNION_PREFIX}${pascalCase(u.name)}`) || INLINE_UNIONS.has(u.name))
         .toSorted((a, b) => a.name.localeCompare(b.name));
 }
 

--- a/spec-generators/test/fragments/attributeBodyLine.test.ts
+++ b/spec-generators/test/fragments/attributeBodyLine.test.ts
@@ -1,4 +1,4 @@
-import { attribute, boolean, docs, node, optionalAttribute, stringIdentifier } from '@codama/spec/api';
+import { array, attribute, boolean, docs, node, optionalAttribute, stringIdentifier, union } from '@codama/spec/api';
 import { describe, expect, it } from 'vitest';
 
 import { getAttributeBodyLineFragment } from '../../src/fragments/attributeBodyLine';
@@ -36,5 +36,27 @@ describe('getAttributeBodyLineFragment', () => {
     it('escapes the Rust keyword `type` as `r#type` in field position', () => {
         const result = getAttributeBodyLineFragment(attribute('type', stringIdentifier()));
         expect(result.content).toBe('pub r#type: CamelCaseString,');
+    });
+
+    it('boxes a required union field as `Box<T>` (box-all-union rule)', () => {
+        const result = getAttributeBodyLineFragment(attribute('value', union('valueNode')));
+        expect(result.content).toBe('pub value: Box<ValueNode>,');
+    });
+
+    it('boxes an optional union field as `Box<Option<T>>` (box outside Option)', () => {
+        const result = getAttributeBodyLineFragment(optionalAttribute('value', union('valueNode')));
+        expect(result.content).toBe(
+            ['#[serde(skip_serializing_if = "crate::is_default")]', 'pub value: Box<Option<ValueNode>>,'].join('\n'),
+        );
+    });
+
+    it('does NOT box a `Vec<union>` field — the Vec already heap-allocates', () => {
+        const result = getAttributeBodyLineFragment(attribute('items', array(union('valueNode'))));
+        expect(result.content).toBe('pub items: Vec<ValueNode>,');
+    });
+
+    it('does NOT box a `node`-typed field (only `union` triggers the box rule)', () => {
+        const result = getAttributeBodyLineFragment(attribute('program', node('programLinkNode')));
+        expect(result.content).toBe('pub program: ProgramLinkNode,');
     });
 });

--- a/spec-generators/test/fragments/unionPage.test.ts
+++ b/spec-generators/test/fragments/unionPage.test.ts
@@ -6,6 +6,8 @@ import { getUnionPageFragment } from '../../src/fragments/unionPage';
 const spec = getSpec();
 const linkCategory = spec.categories.find(c => c.name === 'link')!;
 const linkUnion = linkCategory.unions.find(u => u.name === 'linkNode')!;
+const pdaSeedCategory = spec.categories.find(c => c.name === 'pdaSeed')!;
+const constantPdaSeedValueUnion = pdaSeedCategory.unions.find(u => u.name === 'constantPdaSeedValue')!;
 
 describe('getUnionPageFragment', () => {
     it('emits #[node_union] and a PascalCase enum name', () => {
@@ -46,5 +48,18 @@ describe('getUnionPageFragment', () => {
         expect(imports).toContain('crate::ProgramLinkNode');
         expect(imports).toContain('crate::HasName');
         expect(imports).toContain('crate::CamelCaseString');
+    });
+
+    it('honours the INLINE_UNIONS stripSuffix when naming variants of an inline union', () => {
+        // `constantPdaSeedValue` is in INLINE_UNIONS with stripSuffix: 'ValueNode'.
+        // Its flattened members include `programIdValueNode` + 14 value-node
+        // leaves; the suffix strip should yield `ProgramId`, `Number`, etc.
+        const result = getUnionPageFragment(constantPdaSeedValueUnion, spec);
+        expect(result.content).toContain('pub enum ConstantPdaSeedValue {');
+        expect(result.content).toContain('ProgramId(ProgramIdValueNode),');
+        expect(result.content).toContain('Number(NumberValueNode),');
+        expect(result.content).toContain('String(StringValueNode),');
+        // Not every variant has a stringIdentifier name -> no HasName impl.
+        expect(result.content).not.toContain('impl HasName for ConstantPdaSeedValue');
     });
 });

--- a/spec-generators/test/generate.test.ts
+++ b/spec-generators/test/generate.test.ts
@@ -57,6 +57,11 @@ describe('getRenderMap', () => {
             'link_nodes/pda_link_node.rs',
             'link_nodes/program_link_node.rs',
             'mod.rs',
+            'pda_seed_nodes/constant_pda_seed_node.rs',
+            'pda_seed_nodes/constant_pda_seed_value.rs',
+            'pda_seed_nodes/mod.rs',
+            'pda_seed_nodes/pda_seed_node.rs',
+            'pda_seed_nodes/variable_pda_seed_node.rs',
         ]);
     });
 
@@ -96,7 +101,7 @@ describe('getRenderMap', () => {
 
     it('emits a root mod.rs that re-exports every per-category subdirectory', () => {
         const entry = getFromRenderMap(map, 'mod.rs');
-        for (const dir of ['count_nodes', 'discriminator_nodes', 'link_nodes']) {
+        for (const dir of ['count_nodes', 'discriminator_nodes', 'link_nodes', 'pda_seed_nodes']) {
             expect(entry.content).toContain(`mod ${dir};`);
             expect(entry.content).toContain(`pub use ${dir}::*;`);
         }
@@ -147,6 +152,51 @@ describe('getRenderMap', () => {
             const union = getFromRenderMap(map, 'discriminator_nodes/discriminator_node.rs');
             // Not every variant has a name -> no union HasName impl.
             expect(union.content).not.toContain('impl HasName for DiscriminatorNode');
+        });
+    });
+
+    describe('pdaSeed category', () => {
+        it('routes through Node::PdaSeed and references the inline ConstantPdaSeedValue enum', () => {
+            const entry = getFromRenderMap(map, 'pda_seed_nodes/constant_pda_seed_node.rs');
+            expect(entry.content).toContain('pub struct ConstantPdaSeedNode {');
+            // Box rule: direct union fields are boxed.
+            expect(entry.content).toContain('pub r#type: Box<TypeNode>,');
+            // The value field type is the generated inline union, NOT the
+            // pre-existing ValueNode.
+            expect(entry.content).toContain('pub value: Box<ConstantPdaSeedValue>,');
+            expect(entry.content).toContain('crate::Node::PdaSeed(val.into())');
+        });
+
+        it('emits the ConstantPdaSeedValue inline-union enum with stripped variant names', () => {
+            const entry = getFromRenderMap(map, 'pda_seed_nodes/constant_pda_seed_value.rs');
+            expect(entry.content).toContain('#[node_union]');
+            expect(entry.content).toContain('pub enum ConstantPdaSeedValue {');
+            expect(entry.content).toContain('ProgramId(ProgramIdValueNode),');
+            // Sample of value-node variants (suffix `ValueNode` stripped).
+            expect(entry.content).toContain('Number(NumberValueNode),');
+            expect(entry.content).toContain('String(StringValueNode),');
+            expect(entry.content).toContain('Boolean(BooleanValueNode),');
+            // No HasName: variants like NumberValueNode have no name attribute.
+            expect(entry.content).not.toContain('impl HasName for ConstantPdaSeedValue');
+        });
+
+        it('routes VariablePdaSeedNode through Node::PdaSeed with HasName + a bare Docs field', () => {
+            const entry = getFromRenderMap(map, 'pda_seed_nodes/variable_pda_seed_node.rs');
+            expect(entry.content).toContain('pub struct VariablePdaSeedNode {');
+            expect(entry.content).toContain('pub name: CamelCaseString,');
+            expect(entry.content).toContain('pub docs: Docs,');
+            // Box rule: direct union fields are boxed.
+            expect(entry.content).toContain('pub r#type: Box<TypeNode>,');
+            expect(entry.content).toContain('impl HasName for VariablePdaSeedNode {');
+        });
+
+        it('emits the PdaSeedNode category union with Constant/Variable variants and no HasName', () => {
+            const entry = getFromRenderMap(map, 'pda_seed_nodes/pda_seed_node.rs');
+            expect(entry.content).toContain('pub enum PdaSeedNode {');
+            expect(entry.content).toContain('Constant(ConstantPdaSeedNode),');
+            expect(entry.content).toContain('Variable(VariablePdaSeedNode),');
+            // ConstantPdaSeedNode has no name -> no union HasName impl.
+            expect(entry.content).not.toContain('impl HasName for PdaSeedNode');
         });
     });
 });

--- a/spec-generators/test/unions.test.ts
+++ b/spec-generators/test/unions.test.ts
@@ -9,20 +9,29 @@ const pdaSeedCategory = spec.categories.find(c => c.name === 'pdaSeed')!;
 
 describe('getEmittableUnions', () => {
     it('returns the category-main union (the standalone twin of a `registered…`), sorted alphabetically', () => {
+        // `pdaSeed` also has `constantPdaSeedValue` in INLINE_UNIONS,
+        // so both are emittable; the sort puts `constantPdaSeedValue`
+        // before `pdaSeedNode`.
         expect(getEmittableUnions(linkCategory).map(u => u.name)).toEqual(['linkNode']);
-        expect(getEmittableUnions(pdaSeedCategory).map(u => u.name)).toEqual(['pdaSeedNode']);
+        expect(getEmittableUnions(pdaSeedCategory).map(u => u.name)).toEqual(['constantPdaSeedValue', 'pdaSeedNode']);
     });
 
     it('skips category-registry unions (`registered*`)', () => {
         expect(getEmittableUnions(linkCategory).map(u => u.name)).not.toContain('registeredLinkNode');
     });
 
-    it('skips inline / synthetic unions that lack a `registered<Name>` twin (e.g. constantPdaSeedValue)', () => {
-        // `constantPdaSeedValue` is the `constantPdaSeedNode.value` attribute's
-        // union; it has no `registered<Name>` twin (it's not a category
-        // dispatch enum) so the generator must not emit it as its own Rust
-        // enum. A later PR with inline-union support will handle it.
-        expect(getEmittableUnions(pdaSeedCategory).map(u => u.name)).not.toContain('constantPdaSeedValue');
+    it('skips inline / synthetic unions that are NOT in the INLINE_UNIONS allowlist', () => {
+        // `linkNode`'s category has no inline-union members, so we can
+        // just confirm no spurious emission. A category with inline
+        // unions out of the allowlist would also be filtered out (no
+        // such case in pdaSeed today — constantPdaSeedValue IS in the
+        // allowlist, so it appears).
+        const names = getEmittableUnions(linkCategory).map(u => u.name);
+        for (const u of linkCategory.unions) {
+            if (u.name.startsWith('registered')) continue;
+            if (u.name === 'linkNode') continue;
+            expect(names).not.toContain(u.name);
+        }
     });
 });
 


### PR DESCRIPTION
This PR introduces an `INLINE_UNIONS` allowlist in the generator so that unions without a `registered<Name>` twin can be emitted on an opt-in basis, with a per-union `stripSuffix` controlling variant naming. The infrastructure is validated end to end by completing `pdaSeed`, which was deliberately left out of the previous PR pending exactly this machinery. The `pdaSeed` category now joins `count`, `discriminator`, and `link` under `CATEGORY_ROUTING`, and `codama-nodes/src/generated/pda_seed_nodes/` gains five files: per-node `constant_pda_seed_node.rs` and `variable_pda_seed_node.rs`, the inline-union `constant_pda_seed_value.rs`, the category-union `pda_seed_node.rs`, and a `mod.rs`. The hand-written `pda_seed_nodes/*.rs` files shrink to constructors and `#[cfg(test)] mod tests` blocks, mirroring the PR #1/#2 treatment of link and count/discriminator nodes. One bespoke `impl From<ValueNode> for ConstantPdaSeedValue` is added to the hand-written `constant_pda_seed_node.rs` to bridge the broader `ValueNode` enum into the new `ConstantPdaSeedValue` superset that includes `ProgramId(ProgramIdValueNode)`. The `ConstantPdaSeedNode.value` field type changes from `ValueNode` to `ConstantPdaSeedValue`; existing call sites that pass leaf value nodes work via the auto-derived `From<Variant>` impls, and the one caller in `codama-korok-visitors/src/set_pdas_visitor.rs` that passes a resolved `ValueNode` flows through the new bridge.

Also lands the box-all-union heuristic: every direct (non-Vec) field whose type is a union is wrapped in `Box<\u2026>` (required \u2192 `Box<T>`; optional \u2192 `Box<Option<T>>`, box outside Option). This keeps every category-union variant pointer-sized for its union fields, which is what `clippy::large_enum_variant` actually cares about. The newly-generated pdaSeed structs box their `type` and `value` union fields accordingly; the hand-written constructors wrap with `Box::new(...)` and the corresponding tests dereference with `*node.r#type` / `*node.value`.