### PR TITLE
Omit empty node arrays from serialised IDLs

### DIFF
--- a/codama-nodes/src/contextual_value_nodes/pda_value_node.rs
+++ b/codama-nodes/src/contextual_value_nodes/pda_value_node.rs
@@ -87,16 +87,17 @@ mod tests {
     fn to_json() {
         let node = PdaValueNode::new(PdaLinkNode::new("myPda"), vec![]);
         let json = serde_json::to_string(&node).unwrap();
+        // Empty arrays are omitted on write (skip-when-empty convention).
         assert_eq!(
             json,
-            r#"{"kind":"pdaValueNode","pda":{"kind":"pdaLinkNode","name":"myPda"},"seeds":[]}"#
+            r#"{"kind":"pdaValueNode","pda":{"kind":"pdaLinkNode","name":"myPda"}}"#
         );
     }
 
     #[test]
     fn from_json() {
-        let json: &str =
-            r#"{"kind":"pdaValueNode","pda":{"kind":"pdaLinkNode","name":"myPda"},"seeds":[]}"#;
+        // Absent arrays default to empty on read (skip-when-empty convention).
+        let json: &str = r#"{"kind":"pdaValueNode","pda":{"kind":"pdaLinkNode","name":"myPda"}}"#;
         let node: PdaValueNode = serde_json::from_str(json).unwrap();
         assert_eq!(node, PdaValueNode::new(PdaLinkNode::new("myPda"), vec![]));
     }
@@ -109,9 +110,10 @@ mod tests {
             AccountValueNode::new("myProgramAccount"),
         );
         let json = serde_json::to_string(&node).unwrap();
+        // Empty arrays are omitted on write (skip-when-empty convention).
         assert_eq!(
             json,
-            r#"{"kind":"pdaValueNode","pda":{"kind":"pdaLinkNode","name":"myPda"},"seeds":[],"programId":{"kind":"accountValueNode","name":"myProgramAccount"}}"#
+            r#"{"kind":"pdaValueNode","pda":{"kind":"pdaLinkNode","name":"myPda"},"programId":{"kind":"accountValueNode","name":"myProgramAccount"}}"#
         );
     }
 }

