### PR TITLE
feat: add size_prefix type node to the attribute DSL

### DIFF
--- a/codama-attributes/src/codama_directives/type_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/mod.rs
@@ -4,6 +4,7 @@ mod fixed_size_type_node;
 mod number_type_node;
 mod option_type_node;
 mod public_key_type_node;
+mod size_prefix_type_node;
 mod string_type_node;
 mod struct_field_meta_consumer;
 mod struct_field_type_node;

--- a/codama-attributes/src/codama_directives/type_nodes/size_prefix_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/size_prefix_type_node.rs
@@ -1,0 +1,176 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{NestedTypeNode, NumberTypeNode, SizePrefixTypeNode, TypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for SizePrefixTypeNode<TypeNode> {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("size_prefix")?.as_path_list()?;
+        let mut r#type: SetOnce<TypeNode> = SetOnce::new("type");
+        let mut prefix: SetOnce<NestedTypeNode<NumberTypeNode>> = SetOnce::new("prefix");
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "type" => r#type.set(TypeNode::from_meta(meta.as_value()?)?, meta),
+            "prefix" => prefix.set(parse_prefix(meta.as_value()?)?, meta),
+            _ => {
+                // Both are type nodes, so positional args fill `type` then `prefix`.
+                if meta.is_path_or_list() {
+                    return match r#type.is_set() {
+                        false => r#type.set(TypeNode::from_meta(meta)?, meta),
+                        true => prefix.set(parse_prefix(meta)?, meta),
+                    };
+                }
+                Err(meta.error("unrecognized attribute"))
+            }
+        })?;
+
+        Ok(Self::new(r#type.take(meta)?, prefix.take(meta)?))
+    }
+}
+
+fn parse_prefix(meta: &Meta) -> syn::Result<NestedTypeNode<NumberTypeNode>> {
+    let node = TypeNode::from_meta(meta)?;
+    NestedTypeNode::<NumberTypeNode>::try_from(node)
+        .map_err(|_| meta.error("prefix must be a NumberTypeNode"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{
+        BytesTypeNode, FixedSizeTypeNode,
+        NumberFormat::{U16, U32, U8},
+        OptionTypeNode, StringTypeNode,
+    };
+
+    fn parse_node(meta: Meta) -> SizePrefixTypeNode<TypeNode> {
+        SizePrefixTypeNode::<TypeNode>::from_meta(&meta).unwrap()
+    }
+
+    #[test]
+    fn parsed_fields() {
+        let node = parse_node(syn::parse_quote! { size_prefix(string, number(u32)) });
+        assert_eq!(*node.r#type, TypeNode::String(StringTypeNode::utf8()));
+        assert_eq!(*node.prefix, NestedTypeNode::Value(NumberTypeNode::le(U32)));
+
+        let node = parse_node(syn::parse_quote! { size_prefix(bytes, number(u16, be)) });
+        assert_eq!(*node.r#type, TypeNode::Bytes(BytesTypeNode::new()));
+        assert_eq!(*node.prefix, NestedTypeNode::Value(NumberTypeNode::be(U16)));
+    }
+
+    #[test]
+    fn equivalent_syntaxes() {
+        let expected = SizePrefixTypeNode::new(StringTypeNode::utf8(), NumberTypeNode::le(U32));
+        let positional = parse_node(syn::parse_quote! { size_prefix(string, number(u32)) });
+        let named_prefix =
+            parse_node(syn::parse_quote! { size_prefix(string, prefix = number(u32)) });
+        let fully_explicit =
+            parse_node(syn::parse_quote! { size_prefix(type = string, prefix = number(u32)) });
+
+        assert_eq!(positional, expected);
+        assert_eq!(named_prefix, expected);
+        assert_eq!(fully_explicit, expected);
+        assert_eq!(positional, named_prefix);
+        assert_eq!(named_prefix, fully_explicit);
+    }
+
+    #[test]
+    fn explicit() {
+        assert_type!(
+            { size_prefix(type = string, prefix = number(u32)) },
+            SizePrefixTypeNode::new(StringTypeNode::utf8(), NumberTypeNode::le(U32)).into()
+        );
+        assert_type!(
+            { size_prefix(prefix = number(u32), type = string) },
+            SizePrefixTypeNode::new(StringTypeNode::utf8(), NumberTypeNode::le(U32)).into()
+        );
+        assert_type!(
+            { size_prefix(prefix = number(u32), string) },
+            SizePrefixTypeNode::new(StringTypeNode::utf8(), NumberTypeNode::le(U32)).into()
+        );
+    }
+
+    #[test]
+    fn nested() {
+        assert_type!(
+            { option(size_prefix(string, number(u8))) },
+            OptionTypeNode::new(SizePrefixTypeNode::new(
+                StringTypeNode::utf8(),
+                NumberTypeNode::le(U8)
+            ))
+            .into()
+        );
+
+        let meta: Meta = syn::parse_quote! { option(size_prefix(string, number(u8))) };
+        let node = OptionTypeNode::from_meta(&meta).unwrap();
+        assert_eq!(
+            *node.item,
+            TypeNode::SizePrefix(SizePrefixTypeNode::new(
+                StringTypeNode::utf8(),
+                NumberTypeNode::le(U8)
+            ))
+        );
+    }
+
+    #[test]
+    fn nested_prefix() {
+        assert_type!(
+            { size_prefix(string, fixed_size(number(u32), 4)) },
+            SizePrefixTypeNode::new(
+                StringTypeNode::utf8(),
+                FixedSizeTypeNode::<NestedTypeNode<NumberTypeNode>>::new(
+                    NumberTypeNode::le(U32),
+                    4
+                )
+            )
+            .into()
+        );
+    }
+
+    #[test]
+    fn invalid_prefix() {
+        assert_type_err!(
+            { size_prefix(string, public_key) },
+            "prefix must be a NumberTypeNode"
+        );
+        assert_type_err!(
+            { size_prefix(type = string, prefix = public_key) },
+            "prefix must be a NumberTypeNode"
+        );
+    }
+
+    #[test]
+    fn type_missing() {
+        assert_type_err!({ size_prefix(prefix = number(u32)) }, "type is missing");
+    }
+
+    #[test]
+    fn prefix_missing() {
+        assert_type_err!({ size_prefix(string) }, "prefix is missing");
+    }
+
+    #[test]
+    fn already_set() {
+        assert_type_err!(
+            { size_prefix(type = string, type = bytes) },
+            "type is already set"
+        );
+        assert_type_err!(
+            { size_prefix(string, number(u32), number(u8)) },
+            "prefix is already set"
+        );
+    }
+
+    #[test]
+    fn unrecognized_type() {
+        assert_type_err!(
+            { size_prefix(unrecognized, number(u32)) },
+            "unrecognized type"
+        );
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ size_prefix(string, foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/size_prefix_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/size_prefix_type_node.rs
@@ -140,6 +140,15 @@ mod tests {
     }
 
     #[test]
+    fn positional_order() {
+        // Positional args fill `type` then `prefix` and are never swapped.
+        assert_type_err!(
+            { size_prefix(number(u32), string) },
+            "prefix must be a NumberTypeNode"
+        );
+    }
+
+    #[test]
     fn type_missing() {
         assert_type_err!({ size_prefix(prefix = number(u32)) }, "type is missing");
     }

--- a/codama-attributes/src/codama_directives/type_nodes/type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/type_node.rs
@@ -1,8 +1,8 @@
 use crate::{utils::FromMeta, TypeDirectiveNode};
 use codama_nodes::{
     BooleanTypeNode, BytesTypeNode, FixedSizeTypeNode, NumberTypeNode, OptionTypeNode,
-    PublicKeyTypeNode, RegisteredTypeNode, StringTypeNode, StructFieldTypeNode, StructTypeNode,
-    TypeNode, ZeroableOptionTypeNode,
+    PublicKeyTypeNode, RegisteredTypeNode, SizePrefixTypeNode, StringTypeNode, StructFieldTypeNode,
+    StructTypeNode, TypeNode, ZeroableOptionTypeNode,
 };
 use codama_syn_helpers::{extensions::*, Meta};
 
@@ -16,6 +16,7 @@ impl FromMeta for RegisteredTypeNode {
             "number" => NumberTypeNode::from_meta(meta).map(Self::from),
             "option" => OptionTypeNode::from_meta(meta).map(Self::from),
             "public_key" => PublicKeyTypeNode::from_meta(meta).map(Self::from),
+            "size_prefix" => SizePrefixTypeNode::from_meta(meta).map(Self::from),
             "string" => StringTypeNode::from_meta(meta).map(Self::from),
             "struct" => StructTypeNode::from_meta(meta).map(Self::from),
             "zeroable_option" => ZeroableOptionTypeNode::from_meta(meta).map(Self::from),

--- a/codama-korok-visitors/tests/apply_type_modifiers_visitor/size_prefix_directive.rs
+++ b/codama-korok-visitors/tests/apply_type_modifiers_visitor/size_prefix_directive.rs
@@ -6,7 +6,7 @@ use codama_koroks::FieldKorok;
 use codama_nodes::{
     FixedSizeTypeNode,
     NumberFormat::{U16, U32, U8},
-    NumberTypeNode, SizePrefixTypeNode, StringTypeNode, StructFieldTypeNode,
+    NumberTypeNode, SizePrefixTypeNode, StringTypeNode, StructFieldTypeNode, TypeNode,
 };
 
 #[test]
@@ -106,6 +106,56 @@ fn it_replaces_fixed_size_type_nodes() -> CodamaResult<()> {
     assert_eq!(
         korok.node,
         Some(SizePrefixTypeNode::new(StringTypeNode::utf8(), NumberTypeNode::le(U8)).into())
+    );
+    Ok(())
+}
+
+#[test]
+fn it_matches_the_size_prefix_type_node_written_in_the_dsl() -> CodamaResult<()> {
+    // Via the modifier directive.
+    let modifier_ast: syn::Field = syn::parse_quote! {
+        #[codama(type = string)]
+        #[codama(size_prefix = number(u8))]
+        String
+    };
+    let mut modifier_korok = FieldKorok::parse(&modifier_ast)?;
+    modifier_korok.accept(&mut ApplyTypeOverridesVisitor::new())?;
+    modifier_korok.accept(&mut ApplyTypeModifiersVisitor::new())?;
+
+    // Via the type node in the DSL.
+    let dsl_ast: syn::Field = syn::parse_quote! {
+        #[codama(type = size_prefix(string, number(u8)))]
+        String
+    };
+    let mut dsl_korok = FieldKorok::parse(&dsl_ast)?;
+    dsl_korok.accept(&mut ApplyTypeOverridesVisitor::new())?;
+    dsl_korok.accept(&mut ApplyTypeModifiersVisitor::new())?;
+
+    assert_eq!(modifier_korok.node, dsl_korok.node);
+    assert_eq!(
+        dsl_korok.node,
+        Some(SizePrefixTypeNode::new(StringTypeNode::utf8(), NumberTypeNode::le(U8)).into())
+    );
+    Ok(())
+}
+
+#[test]
+fn it_serializes_to_the_expected_json() -> CodamaResult<()> {
+    let ast: syn::Field = syn::parse_quote! {
+        #[codama(type = size_prefix(string, number(u32)))]
+        String
+    };
+    let mut korok = FieldKorok::parse(&ast)?;
+    korok.accept(&mut ApplyTypeOverridesVisitor::new())?;
+
+    let expected = r#"{"kind":"sizePrefixTypeNode","type":{"kind":"stringTypeNode","encoding":"utf8"},"prefix":{"kind":"numberTypeNode","format":"u32","endian":"le"}}"#;
+    assert_eq!(serde_json::to_string(&korok.node)?, expected);
+    assert_eq!(
+        serde_json::to_string(&SizePrefixTypeNode::<TypeNode>::new(
+            StringTypeNode::utf8(),
+            NumberTypeNode::le(U32)
+        ))?,
+        expected
     );
     Ok(())
 }

--- a/codama-macros/tests/codama_attribute/size_prefix_directive/list_form.fail.rs
+++ b/codama-macros/tests/codama_attribute/size_prefix_directive/list_form.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(size_prefix(string, number(u32)))]
+pub struct TestWithTypeNodeSyntax;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/size_prefix_directive/list_form.fail.stderr
+++ b/codama-macros/tests/codama_attribute/size_prefix_directive/list_form.fail.stderr
@@ -1,0 +1,5 @@
+error: expected `=` followed by a single value: `size_prefix = ...`
+ --> tests/codama_attribute/size_prefix_directive/list_form.fail.rs:3:22
+  |
+3 | #[codama(size_prefix(string, number(u32)))]
+  |                      ^^^^^^^^^^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/size_prefix_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/size_prefix_type_node/_pass.rs
@@ -1,0 +1,21 @@
+use codama_macros::codama;
+
+#[codama(type = size_prefix(string, number(u32)))]
+pub struct ImplicitTest;
+
+#[codama(type = size_prefix(type = string, prefix = number(u32)))]
+pub struct ExplicitTest;
+
+#[codama(type = size_prefix(prefix = number(u32), type = string))]
+pub struct ExplicitReorderedTest;
+
+#[codama(type = size_prefix(string, prefix = number(u32)))]
+pub struct MixedTest;
+
+#[codama(type = size_prefix(string, fixed_size(number(u32), 4)))]
+pub struct NestedPrefixTest;
+
+#[codama(type = option(size_prefix(string, number(u8))))]
+pub struct NestedInsideOptionTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/size_prefix_type_node/already_set.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/size_prefix_type_node/already_set.fail.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(type = size_prefix(type = string, type = bytes))]
+pub struct TypeTest;
+
+#[codama(type = size_prefix(string, number(u32), number(u8)))]
+pub struct PrefixTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/size_prefix_type_node/already_set.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/size_prefix_type_node/already_set.fail.stderr
@@ -1,0 +1,11 @@
+error: type is already set
+ --> tests/codama_attribute/type_nodes/size_prefix_type_node/already_set.fail.rs:3:44
+  |
+3 | #[codama(type = size_prefix(type = string, type = bytes))]
+  |                                            ^^^^^^^^^^^^
+
+error: prefix is already set
+ --> tests/codama_attribute/type_nodes/size_prefix_type_node/already_set.fail.rs:6:50
+  |
+6 | #[codama(type = size_prefix(string, number(u32), number(u8)))]
+  |                                                  ^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/size_prefix_type_node/invalid_prefix.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/size_prefix_type_node/invalid_prefix.fail.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(type = size_prefix(string, public_key))]
+pub struct Test;
+
+#[codama(type = size_prefix(type = string, prefix = public_key))]
+pub struct TestExplicit;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/size_prefix_type_node/invalid_prefix.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/size_prefix_type_node/invalid_prefix.fail.stderr
@@ -1,0 +1,11 @@
+error: prefix must be a NumberTypeNode
+ --> tests/codama_attribute/type_nodes/size_prefix_type_node/invalid_prefix.fail.rs:3:37
+  |
+3 | #[codama(type = size_prefix(string, public_key))]
+  |                                     ^^^^^^^^^^
+
+error: prefix must be a NumberTypeNode
+ --> tests/codama_attribute/type_nodes/size_prefix_type_node/invalid_prefix.fail.rs:6:53
+  |
+6 | #[codama(type = size_prefix(type = string, prefix = public_key))]
+  |                                                     ^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/size_prefix_type_node/prefix_missing.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/size_prefix_type_node/prefix_missing.fail.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(type = size_prefix(string))]
+pub struct Test;
+
+#[codama(type = size_prefix(type = string))]
+pub struct TestExplicit;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/size_prefix_type_node/prefix_missing.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/size_prefix_type_node/prefix_missing.fail.stderr
@@ -1,0 +1,11 @@
+error: prefix is missing
+ --> tests/codama_attribute/type_nodes/size_prefix_type_node/prefix_missing.fail.rs:3:17
+  |
+3 | #[codama(type = size_prefix(string))]
+  |                 ^^^^^^^^^^^^^^^^^^^
+
+error: prefix is missing
+ --> tests/codama_attribute/type_nodes/size_prefix_type_node/prefix_missing.fail.rs:6:17
+  |
+6 | #[codama(type = size_prefix(type = string))]
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/size_prefix_type_node/type_missing.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/size_prefix_type_node/type_missing.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = size_prefix(prefix = number(u32)))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/size_prefix_type_node/type_missing.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/size_prefix_type_node/type_missing.fail.stderr
@@ -1,0 +1,5 @@
+error: type is missing
+ --> tests/codama_attribute/type_nodes/size_prefix_type_node/type_missing.fail.rs:3:17
+  |
+3 | #[codama(type = size_prefix(prefix = number(u32)))]
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
`size_prefix` was only a modifier, so you couldn't nest it. It's a type node now, like `fixed_size` already is:

```rust
size_prefix(string, number(u32))
size_prefix(type = string, prefix = number(u32))
```

which means `option(size_prefix(string, number(u8)))` works. Built the same way as the option nodes in #110, and the prefix can go positional or named.
