### PR TITLE
spec-generators: map float to crate::Number; remove FIELD_TYPE_OVERRIDES

### DIFF
--- a/spec-generators/src/defaults.ts
+++ b/spec-generators/src/defaults.ts
@@ -55,19 +55,3 @@ export const CATEGORY_DIRECTORIES: ReadonlyMap<string, string> = new Map([
     ['type', 'type_nodes'],
     ['value', 'value_nodes'],
 ]);
-
-/**
- * Per-field Rust-type overrides for cases where the spec's TypeExpr
- * maps to a bespoke Rust type that can't be expressed mechanically.
- * Keyed by `"<nodeKind>.<attrName>"`.
- *
- *   - `numberValueNode.number`: spec says `float(f64)` but the Rust
- *     crate uses a bespoke `Number` enum
- *     (`UnsignedInteger(u64) | SignedInteger(i64) | Float(f64)`) with
- *     a custom `serde(from/into = "JsonNumber")` and 8 `From<uN/iN/fN>`
- *     impls. The struct + derives are still generated; the field type
- *     resolves to `crate::Number` via this override and the `Number`
- *     enum + its impls stay hand-written in
- *     `value_nodes/number_value_node.rs`.
- */
-export const FIELD_TYPE_OVERRIDES: ReadonlyMap<string, string> = new Map([['numberValueNode.number', 'crate::Number']]);

--- a/spec-generators/src/fragments/attributeBodyLine.ts
+++ b/spec-generators/src/fragments/attributeBodyLine.ts
@@ -2,7 +2,6 @@ import { pascalCase, snakeCase } from '@codama/fragments';
 import { type Fragment, fragment, mergeFragments } from '@codama/fragments/rust';
 import type { AttributeSpec, TypeExpr } from '@codama/spec';
 
-import { FIELD_TYPE_OVERRIDES } from '../defaults';
 import { use } from './helpers';
 import { getTypeExprFragment } from './typeExpr';
 
@@ -29,23 +28,17 @@ const RUST_KEYWORDS: ReadonlySet<string> = new Set(['enum', 'struct', 'type']);
  * what `clippy::large_enum_variant` actually cares about. `array(…)`,
  * `nestedUnion`, `node`, and scalar fields are never boxed.
  */