--- a/codama-nodes/src/generated/contextual_value_nodes/pda_value_node.rs
+++ b/codama-nodes/src/generated/contextual_value_nodes/pda_value_node.rs
@@ -5,6 +5,7 @@ use codama_nodes_derive::node;
 pub struct PdaValueNode {
     // Children.
     pub pda: Box<PdaValuePda>,
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub seeds: Vec<PdaSeedValueNode>,
     #[serde(skip_serializing_if = "crate::is_default")]
     pub program_id: Box<Option<PdaValueProgramId>>,

--- a/codama-nodes/src/generated/instruction_node.rs
+++ b/codama-nodes/src/generated/instruction_node.rs
@@ -17,7 +17,9 @@ pub struct InstructionNode {
     pub optional_account_strategy: Option<OptionalAccountStrategy>,
 
     // Children.
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub accounts: Vec<InstructionAccountNode>,
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub arguments: Vec<InstructionArgumentNode>,
     #[serde(default, skip_serializing_if = "crate::is_default")]
     pub extra_arguments: Vec<InstructionArgumentNode>,

--- a/codama-nodes/src/generated/pda_node.rs
+++ b/codama-nodes/src/generated/pda_node.rs
@@ -12,6 +12,7 @@ pub struct PdaNode {
     pub program_id: Option<String>,
 
     // Children.
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub seeds: Vec<PdaSeedNode>,
 }
 

--- a/codama-nodes/src/generated/program_node.rs
+++ b/codama-nodes/src/generated/program_node.rs
@@ -17,12 +17,19 @@ pub struct ProgramNode {
     pub docs: Docs,
 
     // Children.
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub accounts: Vec<AccountNode>,
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub instructions: Vec<InstructionNode>,
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub defined_types: Vec<DefinedTypeNode>,
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub pdas: Vec<PdaNode>,
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub events: Vec<EventNode>,
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub errors: Vec<ErrorNode>,
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub constants: Vec<ConstantNode>,
 }
 

--- a/codama-nodes/src/generated/root_node.rs
+++ b/codama-nodes/src/generated/root_node.rs
@@ -9,5 +9,6 @@ pub struct RootNode {
 
     // Children.
     pub program: ProgramNode,
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub additional_programs: Vec<ProgramNode>,
 }

--- a/codama-nodes/src/generated/type_nodes/enum_type_node.rs
+++ b/codama-nodes/src/generated/type_nodes/enum_type_node.rs
@@ -4,6 +4,7 @@ use codama_nodes_derive::type_node;
 #[type_node]
 pub struct EnumTypeNode {
     // Children.
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub variants: Vec<EnumVariantTypeNode>,
     pub size: NestedTypeNode<NumberTypeNode>,
 }

--- a/codama-nodes/src/generated/type_nodes/struct_type_node.rs
+++ b/codama-nodes/src/generated/type_nodes/struct_type_node.rs
@@ -5,6 +5,7 @@ use codama_nodes_derive::type_node;
 #[derive(Default)]
 pub struct StructTypeNode {
     // Children.
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub fields: Vec<StructFieldTypeNode>,
 }
 

--- a/codama-nodes/src/generated/type_nodes/tuple_type_node.rs
+++ b/codama-nodes/src/generated/type_nodes/tuple_type_node.rs
@@ -5,6 +5,7 @@ use codama_nodes_derive::type_node;
 #[derive(Default)]
 pub struct TupleTypeNode {
     // Children.
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub items: Vec<TypeNode>,
 }
 

--- a/codama-nodes/src/generated/value_nodes/array_value_node.rs
+++ b/codama-nodes/src/generated/value_nodes/array_value_node.rs
@@ -5,6 +5,7 @@ use codama_nodes_derive::node;
 #[derive(Default)]
 pub struct ArrayValueNode {
     // Children.
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub items: Vec<ValueNode>,
 }
 

--- a/codama-nodes/src/generated/value_nodes/map_value_node.rs
+++ b/codama-nodes/src/generated/value_nodes/map_value_node.rs
@@ -5,6 +5,7 @@ use codama_nodes_derive::node;
 #[derive(Default)]
 pub struct MapValueNode {
     // Children.
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub entries: Vec<MapEntryValueNode>,
 }
 

--- a/codama-nodes/src/generated/value_nodes/set_value_node.rs
+++ b/codama-nodes/src/generated/value_nodes/set_value_node.rs
@@ -5,6 +5,7 @@ use codama_nodes_derive::node;
 #[derive(Default)]
 pub struct SetValueNode {
     // Children.
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub items: Vec<ValueNode>,
 }
 

--- a/codama-nodes/src/generated/value_nodes/struct_value_node.rs
+++ b/codama-nodes/src/generated/value_nodes/struct_value_node.rs
@@ -5,6 +5,7 @@ use codama_nodes_derive::node;
 #[derive(Default)]
 pub struct StructValueNode {
     // Children.
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub fields: Vec<StructFieldValueNode>,
 }
 

--- a/codama-nodes/src/generated/value_nodes/tuple_value_node.rs
+++ b/codama-nodes/src/generated/value_nodes/tuple_value_node.rs
@@ -5,6 +5,7 @@ use codama_nodes_derive::node;
 #[derive(Default)]
 pub struct TupleValueNode {
     // Children.
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub items: Vec<ValueNode>,
 }
 

--- a/codama-nodes/src/instruction_node.rs
+++ b/codama-nodes/src/instruction_node.rs
@@ -61,16 +61,14 @@ mod tests {
             ..InstructionNode::default()
         };
         let json = serde_json::to_string(&node).unwrap();
-        assert_eq!(
-            json,
-            r#"{"kind":"instructionNode","name":"myInstruction","accounts":[],"arguments":[]}"#
-        );
+        // Empty arrays are omitted on write (skip-when-empty convention).
+        assert_eq!(json, r#"{"kind":"instructionNode","name":"myInstruction"}"#);
     }
 
     #[test]
     fn from_json() {
-        let json =
-            r#"{"kind":"instructionNode","name":"myInstruction","accounts":[],"arguments":[]}"#;
+        // Absent arrays default to empty on read (skip-when-empty convention).
+        let json = r#"{"kind":"instructionNode","name":"myInstruction"}"#;
         let node: InstructionNode = serde_json::from_str(json).unwrap();
         assert_eq!(
             node,

--- a/codama-nodes/src/pda_node.rs
+++ b/codama-nodes/src/pda_node.rs
@@ -66,12 +66,14 @@ mod tests {
     fn to_json() {
         let node = PdaNode::new("myPda", vec![]);
         let json = serde_json::to_string(&node).unwrap();
-        assert_eq!(json, r#"{"kind":"pdaNode","name":"myPda","seeds":[]}"#);
+        // Empty arrays are omitted on write (skip-when-empty convention).
+        assert_eq!(json, r#"{"kind":"pdaNode","name":"myPda"}"#);
     }
 
     #[test]
     fn from_json() {
-        let json = r#"{"kind":"pdaNode","name":"myPda","seeds":[]}"#;
+        // Absent arrays default to empty on read (skip-when-empty convention).
+        let json = r#"{"kind":"pdaNode","name":"myPda"}"#;
         let node: PdaNode = serde_json::from_str(json).unwrap();
         assert_eq!(node, PdaNode::new("myPda", vec![]));
     }

--- a/codama-nodes/src/program_node.rs
+++ b/codama-nodes/src/program_node.rs
@@ -125,15 +125,17 @@ mod tests {
             ..ProgramNode::default()
         };
         let json = serde_json::to_string(&node).unwrap();
+        // Empty arrays are omitted on write (skip-when-empty convention).
         assert_eq!(
             json,
-            r#"{"kind":"programNode","name":"myProgram","publicKey":"1234..5678","version":"1.2.3","accounts":[],"instructions":[],"definedTypes":[],"pdas":[],"events":[],"errors":[],"constants":[]}"#
+            r#"{"kind":"programNode","name":"myProgram","publicKey":"1234..5678","version":"1.2.3"}"#
         );
     }
 
     #[test]
     fn from_json() {
-        let json = r#"{"kind":"programNode","name":"myProgram","publicKey":"1234..5678","version":"1.2.3","accounts":[],"instructions":[],"definedTypes":[],"pdas":[],"events":[],"errors":[],"constants":[]}"#;
+        // Absent arrays default to empty on read (skip-when-empty convention).
+        let json = r#"{"kind":"programNode","name":"myProgram","publicKey":"1234..5678","version":"1.2.3"}"#;
         let node: ProgramNode = serde_json::from_str(json).unwrap();
         assert_eq!(
             node,

--- a/codama-nodes/src/root_node.rs
+++ b/codama-nodes/src/root_node.rs
@@ -99,15 +99,17 @@ mod tests {
             ..ProgramNode::default()
         });
         let json = serde_json::to_string(&node).unwrap();
+        // Empty arrays are omitted on write (skip-when-empty convention).
         assert_eq!(
             json,
-            r#"{"kind":"rootNode","standard":"codama","version":"1.8.0","program":{"kind":"programNode","name":"myProgram","publicKey":"1234..5678","version":"1.2.3","accounts":[],"instructions":[],"definedTypes":[],"pdas":[],"events":[],"errors":[],"constants":[]},"additionalPrograms":[]}"#
+            r#"{"kind":"rootNode","standard":"codama","version":"1.8.0","program":{"kind":"programNode","name":"myProgram","publicKey":"1234..5678","version":"1.2.3"}}"#
         );
     }
 
     #[test]
     fn from_json() {
-        let json = r#"{"kind":"rootNode","standard":"codama","version":"1.8.0","program":{"kind":"programNode","name":"myProgram","publicKey":"1234..5678","version":"1.2.3","accounts":[],"instructions":[],"definedTypes":[],"pdas":[],"events":[],"errors":[],"constants":[]},"additionalPrograms":[]}"#;
+        // Absent arrays default to empty on read (skip-when-empty convention).
+        let json = r#"{"kind":"rootNode","standard":"codama","version":"1.8.0","program":{"kind":"programNode","name":"myProgram","publicKey":"1234..5678","version":"1.2.3"}}"#;
         let node: RootNode = serde_json::from_str(json).unwrap();
         assert_eq!(
             node,

--- a/codama-nodes/src/type_nodes/enum_struct_variant_type_node.rs
+++ b/codama-nodes/src/type_nodes/enum_struct_variant_type_node.rs
@@ -91,15 +91,17 @@ mod tests {
     fn to_json() {
         let node = EnumStructVariantTypeNode::new("my_variant", StructTypeNode::new(vec![]));
         let json = serde_json::to_string(&node).unwrap();
+        // Empty arrays are omitted on write (skip-when-empty convention).
         assert_eq!(
             json,
-            r#"{"kind":"enumStructVariantTypeNode","name":"myVariant","struct":{"kind":"structTypeNode","fields":[]}}"#
+            r#"{"kind":"enumStructVariantTypeNode","name":"myVariant","struct":{"kind":"structTypeNode"}}"#
         );
     }
 
     #[test]
     fn from_json() {
-        let json = r#"{"kind":"enumStructVariantTypeNode","name":"myVariant","struct":{"kind":"structTypeNode","fields":[]}}"#;
+        // Absent arrays default to empty on read (skip-when-empty convention).
+        let json = r#"{"kind":"enumStructVariantTypeNode","name":"myVariant","struct":{"kind":"structTypeNode"}}"#;
         let node: EnumStructVariantTypeNode = serde_json::from_str(json).unwrap();
         assert_eq!(
             node,

--- a/codama-nodes/src/type_nodes/enum_tuple_variant_type_node.rs
+++ b/codama-nodes/src/type_nodes/enum_tuple_variant_type_node.rs
@@ -91,15 +91,17 @@ mod tests {
     fn to_json() {
         let node = EnumTupleVariantTypeNode::new("my_variant", TupleTypeNode::new(vec![]));
         let json = serde_json::to_string(&node).unwrap();
+        // Empty arrays are omitted on write (skip-when-empty convention).
         assert_eq!(
             json,
-            r#"{"kind":"enumTupleVariantTypeNode","name":"myVariant","tuple":{"kind":"tupleTypeNode","items":[]}}"#
+            r#"{"kind":"enumTupleVariantTypeNode","name":"myVariant","tuple":{"kind":"tupleTypeNode"}}"#
         );
     }
 
     #[test]
     fn from_json() {
-        let json = r#"{"kind":"enumTupleVariantTypeNode","name":"myVariant","tuple":{"kind":"tupleTypeNode","items":[]}}"#;
+        // Absent arrays default to empty on read (skip-when-empty convention).
+        let json = r#"{"kind":"enumTupleVariantTypeNode","name":"myVariant","tuple":{"kind":"tupleTypeNode"}}"#;
         let node: EnumTupleVariantTypeNode = serde_json::from_str(json).unwrap();
         assert_eq!(
             node,

--- a/codama-nodes/src/type_nodes/hidden_prefix_type_node.rs
+++ b/codama-nodes/src/type_nodes/hidden_prefix_type_node.rs
@@ -10,6 +10,7 @@ pub struct HiddenPrefixTypeNode<T: TypeNodeUnionTrait> {
     // Children.
     #[serde(bound = "T: TypeNodeUnionTrait")]
     pub r#type: Box<T>,
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub prefix: Vec<ConstantValueNode>,
 }
 

--- a/codama-nodes/src/type_nodes/hidden_suffix_type_node.rs
+++ b/codama-nodes/src/type_nodes/hidden_suffix_type_node.rs
@@ -10,6 +10,7 @@ pub struct HiddenSuffixTypeNode<T: TypeNodeUnionTrait> {
     // Children.
     #[serde(bound = "T: TypeNodeUnionTrait")]
     pub r#type: Box<T>,
+    #[serde(default, skip_serializing_if = "crate::is_default")]
     pub suffix: Vec<ConstantValueNode>,
 }
 

--- a/codama/tests/membership/mod.rs
+++ b/codama/tests/membership/mod.rs
@@ -72,7 +72,6 @@ fn get_idl() {
         }
       }
     ],
-    "instructions": [],
     "definedTypes": [
       {
         "kind": "definedTypeNode",
@@ -134,12 +133,8 @@ fn get_idl() {
           }
         ]
       }
-    ],
-    "events": [],
-    "errors": [],
-    "constants": []
-  },
-  "additionalPrograms": []
+    ]
+  }
 }"#
     );
 }

--- a/codama/tests/system/mod.rs
+++ b/codama/tests/system/mod.rs
@@ -917,8 +917,6 @@ fn get_idl() {
         }
       }
     ],
-    "pdas": [],
-    "events": [],
     "errors": [
       {
         "kind": "errorNode",
@@ -974,10 +972,8 @@ fn get_idl() {
         "code": 8,
         "message": "specified nonce does not match stored nonce"
       }
-    ],
-    "constants": []
-  },
-  "additionalPrograms": []
+    ]
+  }
 }"#
     );
 }

