### PR TITLE
Bump Rust toolchain to 1.92.0 to fix cargo-release install

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   RUSTFLAGS: "-Dwarnings"
-  RUST_TOOLCHAIN: "1.91.1"
+  RUST_TOOLCHAIN: "1.92.0"
 
 jobs:
   lint:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ env:
   # It also helps prevent rate limiting on the registry.
   PUBLISH_GRACE_SLEEP: 25
   RUSTFLAGS: "-Dwarnings"
-  RUST_TOOLCHAIN: "1.91.1"
+  RUST_TOOLCHAIN: "1.92.0"
 
 on:
   workflow_dispatch:
@@ -74,7 +74,7 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Install Cargo Release
-        run: which cargo-release || cargo +${{ env.RUST_TOOLCHAIN }} install cargo-release
+        run: which cargo-release || cargo +${{ env.RUST_TOOLCHAIN }} install cargo-release --locked
 
       - name: Ensure CARGO_REGISTRY_TOKEN variable is set
         env:

--- a/codama-macros/tests/codama_account_derive/multiple_types.fail.rs
+++ b/codama-macros/tests/codama_account_derive/multiple_types.fail.rs
@@ -1,4 +1,4 @@
-use codama_macros::{codama, CodamaAccount};
+use codama_macros::CodamaAccount;
 
 #[derive(CodamaAccount)]
 #[codama(type = boolean)]

--- a/codama-macros/tests/codama_attribute/on_fields.fail.rs
+++ b/codama-macros/tests/codama_attribute/on_fields.fail.rs
@@ -1,4 +1,4 @@
-use codama_macros::{codama, CodamaType};
+use codama_macros::CodamaType;
 
 #[derive(CodamaType)]
 pub struct StructTest {

--- a/codama-macros/tests/codama_event_derive/multiple_types.fail.rs
+++ b/codama-macros/tests/codama_event_derive/multiple_types.fail.rs
@@ -1,4 +1,4 @@
-use codama_macros::{codama, CodamaEvent};
+use codama_macros::CodamaEvent;
 
 #[derive(CodamaEvent)]
 #[codama(type = boolean)]

--- a/codama-macros/tests/codama_instruction_derive/multiple_types.fail.rs
+++ b/codama-macros/tests/codama_instruction_derive/multiple_types.fail.rs
@@ -1,4 +1,4 @@
-use codama_macros::{codama, CodamaInstruction};
+use codama_macros::CodamaInstruction;
 
 #[derive(CodamaInstruction)]
 #[codama(type = boolean)]

--- a/codama-macros/tests/codama_type_derive/multiple_types.fail.rs
+++ b/codama-macros/tests/codama_type_derive/multiple_types.fail.rs
@@ -1,4 +1,4 @@
-use codama_macros::{codama, CodamaType};
+use codama_macros::CodamaType;
 
 #[derive(CodamaType)]
 #[codama(type = boolean)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.91.1"
+channel = "1.92.0"


### PR DESCRIPTION
This PR fixes the `Publish Crates` workflow, which broke because `cargo-release@1.1.3` (published 2026-07-10) requires Rust 1.92 while the workflow pinned 1.91.1, causing `cargo install cargo-release` to abort during resolution with exit code 101. It bumps the pinned toolchain to `1.92.0` across `publish.yml`, `main.yml`, and `rust-toolchain.toml`, and adds `--locked` to the `cargo install` so future runs use `cargo-release`'s own lockfile and are insulated from transitive-dependency MSRV drift. The five `codama-macros` compile-fail fixtures drop their now-unused `codama` import, which Rust 1.92 flags under `-Dwarnings`; removing it keeps the golden `.stderr` snapshots untouched. Verified locally on 1.92.0 with a clean fmt, clippy (`--all-targets --all-features` under `-Dwarnings`), and full test run.