-export function getAttributeBodyLineFragment(nodeKind: string, attr: AttributeSpec): Fragment {
-    const override = FIELD_TYPE_OVERRIDES.get(`${nodeKind}.${attr.name}`);
+export function getAttributeBodyLineFragment(attr: AttributeSpec): Fragment {
     // `literalUnion` is anonymous in the spec; the generator emits a
     // Rust enum shell named `pascalCase(attr.name)` (see
     // `literalUnions.ts`). The type-expression renderer can't produce
     // that name on its own — it doesn't have the attribute name — so
     // we resolve the field type here instead.
-    const isLiteralUnion = override === undefined && attr.type.kind === 'literalUnion';
-    const inner =
-        override !== undefined
-            ? use(override)
-            : isLiteralUnion
-              ? use(`crate::${pascalCase(attr.name)}`)
-              : getTypeExprFragment(attr.type);
+    const isLiteralUnion = attr.type.kind === 'literalUnion';
+    const inner = isLiteralUnion ? use(`crate::${pascalCase(attr.name)}`) : getTypeExprFragment(attr.type);
     const isOptional = attr.optional === true;
-    const isVecLike = override !== undefined ? false : isVecLikeType(attr.type);
-    const isUnion = override !== undefined ? false : isUnionType(attr.type);
+    const isVecLike = isVecLikeType(attr.type);
+    const isUnion = isUnionType(attr.type);
 
     let typeFragment: Fragment;
     let serdeAttr: string;

--- a/spec-generators/src/fragments/nodeStructFragment.ts
+++ b/spec-generators/src/fragments/nodeStructFragment.ts
@@ -2,7 +2,6 @@ import { pascalCase } from '@codama/fragments';
 import { type Fragment, fragment, mergeFragments, removeFromImportMap } from '@codama/fragments/rust';
 import { isChildAttribute, type AttributeSpec, type NodeSpec, type Spec, type TypeExpr } from '@codama/spec';
 
-import { FIELD_TYPE_OVERRIDES } from '../defaults';
 import { getNodeMacroFlavor } from '../nodeFlavor';
 import { getAttributeBodyLineFragment } from './attributeBodyLine';
 import { use } from './helpers';
@@ -34,7 +33,7 @@ export function getNodeStructFragment(node: NodeSpec, spec: Spec): Fragment {
     const raw =
         data.length === 0 && children.length === 0
             ? fragment`${header}\npub struct ${structName} {}`
-            : fragment`${header}\npub struct ${structName} {\n${buildBody(node.kind, data, children)}\n}`;
+            : fragment`${header}\npub struct ${structName} {\n${buildBody(data, children)}\n}`;
 
     // Drop the self-import a self-referential field (e.g.
     // `subInstructions: Vec<InstructionNode>`) would otherwise add —
@@ -50,7 +49,7 @@ const SCALAR_KINDS: ReadonlySet<TypeExpr['kind']> = new Set(['integer', 'float',
 function buildDeriveFragment(node: NodeSpec): Fragment | undefined {
     const isEmpty = node.attributes.length === 0;
     const isCopy = isEmpty || node.attributes.every(a => SCALAR_KINDS.has(a.type.kind));
-    const isDefault = isEmpty || node.attributes.every(a => isUnconditionallyDefaultable(node.kind, a));
+    const isDefault = isEmpty || node.attributes.every(isUnconditionallyDefaultable);
     const derives: string[] = [];
     if (isCopy) derives.push('Copy');
     if (isDefault) derives.push('Default');
@@ -67,19 +66,18 @@ function buildDeriveFragment(node: NodeSpec): Fragment | undefined {
  * Sound shapes: any `optional` attribute, `array`, `docs`, scalar
  * primitives, and the `String`-rendering kinds (`string`, `address`,
  * `codamaVersion`, `literal`). Required `union`/`enumeration`/`node`/
- * `nestedUnion`/`literalUnion` reference opaque types; required
- * `FIELD_TYPE_OVERRIDES` targets are also opaque.
+ * `nestedUnion`/`literalUnion` reference opaque types and disqualify
+ * the struct. `float` renders to `crate::Number`, which is `Copy` but
+ * NOT `Default`, so it's deliberately absent here.
  */
-function isUnconditionallyDefaultable(nodeKind: string, attr: AttributeSpec): boolean {
+function isUnconditionallyDefaultable(attr: AttributeSpec): boolean {
     if (attr.optional === true) return true;
-    if (FIELD_TYPE_OVERRIDES.has(`${nodeKind}.${attr.name}`)) return false;
     const k = attr.type.kind;
     return (
         k === 'array' ||
         k === 'docs' ||
         k === 'boolean' ||
         k === 'integer' ||
-        k === 'float' ||
         k === 'string' ||
         k === 'address' ||
         k === 'codamaVersion' ||
@@ -102,15 +100,15 @@ function partitionAttributes(node: NodeSpec): PartitionedAttributes {
     return { data, children };
 }
 
-function buildBody(nodeKind: string, data: readonly AttributeSpec[], children: readonly AttributeSpec[]): Fragment {
+function buildBody(data: readonly AttributeSpec[], children: readonly AttributeSpec[]): Fragment {
     const sections: Fragment[] = [];
-    if (data.length > 0) sections.push(buildSection(nodeKind, '// Data.', data));
-    if (children.length > 0) sections.push(buildSection(nodeKind, '// Children.', children));
+    if (data.length > 0) sections.push(buildSection('// Data.', data));
+    if (children.length > 0) sections.push(buildSection('// Children.', children));
     return mergeFragments(sections, parts => parts.join('\n\n'));
 }
 
-function buildSection(nodeKind: string, header: string, attrs: readonly AttributeSpec[]): Fragment {
-    const lines = attrs.map(attr => getAttributeBodyLineFragment(nodeKind, attr));
+function buildSection(header: string, attrs: readonly AttributeSpec[]): Fragment {
+    const lines = attrs.map(getAttributeBodyLineFragment);
     const body = mergeFragments(lines, parts => parts.join('\n'));
     return fragment`${header}\n${body}`;
 }

--- a/spec-generators/src/fragments/typeExpr.ts
+++ b/spec-generators/src/fragments/typeExpr.ts
@@ -17,11 +17,6 @@ const NUMBER_FORMAT_TO_RUST: ReadonlyMap<string, string> = new Map([
     ['i128', 'i128'],
 ]);
 
-const FLOAT_WIDTH_TO_RUST: ReadonlyMap<string, string> = new Map([
-    ['f32', 'f32'],
-    ['f64', 'f64'],
-]);
-
 /**
  * Translate a spec {@link TypeExpr} to a Rust type expression. The
  * fragment's content is the rendered type text (e.g.
@@ -35,11 +30,12 @@ const FLOAT_WIDTH_TO_RUST: ReadonlyMap<string, string> = new Map([
  *   - `string` (`identifier`)     → `CamelCaseString`
  *   - `string` (`version`)        → `String`
  *   - `boolean`                   → `bool`
- *   - `integer`/`float`           → `uN` / `iN` / `fN` by width
+ *   - `integer`                   → `uN` / `iN` by width
+ *   - `float`                     → `crate::Number` (bespoke u64|i64|f64 enum)
  *   - `docs`                      → `Docs`
- *   - `enumeration('foo')`        → `Foo` (subject to overrides)
+ *   - `enumeration('foo')`        → `Foo`
  *   - `node('fooBar')`            → `FooBar`
- *   - `union('fooBar')`           → `FooBar` (subject to overrides)
+ *   - `union('fooBar')`           → `FooBar`
  *   - `nestedUnion('alias','k')`  → `Alias<Kind>` (only `nestedTypeNode` in v1)
  *   - `array(of)`                 → `Vec<Of>`
  *   - `tuple(items)`              → `(A, B, …)`
@@ -58,11 +54,12 @@ export function getTypeExprFragment(expr: TypeExpr): Fragment {
             if (!rust) throw new Error(`unknown integer width "${expr.width}"`);
             return fragment`${rust}`;
         }
-        case 'float': {
-            const rust = FLOAT_WIDTH_TO_RUST.get(expr.width);
-            if (!rust) throw new Error(`unknown float width "${expr.width}"`);
-            return fragment`${rust}`;
-        }
+        case 'float':
+            // v1's only float (`numberValueNode.number`) is `f64`; Rust uses
+            // the bespoke `Number` enum (`u64|i64|f64` with custom serde +
+            // `From<uN/iN/fN>` impls). Mirrors the JS generator, which maps
+            // `float → number` (TS's polymorphic number type).
+            return use('crate::Number');
         case 'literal':
             // The literal value lives in the hand-written `Default`.
             return fragment`String`;

--- a/spec-generators/src/index.ts
+++ b/spec-generators/src/index.ts
@@ -34,7 +34,7 @@ import {
 import { getRepoDirectory } from './repoDirectory';
 import { getEmittableUnions, isRegisteredCategoryUnion } from './unions';
 
-export { CATEGORY_DIRECTORIES, type CategoryRouting, CATEGORY_ROUTING, FIELD_TYPE_OVERRIDES } from './defaults';
+export { CATEGORY_DIRECTORIES, type CategoryRouting, CATEGORY_ROUTING } from './defaults';
 export {
     buildRenderScope,
     type GenerateOptions,

--- a/spec-generators/test/fragments/attributeBodyLine.test.ts
+++ b/spec-generators/test/fragments/attributeBodyLine.test.ts
@@ -1,33 +1,23 @@
-import {
-    array,
-    attribute,
-    boolean,
-    docs,
-    f64,
-    node,
-    optionalAttribute,
-    stringIdentifier,
-    union,
-} from '@codama/spec/api';
+import { array, attribute, boolean, docs, node, optionalAttribute, stringIdentifier, union } from '@codama/spec/api';
 import { describe, expect, it } from 'vitest';
 
 import { getAttributeBodyLineFragment } from '../../src/fragments/attributeBodyLine';
 
 describe('getAttributeBodyLineFragment', () => {
     it('renders a required primitive field with no serde attribute and no leading indentation', () => {
-        const result = getAttributeBodyLineFragment('someNode', attribute('isWritable', boolean()));
+        const result = getAttributeBodyLineFragment(attribute('isWritable', boolean()));
         // No leading whitespace — rustfmt restores indentation on the
         // generated file.
         expect(result.content).toBe('pub is_writable: bool,');
     });
 
     it('renders a required stringIdentifier field as CamelCaseString with no serde attribute', () => {
-        const result = getAttributeBodyLineFragment('someNode', attribute('name', stringIdentifier()));
+        const result = getAttributeBodyLineFragment(attribute('name', stringIdentifier()));
         expect(result.content).toBe('pub name: CamelCaseString,');
     });
 
     it('renders an optional single-valued node attribute with Option<…> + skip_serializing_if', () => {
-        const result = getAttributeBodyLineFragment('someNode', optionalAttribute('program', node('programLinkNode')));
+        const result = getAttributeBodyLineFragment(optionalAttribute('program', node('programLinkNode')));
         expect(result.content).toBe(
             ['#[serde(skip_serializing_if = "crate::is_default")]', 'pub program: Option<ProgramLinkNode>,'].join('\n'),
         );
@@ -36,44 +26,37 @@ describe('getAttributeBodyLineFragment', () => {
     it('renders a docs attribute as a bare `Docs` regardless of `optional`, never wrapping it in Option', () => {
         // `Docs` already has a sensible `Default` (empty Vec) + `is_default`,
         // so the spec's `optional: true` collapses to the same serde shape.
-        const required = getAttributeBodyLineFragment('someNode', attribute('docs', docs()));
-        const optional = getAttributeBodyLineFragment('someNode', optionalAttribute('docs', docs()));
+        const required = getAttributeBodyLineFragment(attribute('docs', docs()));
+        const optional = getAttributeBodyLineFragment(optionalAttribute('docs', docs()));
         const expected = ['#[serde(default, skip_serializing_if = "crate::is_default")]', 'pub docs: Docs,'].join('\n');
         expect(required.content).toBe(expected);
         expect(optional.content).toBe(expected);
     });
 
     it('escapes the Rust keyword `type` as `r#type` in field position', () => {
-        const result = getAttributeBodyLineFragment('someNode', attribute('type', stringIdentifier()));
+        const result = getAttributeBodyLineFragment(attribute('type', stringIdentifier()));
         expect(result.content).toBe('pub r#type: CamelCaseString,');
     });
 
     it('boxes a required union field as `Box<T>` (box-all-union rule)', () => {
-        const result = getAttributeBodyLineFragment('someNode', attribute('value', union('valueNode')));
+        const result = getAttributeBodyLineFragment(attribute('value', union('valueNode')));
         expect(result.content).toBe('pub value: Box<ValueNode>,');
     });
 
     it('boxes an optional union field as `Box<Option<T>>` (box outside Option)', () => {
-        const result = getAttributeBodyLineFragment('someNode', optionalAttribute('value', union('valueNode')));
+        const result = getAttributeBodyLineFragment(optionalAttribute('value', union('valueNode')));
         expect(result.content).toBe(
             ['#[serde(skip_serializing_if = "crate::is_default")]', 'pub value: Box<Option<ValueNode>>,'].join('\n'),
         );
     });
 
     it('does NOT box a `Vec<union>` field — the Vec already heap-allocates', () => {
-        const result = getAttributeBodyLineFragment('someNode', attribute('items', array(union('valueNode'))));
+        const result = getAttributeBodyLineFragment(attribute('items', array(union('valueNode'))));
         expect(result.content).toBe('pub items: Vec<ValueNode>,');
     });
 
     it('does NOT box a `node`-typed field (only `union` triggers the box rule)', () => {
-        const result = getAttributeBodyLineFragment('someNode', attribute('program', node('programLinkNode')));
+        const result = getAttributeBodyLineFragment(attribute('program', node('programLinkNode')));
         expect(result.content).toBe('pub program: ProgramLinkNode,');
-    });
-
-    it('applies FIELD_TYPE_OVERRIDES for a (nodeKind, attrName) pair (e.g. numberValueNode.number → Number)', () => {
-        // Spec says `f64`; the override pins Rust to the bespoke `Number` enum.
-        const result = getAttributeBodyLineFragment('numberValueNode', attribute('number', f64()));
-        expect(result.content).toBe('pub number: Number,');
-        expect([...result.imports.keys()]).toContain('crate::Number');
     });
 });

--- a/spec-generators/test/fragments/typeExpr.test.ts
+++ b/spec-generators/test/fragments/typeExpr.test.ts
@@ -4,6 +4,7 @@ import {
     boolean,
     docs,
     enumeration,
+    f64,
     literal,
     literalUnion,
     nestedUnion,
@@ -38,6 +39,15 @@ describe('getTypeExprFragment', () => {
 
     it('renders integer widths to the matching Rust primitive', () => {
         expect(getTypeExprFragment(u32()).content).toBe('u32');
+    });
+
+    it('renders float as the bespoke `crate::Number` enum (mirrors JS `float → number`)', () => {
+        // v1's only float (`numberValueNode.number`) is `f64`; Rust's
+        // `Number` enum (`u64|i64|f64` with custom serde) is the
+        // analogue of TS's polymorphic `number`.
+        const result = getTypeExprFragment(f64());
+        expect(result.content).toBe('Number');
+        expect([...result.imports.keys()]).toEqual(['crate::Number']);
     });
 
     it("renders the v1 `literal('codama')` TypeExpr as `String`", () => {

--- a/spec-generators/test/generate.test.ts
+++ b/spec-generators/test/generate.test.ts
@@ -343,11 +343,13 @@ describe('getRenderMap', () => {
             }
         });
 
-        it('honours FIELD_TYPE_OVERRIDES on numberValueNode.number → Number + #[derive(Copy)]', () => {
+        it('renders numberValueNode.number as `Number` (float → Number) + #[derive(Copy)]', () => {
             const entry = getFromRenderMap(map, 'value_nodes/number_value_node.rs');
             expect(entry.content).toContain('pub struct NumberValueNode {');
             expect(entry.content).toContain('pub number: Number,');
-            // Number is a single scalar -> heuristic derives Copy.
+            // `Number` is `Copy` but NOT `Default`, so the heuristic
+            // derives `Copy` only — `numberValueNode` has a hand-written
+            // `impl Default`.
             expect(entry.content).toContain('#[derive(Copy)]');
         });
 


### PR DESCRIPTION
The sole entry in `FIELD_TYPE_OVERRIDES` — `numberValueNode.number → crate::Number` — wasn't really a per-field exception: it was the spec's only `float`, and the JS generator already maps `float → number`. `Number` (a `u64|i64|f64` enum with custom serde) is the exact Rust analogue, so the mapping now lives in `typeExpr.ts` and the whole override surface collapses. `attributeBodyLine.ts` loses its override lookup (and its `nodeKind` parameter); `nodeStructFragment.ts`'s Default heuristic drops the opaque-check and moves `float` out of the Default-able set (`Number` is `Copy`, not `Default`), keeping it in `SCALAR_KINDS` for `Copy`.

Generated output is byte-identical: `NumberValueNode` keeps `pub number: Number,`, `#[derive(Copy)]`, and the hand-written `Number` enum is untouched. Tests move alongside the source. No per-field/per-name overrides remain.