--- a/spec-generators/src/fragments/attributeBodyLine.ts
+++ b/spec-generators/src/fragments/attributeBodyLine.ts
@@ -16,9 +16,13 @@ const RUST_KEYWORDS: ReadonlySet<string> = new Set(['enum', 'struct', 'type']);
  *
  * Serde rules:
  *
- *   - Required, non-Vec field      → no `#[serde]` attr.
+ *   - Any Vec field                → bare `Vec<T>` + `#[serde(default, skip_serializing_if = "crate::is_default")]`,
+ *                                    regardless of `optional`. Arrays are omitted when empty on write and default
+ *                                    to `[]` when absent on read (an absent array and an empty array are
+ *                                    semantically identical). See the "Array attributes are omitted when empty"
+ *                                    convention in the `@codama/spec` README.
+ *   - Required non-Vec, non-union  → no `#[serde]` attr (required unions are boxed below).
  *   - Optional single              → `Option<T>` + `#[serde(skip_serializing_if = "crate::is_default")]`.
- *   - Optional Vec                 → bare `Vec<T>` + `#[serde(default, skip_serializing_if = "crate::is_default")]`.
  *   - `docs` field                 → `Docs` + `#[serde(default, skip_serializing_if = "crate::is_default")]`.
  *
  * Box rule (box-all-union): every direct (non-`Vec`) field whose type
