### PR TITLE
feat: add amount, date_time, remainder_option, sol_amount and tuple type nodes to the DSL

### DIFF
--- a/codama-attributes/src/codama_directives/mod.rs
+++ b/codama-attributes/src/codama_directives/mod.rs
@@ -1,4 +1,5 @@
 mod link_nodes;
+mod nested_number;
 mod type_nodes;
 mod value_nodes;
 

--- a/codama-attributes/src/codama_directives/nested_number.rs
+++ b/codama-attributes/src/codama_directives/nested_number.rs
@@ -1,0 +1,14 @@
+use crate::utils::FromMeta;
+use codama_nodes::{NestedTypeNode, NumberTypeNode, TypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+/// Parse a type node that must resolve to a number, allowing the wrappers
+/// `NestedTypeNode` accepts, e.g. `number(u32)` or `fixed_size(number(u32), 4)`.
+pub(super) fn nested_number(
+    meta: &Meta,
+    ident: &str,
+) -> syn::Result<NestedTypeNode<NumberTypeNode>> {
+    let node = TypeNode::from_meta(meta)?;
+    NestedTypeNode::<NumberTypeNode>::try_from(node)
+        .map_err(|_| meta.error(format!("{ident} must be a NumberTypeNode")))
+}

--- a/codama-attributes/src/codama_directives/type_nodes/amount_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/amount_type_node.rs
@@ -1,0 +1,112 @@
+use crate::codama_directives::nested_number::nested_number;
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{AmountTypeNode, NestedTypeNode, NumberTypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for AmountTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("amount")?.as_path_list()?;
+        let mut number: SetOnce<NestedTypeNode<NumberTypeNode>> = SetOnce::new("number");
+        let mut decimals: SetOnce<u32> = SetOnce::new("decimals");
+        let mut unit: SetOnce<String> = SetOnce::new("unit");
+
+        pl.each(|ref meta| {
+            // A positional `number(u64)` shares its path with the `number` field,
+            // so lists and bare paths are always read as the type node.
+            if meta.is_path_or_list() {
+                return number.set(nested_number(meta, "number")?, meta);
+            }
+            match meta.path_str().as_str() {
+                "number" => number.set(nested_number(meta.as_value()?, "number")?, meta),
+                "decimals" => {
+                    decimals.set(meta.as_value()?.as_expr()?.as_unsigned_integer()?, meta)
+                }
+                "unit" => unit.set(meta.as_value()?.as_expr()?.as_string()?, meta),
+                _ => {
+                    // The other positional args are told apart by shape: a string
+                    // literal is the unit, an integer is the decimals.
+                    if let Ok(expr) = meta.as_expr() {
+                        return match expr.as_string() {
+                            Ok(value) => unit.set(value, meta),
+                            Err(_) => decimals.set(expr.as_unsigned_integer()?, meta),
+                        };
+                    }
+                    Err(meta.error("unrecognized attribute"))
+                }
+            }
+        })?;
+
+        Ok(AmountTypeNode::new(
+            number.take(meta)?,
+            decimals.option().unwrap_or(0),
+            unit.option(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::NumberFormat::U64;
+
+    #[test]
+    fn number_only() {
+        assert_type!(
+            { amount(number(u64)) },
+            AmountTypeNode::new(NumberTypeNode::le(U64), 0, None).into()
+        );
+    }
+
+    #[test]
+    fn implicit() {
+        assert_type!(
+            { amount(number(u64), 9, "SOL") },
+            AmountTypeNode::new(NumberTypeNode::le(U64), 9, Some("SOL".to_string())).into()
+        );
+    }
+
+    #[test]
+    fn explicit() {
+        assert_type!(
+            { amount(number = number(u64), decimals = 9, unit = "SOL") },
+            AmountTypeNode::new(NumberTypeNode::le(U64), 9, Some("SOL".to_string())).into()
+        );
+    }
+
+    #[test]
+    fn positional_args_are_matched_by_shape() {
+        assert_type!(
+            { amount("SOL", 9, number(u64)) },
+            AmountTypeNode::new(NumberTypeNode::le(U64), 9, Some("SOL".to_string())).into()
+        );
+    }
+
+    #[test]
+    fn decimals_without_unit() {
+        assert_type!(
+            { amount(number(u64), 6) },
+            AmountTypeNode::new(NumberTypeNode::le(U64), 6, None).into()
+        );
+    }
+
+    #[test]
+    fn invalid_number() {
+        assert_type_err!({ amount(string) }, "number must be a NumberTypeNode");
+    }
+
+    #[test]
+    fn number_missing() {
+        assert_type_err!({ amount(decimals = 9) }, "number is missing");
+    }
+
+    #[test]
+    fn already_set() {
+        assert_type_err!({ amount(number(u64), 9, 6) }, "decimals is already set");
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ amount(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/date_time_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/date_time_type_node.rs
@@ -1,0 +1,75 @@
+use crate::codama_directives::nested_number::nested_number;
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{DateTimeTypeNode, NestedTypeNode, NumberTypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for DateTimeTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("date_time")?.as_path_list()?;
+        let mut number: SetOnce<NestedTypeNode<NumberTypeNode>> = SetOnce::new("number");
+
+        pl.each(|ref meta| {
+            // A positional `number(u64)` shares its path with the `number` field,
+            // so lists and bare paths are always read as the type node.
+            if meta.is_path_or_list() {
+                return number.set(nested_number(meta, "number")?, meta);
+            }
+            match meta.path_str().as_str() {
+                "number" => number.set(nested_number(meta.as_value()?, "number")?, meta),
+                _ => Err(meta.error("unrecognized attribute")),
+            }
+        })?;
+
+        Ok(DateTimeTypeNode::new(number.take(meta)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{FixedSizeTypeNode, NumberFormat::U64};
+
+    #[test]
+    fn implicit() {
+        assert_type!(
+            { date_time(number(u64)) },
+            DateTimeTypeNode::new(NumberTypeNode::le(U64)).into()
+        );
+    }
+
+    #[test]
+    fn explicit() {
+        assert_type!(
+            { date_time(number = number(u64)) },
+            DateTimeTypeNode::new(NumberTypeNode::le(U64)).into()
+        );
+    }
+
+    #[test]
+    fn nested_number() {
+        assert_type!(
+            { date_time(fixed_size(number(u64), 8)) },
+            DateTimeTypeNode::new(FixedSizeTypeNode::<NestedTypeNode<NumberTypeNode>>::new(
+                NumberTypeNode::le(U64),
+                8
+            ))
+            .into()
+        );
+    }
+
+    #[test]
+    fn invalid_number() {
+        assert_type_err!({ date_time(string) }, "number must be a NumberTypeNode");
+    }
+
+    #[test]
+    fn number_missing() {
+        assert_type_err!({ date_time() }, "number is missing");
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ date_time(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/mod.rs
@@ -1,14 +1,19 @@
+mod amount_type_node;
 mod boolean_type_node;
 mod bytes_type_node;
+mod date_time_type_node;
 mod fixed_size_type_node;
 mod number_type_node;
 mod option_type_node;
 mod public_key_type_node;
+mod remainder_option_type_node;
 mod size_prefix_type_node;
+mod sol_amount_type_node;
 mod string_type_node;
 mod struct_field_meta_consumer;
 mod struct_field_type_node;
 mod struct_type_node;
+mod tuple_type_node;
 mod type_node;
 mod zeroable_option_type_node;
 

--- a/codama-attributes/src/codama_directives/type_nodes/remainder_option_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/remainder_option_type_node.rs
@@ -1,0 +1,75 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{RemainderOptionTypeNode, TypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for RemainderOptionTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("remainder_option")?.as_path_list()?;
+        let mut item: SetOnce<TypeNode> = SetOnce::new("item");
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "item" => item.set(TypeNode::from_meta(meta.as_value()?)?, meta),
+            _ => {
+                if meta.is_path_or_list() {
+                    return item.set(TypeNode::from_meta(meta)?, meta);
+                }
+                Err(meta.error("unrecognized attribute"))
+            }
+        })?;
+
+        Ok(RemainderOptionTypeNode::new(item.take(meta)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{NumberTypeNode, StringTypeNode, U8};
+
+    #[test]
+    fn implicit() {
+        assert_type!(
+            { remainder_option(number(u8)) },
+            RemainderOptionTypeNode::new(NumberTypeNode::le(U8)).into()
+        );
+    }
+
+    #[test]
+    fn explicit() {
+        assert_type!(
+            { remainder_option(item = number(u8)) },
+            RemainderOptionTypeNode::new(NumberTypeNode::le(U8)).into()
+        );
+    }
+
+    #[test]
+    fn nested() {
+        assert_type!(
+            { remainder_option(size_prefix(string, number(u8))) },
+            RemainderOptionTypeNode::new(codama_nodes::SizePrefixTypeNode::new(
+                StringTypeNode::utf8(),
+                NumberTypeNode::le(U8)
+            ))
+            .into()
+        );
+    }
+
+    #[test]
+    fn item_missing() {
+        assert_type_err!({ remainder_option() }, "item is missing");
+    }
+
+    #[test]
+    fn already_set() {
+        assert_type_err!(
+            { remainder_option(number(u8), string) },
+            "item is already set"
+        );
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ remainder_option(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/sol_amount_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/sol_amount_type_node.rs
@@ -1,0 +1,66 @@
+use crate::codama_directives::nested_number::nested_number;
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{NestedTypeNode, NumberTypeNode, SolAmountTypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for SolAmountTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("sol_amount")?.as_path_list()?;
+        let mut number: SetOnce<NestedTypeNode<NumberTypeNode>> = SetOnce::new("number");
+
+        pl.each(|ref meta| {
+            // A positional `number(u64)` shares its path with the `number` field,
+            // so lists and bare paths are always read as the type node.
+            if meta.is_path_or_list() {
+                return number.set(nested_number(meta, "number")?, meta);
+            }
+            match meta.path_str().as_str() {
+                "number" => number.set(nested_number(meta.as_value()?, "number")?, meta),
+                _ => Err(meta.error("unrecognized attribute")),
+            }
+        })?;
+
+        Ok(SolAmountTypeNode::new(number.take(meta)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::NumberFormat::U64;
+
+    #[test]
+    fn implicit() {
+        assert_type!(
+            { sol_amount(number(u64)) },
+            SolAmountTypeNode::new(NumberTypeNode::le(U64)).into()
+        );
+    }
+
+    #[test]
+    fn explicit() {
+        assert_type!(
+            { sol_amount(number = number(u64)) },
+            SolAmountTypeNode::new(NumberTypeNode::le(U64)).into()
+        );
+    }
+
+    #[test]
+    fn invalid_number() {
+        assert_type_err!(
+            { sol_amount(public_key) },
+            "number must be a NumberTypeNode"
+        );
+    }
+
+    #[test]
+    fn number_missing() {
+        assert_type_err!({ sol_amount() }, "number is missing");
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ sol_amount(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/tuple_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/tuple_type_node.rs
@@ -1,0 +1,76 @@
+use crate::utils::FromMeta;
+use codama_errors::IteratorCombineErrors;
+use codama_nodes::{TupleTypeNode, TypeNode};
+use codama_syn_helpers::Meta;
+
+impl FromMeta for TupleTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        meta.assert_directive("tuple")?;
+        if meta.is_path_or_empty_list() {
+            return Ok(TupleTypeNode::new(vec![]));
+        }
+
+        let items = meta
+            .as_path_list()?
+            .parse_metas()?
+            .iter()
+            .map(TypeNode::from_meta)
+            .collect_and_combine_errors()?;
+
+        Ok(TupleTypeNode::new(items))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{
+        NumberFormat::{U32, U8},
+        NumberTypeNode, PublicKeyTypeNode, StringTypeNode,
+    };
+
+    #[test]
+    fn empty() {
+        assert_type!({ tuple }, TupleTypeNode::new(vec![]).into());
+        assert_type!({ tuple() }, TupleTypeNode::new(vec![]).into());
+    }
+
+    #[test]
+    fn single_item() {
+        assert_type!(
+            { tuple(number(u32)) },
+            TupleTypeNode::new(vec![NumberTypeNode::le(U32).into()]).into()
+        );
+    }
+
+    #[test]
+    fn multiple_items() {
+        assert_type!(
+            { tuple(number(u32), string, public_key) },
+            TupleTypeNode::new(vec![
+                NumberTypeNode::le(U32).into(),
+                StringTypeNode::utf8().into(),
+                PublicKeyTypeNode::new().into(),
+            ])
+            .into()
+        );
+    }
+
+    #[test]
+    fn nested() {
+        assert_type!(
+            { tuple(option(number(u8)), tuple(string)) },
+            TupleTypeNode::new(vec![
+                codama_nodes::OptionTypeNode::new(NumberTypeNode::le(U8)).into(),
+                TupleTypeNode::new(vec![StringTypeNode::utf8().into()]).into(),
+            ])
+            .into()
+        );
+    }
+
+    #[test]
+    fn unrecognized_type() {
+        assert_type_err!({ tuple(unrecognized) }, "unrecognized type");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/type_node.rs
@@ -1,24 +1,30 @@
 use crate::{utils::FromMeta, TypeDirectiveNode};
 use codama_nodes::{
-    BooleanTypeNode, BytesTypeNode, FixedSizeTypeNode, NumberTypeNode, OptionTypeNode,
-    PublicKeyTypeNode, RegisteredTypeNode, SizePrefixTypeNode, StringTypeNode, StructFieldTypeNode,
-    StructTypeNode, TypeNode, ZeroableOptionTypeNode,
+    AmountTypeNode, BooleanTypeNode, BytesTypeNode, DateTimeTypeNode, FixedSizeTypeNode,
+    NumberTypeNode, OptionTypeNode, PublicKeyTypeNode, RegisteredTypeNode, RemainderOptionTypeNode,
+    SizePrefixTypeNode, SolAmountTypeNode, StringTypeNode, StructFieldTypeNode, StructTypeNode,
+    TupleTypeNode, TypeNode, ZeroableOptionTypeNode,
 };
 use codama_syn_helpers::{extensions::*, Meta};
 
 impl FromMeta for RegisteredTypeNode {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
         match meta.path_str().as_str() {
+            "amount" => AmountTypeNode::from_meta(meta).map(Self::from),
             "boolean" => BooleanTypeNode::from_meta(meta).map(Self::from),
             "bytes" => BytesTypeNode::from_meta(meta).map(Self::from),
+            "date_time" => DateTimeTypeNode::from_meta(meta).map(Self::from),
             "field" => StructFieldTypeNode::from_meta(meta).map(Self::from),
             "fixed_size" => FixedSizeTypeNode::from_meta(meta).map(Self::from),
             "number" => NumberTypeNode::from_meta(meta).map(Self::from),
             "option" => OptionTypeNode::from_meta(meta).map(Self::from),
             "public_key" => PublicKeyTypeNode::from_meta(meta).map(Self::from),
+            "remainder_option" => RemainderOptionTypeNode::from_meta(meta).map(Self::from),
             "size_prefix" => SizePrefixTypeNode::from_meta(meta).map(Self::from),
+            "sol_amount" => SolAmountTypeNode::from_meta(meta).map(Self::from),
             "string" => StringTypeNode::from_meta(meta).map(Self::from),
             "struct" => StructTypeNode::from_meta(meta).map(Self::from),
+            "tuple" => TupleTypeNode::from_meta(meta).map(Self::from),
             "zeroable_option" => ZeroableOptionTypeNode::from_meta(meta).map(Self::from),
             _ => Err(meta.error("unrecognized type")),
         }

--- a/codama-macros/tests/codama_attribute/type_nodes/amount_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/amount_type_node/_pass.rs
@@ -1,0 +1,15 @@
+use codama_macros::codama;
+
+#[codama(type = amount(number(u64)))]
+pub struct NumberOnlyTest;
+
+#[codama(type = amount(number(u64), 9, "SOL"))]
+pub struct ImplicitTest;
+
+#[codama(type = amount(number = number(u64), decimals = 9, unit = "SOL"))]
+pub struct ExplicitTest;
+
+#[codama(type = amount(number(u64), 6))]
+pub struct DecimalsOnlyTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/date_time_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/date_time_type_node/_pass.rs
@@ -1,0 +1,12 @@
+use codama_macros::codama;
+
+#[codama(type = date_time(number(u64)))]
+pub struct ImplicitTest;
+
+#[codama(type = date_time(number = number(u64)))]
+pub struct ExplicitTest;
+
+#[codama(type = date_time(fixed_size(number(u64), 8)))]
+pub struct NestedNumberTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/remainder_option_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/remainder_option_type_node/_pass.rs
@@ -1,0 +1,12 @@
+use codama_macros::codama;
+
+#[codama(type = remainder_option(number(u8)))]
+pub struct ImplicitTest;
+
+#[codama(type = remainder_option(item = number(u8)))]
+pub struct ExplicitTest;
+
+#[codama(type = remainder_option(size_prefix(string, number(u8))))]
+pub struct NestedTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/sol_amount_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/sol_amount_type_node/_pass.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(type = sol_amount(number(u64)))]
+pub struct ImplicitTest;
+
+#[codama(type = sol_amount(number = number(u64)))]
+pub struct ExplicitTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/tuple_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/tuple_type_node/_pass.rs
@@ -1,0 +1,18 @@
+use codama_macros::codama;
+
+#[codama(type = tuple)]
+pub struct EmptyTest;
+
+#[codama(type = tuple())]
+pub struct EmptyListTest;
+
+#[codama(type = tuple(number(u32)))]
+pub struct SingleItemTest;
+
+#[codama(type = tuple(number(u32), string, public_key))]
+pub struct MultipleItemsTest;
+
+#[codama(type = tuple(option(number(u8)), tuple(string)))]
+pub struct NestedTest;
+
+fn main() {}


### PR DESCRIPTION
Part of splitting the remaining type nodes into separate PRs, as you asked on #117. This one is independent of the others and can be merged in any order.

Adds `amount`, `date_time`, `remainder_option`, `sol_amount` and `tuple`.

```rust
#[codama(type = tuple(number(u32), string, public_key))]
#[codama(type = amount(number(u64), 9, "SOL"))]
#[codama(type = date_time(fixed_size(number(u64), 8)))]
#[codama(type = remainder_option(size_prefix(string, number(u8))))]
#[codama(type = sol_amount(number(u64)))]
```

Each accepts a named form too, so `amount(number = number(u64), decimals = 9, unit = "SOL")` is the same as the positional version above.

### The one thing worth a close look

`amount`, `date_time` and `sol_amount` each have a field named `number`, which is also the name of a type node. So `date_time(number(u64))` was parsing `number(u64)` as the named field `number` and failing. These three now check the shape of the meta before matching its name: a list or bare path is the type node, a name-value pair is the field.

`amount` goes a step further, since its other two positional args are told apart by shape rather than position. A string literal is the unit and an integer is the decimals, so `amount("SOL", 9, number(u64))` parses the same as `amount(number(u64), 9, "SOL")`. There is a test pinning that. Happy to make it strictly positional if you would rather not have the flexibility.

### The rest of the series

- #122 adds array, set and map plus the count node DSL. Independent.
- #123 adds the offset, sentinel and hidden prefix/suffix nodes plus `constant(...)`. Independent.
- #124 adds enum and its variants. Stacked on this PR, since tuple variants need `tuple`.

This PR adds `codama_directives/nested_number.rs`, a small helper for parsing a type node that has to resolve to a number. #122 and #124 add the same file, so whichever lands second needs a trivial rebase to drop the duplicate. Happy to pull it out into its own PR first if you would rather.