@@ -53,11 +57,17 @@ export function getAttributeBodyLineFragment(attr: AttributeSpec): Fragment {
         // hand-written convention.
         typeFragment = inner;
         serdeAttr = '#[serde(default, skip_serializing_if = "crate::is_default")]';
+    } else if (isVecLike) {
+        // Every array is a bare `Vec<T>` that skips-when-empty and
+        // defaults-when-absent, independent of `optional`. See the
+        // "Array attributes are omitted when empty" convention in the
+        // `@codama/spec` README. `array(union(...))` fields are Vecs, not
+        // bare unions, so this branch must precede the union branch below;
+        // the element type's own boxing is handled by `getTypeExprFragment`.
+        typeFragment = inner;
+        serdeAttr = '#[serde(default, skip_serializing_if = "crate::is_default")]';
     } else if (isOptional) {
-        if (isVecLike) {
-            typeFragment = inner;
-            serdeAttr = '#[serde(default, skip_serializing_if = "crate::is_default")]';
-        } else if (isUnion) {
+        if (isUnion) {
             // Optional union → `Box<Option<T>>` (box outside Option).
             typeFragment = fragment`Box<Option<${inner}>>`;
             serdeAttr = '#[serde(skip_serializing_if = "crate::is_default")]';

--- a/spec-generators/test/fragments/attributeBodyLine.test.ts
+++ b/spec-generators/test/fragments/attributeBodyLine.test.ts
@@ -62,7 +62,24 @@ describe('getAttributeBodyLineFragment', () => {
 
     it('does NOT box a `Vec<union>` field — the Vec already heap-allocates', () => {
         const result = getAttributeBodyLineFragment(attribute('items', array(union('valueNode'))));
-        expect(result.content).toBe('pub items: Vec<ValueNode>,');
+        expect(result.content).toBe(
+            ['#[serde(default, skip_serializing_if = "crate::is_default")]', 'pub items: Vec<ValueNode>,'].join('\n'),
+        );
+    });
+
+    it('gives a required array field the same skip-when-empty serde attrs as an optional one', () => {
+        // Arrays are omitted when empty on write and default to `[]` when
+        // absent on read, independent of `optional`. See the "Array
+        // attributes are omitted when empty" convention in the `@codama/spec`
+        // README.
+        const required = getAttributeBodyLineFragment(attribute('accounts', array(node('accountNode'))));
+        const optional = getAttributeBodyLineFragment(optionalAttribute('accounts', array(node('accountNode'))));
+        const expected = [
+            '#[serde(default, skip_serializing_if = "crate::is_default")]',
+            'pub accounts: Vec<AccountNode>,',
+        ].join('\n');
+        expect(required.content).toBe(expected);
+        expect(optional.content).toBe(expected);
     });
 
     it('does NOT box a `node`-typed field (only `union`/`anyNode` triggers the box rule)', () => {


### PR DESCRIPTION
This PR makes every node array skip serialisation when empty and default to `[]` when absent, implementing the array convention documented in `@codama/spec`. The Rust spec generator now emits `#[serde(default, skip_serializing_if = "crate::is_default")]` for every `Vec` field regardless of whether the attribute is optional, so formerly-required arrays like `ProgramNode.accounts`, `InstructionNode.arguments`, and `StructTypeNode.fields` are dropped from the wire form when empty and tolerate absence on read. The generated `codama-nodes` structs are regenerated accordingly, the two hand-written `HiddenPrefix`/`HiddenSuffix` type nodes get the same treatment, and the round-trip tests assert the slimmer output while proving that absent arrays deserialise to empty vectors. Reading remains backwards-compatible: IDLs that still serialise empty arrays continue to parse. `cargo test --workspace`, `cargo fmt`, and `clippy` are green.