### PR TITLE
feat: add enum and enum variant type nodes to the DSL

### DIFF
--- a/codama-attributes/src/codama_directives/count_nodes/count_node.rs
+++ b/codama-attributes/src/codama_directives/count_nodes/count_node.rs
@@ -1,0 +1,90 @@
+use crate::utils::FromMeta;
+use codama_nodes::{CountNode, FixedCountNode, PrefixedCountNode, RemainderCountNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for CountNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        // A bare integer is the common case, so `3` is short for `fixed_count(3)`.
+        if let Ok(expr) = meta.as_expr() {
+            if let Ok(value) = expr.as_unsigned_integer() {
+                return Ok(FixedCountNode::new(value).into());
+            }
+        }
+
+        match meta.path_str().as_str() {
+            "fixed_count" => FixedCountNode::from_meta(meta).map(Self::from),
+            "prefixed_count" => PrefixedCountNode::from_meta(meta).map(Self::from),
+            "remainder_count" => RemainderCountNode::from_meta(meta).map(Self::from),
+            _ => Err(meta.error("unrecognized count")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codama_nodes::{NumberFormat::U32, NumberTypeNode};
+
+    fn parse(meta: Meta) -> syn::Result<CountNode> {
+        CountNode::from_meta(&meta)
+    }
+
+    #[test]
+    fn fixed() {
+        let expected: CountNode = FixedCountNode::new(3).into();
+        assert_eq!(
+            parse(syn::parse_quote! { fixed_count(3) }).unwrap(),
+            expected
+        );
+        assert_eq!(
+            parse(syn::parse_quote! { fixed_count(value = 3) }).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn bare_integer_is_a_fixed_count() {
+        assert_eq!(
+            parse(syn::parse_quote! { 3 }).unwrap(),
+            FixedCountNode::new(3).into()
+        );
+    }
+
+    #[test]
+    fn prefixed() {
+        let expected: CountNode = PrefixedCountNode::new(NumberTypeNode::le(U32)).into();
+        assert_eq!(
+            parse(syn::parse_quote! { prefixed_count(number(u32)) }).unwrap(),
+            expected
+        );
+        assert_eq!(
+            parse(syn::parse_quote! { prefixed_count(prefix = number(u32)) }).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn remainder() {
+        let expected: CountNode = RemainderCountNode::new().into();
+        assert_eq!(
+            parse(syn::parse_quote! { remainder_count }).unwrap(),
+            expected
+        );
+        assert_eq!(
+            parse(syn::parse_quote! { remainder_count() }).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn invalid_prefix() {
+        let error = parse(syn::parse_quote! { prefixed_count(string) }).unwrap_err();
+        assert_eq!(error.to_string(), "prefix must be a NumberTypeNode");
+    }
+
+    #[test]
+    fn unrecognized_count() {
+        let error = parse(syn::parse_quote! { unrecognized }).unwrap_err();
+        assert_eq!(error.to_string(), "unrecognized count");
+    }
+}

--- a/codama-attributes/src/codama_directives/count_nodes/fixed_count_node.rs
+++ b/codama-attributes/src/codama_directives/count_nodes/fixed_count_node.rs
@@ -1,0 +1,22 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::FixedCountNode;
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for FixedCountNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("fixed_count")?.as_path_list()?;
+        let mut value: SetOnce<u64> = SetOnce::new("value");
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "value" => value.set(meta.as_value()?.as_expr()?.as_unsigned_integer()?, meta),
+            _ => {
+                if let Ok(expr) = meta.as_expr() {
+                    return value.set(expr.as_unsigned_integer()?, meta);
+                }
+                Err(meta.error("unrecognized attribute"))
+            }
+        })?;
+
+        Ok(FixedCountNode::new(value.take(meta)?))
+    }
+}

--- a/codama-attributes/src/codama_directives/count_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/count_nodes/mod.rs
@@ -1,0 +1,4 @@
+mod count_node;
+mod fixed_count_node;
+mod prefixed_count_node;
+mod remainder_count_node;

--- a/codama-attributes/src/codama_directives/count_nodes/prefixed_count_node.rs
+++ b/codama-attributes/src/codama_directives/count_nodes/prefixed_count_node.rs
@@ -1,0 +1,23 @@
+use crate::codama_directives::nested_number::nested_number;
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{NestedTypeNode, NumberTypeNode, PrefixedCountNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for PrefixedCountNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("prefixed_count")?.as_path_list()?;
+        let mut prefix: SetOnce<NestedTypeNode<NumberTypeNode>> = SetOnce::new("prefix");
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "prefix" => prefix.set(nested_number(meta.as_value()?, "prefix")?, meta),
+            _ => {
+                if meta.is_path_or_list() {
+                    return prefix.set(nested_number(meta, "prefix")?, meta);
+                }
+                Err(meta.error("unrecognized attribute"))
+            }
+        })?;
+
+        Ok(PrefixedCountNode::new(prefix.take(meta)?))
+    }
+}

--- a/codama-attributes/src/codama_directives/count_nodes/remainder_count_node.rs
+++ b/codama-attributes/src/codama_directives/count_nodes/remainder_count_node.rs
@@ -1,0 +1,13 @@
+use crate::utils::FromMeta;
+use codama_nodes::RemainderCountNode;
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for RemainderCountNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        meta.assert_directive("remainder_count")?;
+        if meta.is_path_or_empty_list() {
+            return Ok(RemainderCountNode::new());
+        }
+        Err(meta.error("remainder_count does not take any argument"))
+    }
+}

--- a/codama-attributes/src/codama_directives/mod.rs
+++ b/codama-attributes/src/codama_directives/mod.rs
@@ -1,4 +1,6 @@
+mod count_nodes;
 mod link_nodes;
+mod nested_number;
 mod type_nodes;
 mod value_nodes;
 

--- a/codama-attributes/src/codama_directives/nested_number.rs
+++ b/codama-attributes/src/codama_directives/nested_number.rs
@@ -4,7 +4,7 @@ use codama_syn_helpers::{extensions::*, Meta};
 
 /// Parse a type node that must resolve to a number, allowing the wrappers
 /// `NestedTypeNode` accepts, e.g. `number(u32)` or `fixed_size(number(u32), 4)`.
-pub(super) fn nested_number(
+pub(crate) fn nested_number(
     meta: &Meta,
     ident: &str,
 ) -> syn::Result<NestedTypeNode<NumberTypeNode>> {

--- a/codama-attributes/src/codama_directives/type_nodes/amount_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/amount_type_node.rs
@@ -1,4 +1,4 @@
-use super::nested_number::nested_number;
+use crate::codama_directives::nested_number::nested_number;
 use crate::utils::{FromMeta, SetOnce};
 use codama_nodes::{AmountTypeNode, NestedTypeNode, NumberTypeNode};
 use codama_syn_helpers::{extensions::*, Meta};

--- a/codama-attributes/src/codama_directives/type_nodes/amount_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/amount_type_node.rs
@@ -1,0 +1,112 @@
+use super::nested_number::nested_number;
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{AmountTypeNode, NestedTypeNode, NumberTypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for AmountTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("amount")?.as_path_list()?;
+        let mut number: SetOnce<NestedTypeNode<NumberTypeNode>> = SetOnce::new("number");
+        let mut decimals: SetOnce<u32> = SetOnce::new("decimals");
+        let mut unit: SetOnce<String> = SetOnce::new("unit");
+
+        pl.each(|ref meta| {
+            // A positional `number(u64)` shares its path with the `number` field,
+            // so lists and bare paths are always read as the type node.
+            if meta.is_path_or_list() {
+                return number.set(nested_number(meta, "number")?, meta);
+            }
+            match meta.path_str().as_str() {
+                "number" => number.set(nested_number(meta.as_value()?, "number")?, meta),
+                "decimals" => {
+                    decimals.set(meta.as_value()?.as_expr()?.as_unsigned_integer()?, meta)
+                }
+                "unit" => unit.set(meta.as_value()?.as_expr()?.as_string()?, meta),
+                _ => {
+                    // The other positional args are told apart by shape: a string
+                    // literal is the unit, an integer is the decimals.
+                    if let Ok(expr) = meta.as_expr() {
+                        return match expr.as_string() {
+                            Ok(value) => unit.set(value, meta),
+                            Err(_) => decimals.set(expr.as_unsigned_integer()?, meta),
+                        };
+                    }
+                    Err(meta.error("unrecognized attribute"))
+                }
+            }
+        })?;
+
+        Ok(AmountTypeNode::new(
+            number.take(meta)?,
+            decimals.option().unwrap_or(0),
+            unit.option(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::NumberFormat::U64;
+
+    #[test]
+    fn number_only() {
+        assert_type!(
+            { amount(number(u64)) },
+            AmountTypeNode::new(NumberTypeNode::le(U64), 0, None).into()
+        );
+    }
+
+    #[test]
+    fn implicit() {
+        assert_type!(
+            { amount(number(u64), 9, "SOL") },
+            AmountTypeNode::new(NumberTypeNode::le(U64), 9, Some("SOL".to_string())).into()
+        );
+    }
+
+    #[test]
+    fn explicit() {
+        assert_type!(
+            { amount(number = number(u64), decimals = 9, unit = "SOL") },
+            AmountTypeNode::new(NumberTypeNode::le(U64), 9, Some("SOL".to_string())).into()
+        );
+    }
+
+    #[test]
+    fn positional_args_are_matched_by_shape() {
+        assert_type!(
+            { amount("SOL", 9, number(u64)) },
+            AmountTypeNode::new(NumberTypeNode::le(U64), 9, Some("SOL".to_string())).into()
+        );
+    }
+
+    #[test]
+    fn decimals_without_unit() {
+        assert_type!(
+            { amount(number(u64), 6) },
+            AmountTypeNode::new(NumberTypeNode::le(U64), 6, None).into()
+        );
+    }
+
+    #[test]
+    fn invalid_number() {
+        assert_type_err!({ amount(string) }, "number must be a NumberTypeNode");
+    }
+
+    #[test]
+    fn number_missing() {
+        assert_type_err!({ amount(decimals = 9) }, "number is missing");
+    }
+
+    #[test]
+    fn already_set() {
+        assert_type_err!({ amount(number(u64), 9, 6) }, "decimals is already set");
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ amount(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/array_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/array_type_node.rs
@@ -1,0 +1,102 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{ArrayTypeNode, CountNode, TypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for ArrayTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("array")?.as_path_list()?;
+        let mut item: SetOnce<TypeNode> = SetOnce::new("item");
+        let mut count: SetOnce<CountNode> = SetOnce::new("count");
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "item" => item.set(TypeNode::from_meta(meta.as_value()?)?, meta),
+            "count" => count.set(CountNode::from_meta(meta.as_value()?)?, meta),
+            // The count nodes have their own directives, so they are recognised
+            // by name before falling through to the item.
+            "fixed_count" | "prefixed_count" | "remainder_count" => {
+                count.set(CountNode::from_meta(meta)?, meta)
+            }
+            _ => {
+                if meta.is_path_or_list() {
+                    return item.set(TypeNode::from_meta(meta)?, meta);
+                }
+                if meta.as_expr().is_ok() {
+                    return count.set(CountNode::from_meta(meta)?, meta);
+                }
+                Err(meta.error("unrecognized attribute"))
+            }
+        })?;
+
+        Ok(ArrayTypeNode::new(item.take(meta)?, count.take(meta)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{
+        FixedCountNode,
+        NumberFormat::{U32, U8},
+        NumberTypeNode, PrefixedCountNode, RemainderCountNode, StringTypeNode,
+    };
+
+    #[test]
+    fn implicit() {
+        assert_type!(
+            { array(number(u8), fixed_count(3)) },
+            ArrayTypeNode::new(NumberTypeNode::le(U8), FixedCountNode::new(3)).into()
+        );
+    }
+
+    #[test]
+    fn bare_integer_count() {
+        assert_type!(
+            { array(number(u8), 3) },
+            ArrayTypeNode::new(NumberTypeNode::le(U8), FixedCountNode::new(3)).into()
+        );
+    }
+
+    #[test]
+    fn explicit() {
+        assert_type!(
+            { array(item = number(u8), count = fixed_count(3)) },
+            ArrayTypeNode::new(NumberTypeNode::le(U8), FixedCountNode::new(3)).into()
+        );
+    }
+
+    #[test]
+    fn prefixed_count() {
+        assert_type!(
+            { array(string, prefixed_count(number(u32))) },
+            ArrayTypeNode::new(
+                StringTypeNode::utf8(),
+                PrefixedCountNode::new(NumberTypeNode::le(U32))
+            )
+            .into()
+        );
+    }
+
+    #[test]
+    fn remainder_count() {
+        assert_type!(
+            { array(number(u8), remainder_count) },
+            ArrayTypeNode::new(NumberTypeNode::le(U8), RemainderCountNode::new()).into()
+        );
+    }
+
+    #[test]
+    fn item_missing() {
+        assert_type_err!({ array(fixed_count(3)) }, "item is missing");
+    }
+
+    #[test]
+    fn count_missing() {
+        assert_type_err!({ array(number(u8)) }, "count is missing");
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ array(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/date_time_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/date_time_type_node.rs
@@ -1,0 +1,75 @@
+use super::nested_number::nested_number;
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{DateTimeTypeNode, NestedTypeNode, NumberTypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for DateTimeTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("date_time")?.as_path_list()?;
+        let mut number: SetOnce<NestedTypeNode<NumberTypeNode>> = SetOnce::new("number");
+
+        pl.each(|ref meta| {
+            // A positional `number(u64)` shares its path with the `number` field,
+            // so lists and bare paths are always read as the type node.
+            if meta.is_path_or_list() {
+                return number.set(nested_number(meta, "number")?, meta);
+            }
+            match meta.path_str().as_str() {
+                "number" => number.set(nested_number(meta.as_value()?, "number")?, meta),
+                _ => Err(meta.error("unrecognized attribute")),
+            }
+        })?;
+
+        Ok(DateTimeTypeNode::new(number.take(meta)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{FixedSizeTypeNode, NumberFormat::U64};
+
+    #[test]
+    fn implicit() {
+        assert_type!(
+            { date_time(number(u64)) },
+            DateTimeTypeNode::new(NumberTypeNode::le(U64)).into()
+        );
+    }
+
+    #[test]
+    fn explicit() {
+        assert_type!(
+            { date_time(number = number(u64)) },
+            DateTimeTypeNode::new(NumberTypeNode::le(U64)).into()
+        );
+    }
+
+    #[test]
+    fn nested_number() {
+        assert_type!(
+            { date_time(fixed_size(number(u64), 8)) },
+            DateTimeTypeNode::new(FixedSizeTypeNode::<NestedTypeNode<NumberTypeNode>>::new(
+                NumberTypeNode::le(U64),
+                8
+            ))
+            .into()
+        );
+    }
+
+    #[test]
+    fn invalid_number() {
+        assert_type_err!({ date_time(string) }, "number must be a NumberTypeNode");
+    }
+
+    #[test]
+    fn number_missing() {
+        assert_type_err!({ date_time() }, "number is missing");
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ date_time(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/date_time_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/date_time_type_node.rs
@@ -1,4 +1,4 @@
-use super::nested_number::nested_number;
+use crate::codama_directives::nested_number::nested_number;
 use crate::utils::{FromMeta, SetOnce};
 use codama_nodes::{DateTimeTypeNode, NestedTypeNode, NumberTypeNode};
 use codama_syn_helpers::{extensions::*, Meta};

--- a/codama-attributes/src/codama_directives/type_nodes/enum_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/enum_type_node.rs
@@ -1,0 +1,108 @@
+use crate::codama_directives::nested_number::nested_number;
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{EnumTypeNode, EnumVariantTypeNode, NestedTypeNode, NumberTypeNode, U8};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for EnumTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        meta.assert_directive("enum")?;
+        let mut variants: Vec<EnumVariantTypeNode> = Vec::new();
+        let mut size: SetOnce<NestedTypeNode<NumberTypeNode>> = SetOnce::new("size");
+
+        if !meta.is_path_or_empty_list() {
+            meta.as_path_list()?
+                .each(|ref meta| match meta.path_str().as_str() {
+                    "size" => size.set(nested_number(meta.as_value()?, "size")?, meta),
+                    "variant" => {
+                        variants.push(EnumVariantTypeNode::from_meta(meta)?);
+                        Ok(())
+                    }
+                    _ => Err(meta.error("expected variant(...) or size = ...")),
+                })?;
+        }
+
+        Ok(EnumTypeNode {
+            variants,
+            size: size
+                .option()
+                .unwrap_or(NestedTypeNode::Value(NumberTypeNode::le(U8))),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{
+        EnumEmptyVariantTypeNode, EnumTupleVariantTypeNode, NumberFormat::U16, TupleTypeNode,
+    };
+
+    #[test]
+    fn empty() {
+        assert_type!({ enum }, EnumTypeNode::new(vec![]).into());
+        assert_type!({ enum() }, EnumTypeNode::new(vec![]).into());
+    }
+
+    #[test]
+    fn empty_variants() {
+        assert_type!(
+            { enum(variant("pending"), variant("done")) },
+            EnumTypeNode::new(vec![
+                EnumEmptyVariantTypeNode::new("pending").into(),
+                EnumEmptyVariantTypeNode::new("done").into(),
+            ])
+            .into()
+        );
+    }
+
+    #[test]
+    fn tuple_variant() {
+        assert_type!(
+            { enum(variant("pair", tuple(number(u8)))) },
+            EnumTypeNode::new(vec![EnumTupleVariantTypeNode::new(
+                "pair",
+                TupleTypeNode::new(vec![NumberTypeNode::le(U8).into()])
+            )
+            .into()])
+            .into()
+        );
+    }
+
+    #[test]
+    fn size_defaults_to_u8() {
+        assert_type!(
+            { enum(variant("a")) },
+            EnumTypeNode {
+                variants: vec![EnumEmptyVariantTypeNode::new("a").into()],
+                size: NestedTypeNode::Value(NumberTypeNode::le(U8)),
+            }
+            .into()
+        );
+    }
+
+    #[test]
+    fn explicit_size() {
+        assert_type!(
+            { enum(variant("a"), size = number(u16)) },
+            EnumTypeNode {
+                variants: vec![EnumEmptyVariantTypeNode::new("a").into()],
+                size: NestedTypeNode::Value(NumberTypeNode::le(U16)),
+            }
+            .into()
+        );
+    }
+
+    #[test]
+    fn invalid_size() {
+        assert_type_err!(
+            { enum(size = string) },
+            "size must be a NumberTypeNode"
+        );
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ enum(foo = 42) }, "expected variant(...) or size = ...");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/enum_variant_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/enum_variant_type_node.rs
@@ -1,0 +1,147 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{
+    CamelCaseString, EnumEmptyVariantTypeNode, EnumStructVariantTypeNode, EnumTupleVariantTypeNode,
+    EnumVariantTypeNode, NestedTypeNode, TypeNode,
+};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for EnumVariantTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("variant")?.as_path_list()?;
+        let mut name: SetOnce<CamelCaseString> = SetOnce::new("name");
+        let mut discriminator: SetOnce<u32> = SetOnce::new("discriminator");
+        let mut payload: SetOnce<TypeNode> = SetOnce::new("payload");
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "name" => name.set(meta.as_value()?.as_expr()?.as_string()?.into(), meta),
+            "discriminator" => {
+                discriminator.set(meta.as_value()?.as_expr()?.as_unsigned_integer()?, meta)
+            }
+            _ => {
+                // The payload decides the variant kind: `struct(...)` or
+                // `tuple(...)`, and no payload at all means an empty variant.
+                if meta.is_path_or_list() {
+                    return payload.set(TypeNode::from_meta(meta)?, meta);
+                }
+                if let Ok(value) = meta.as_expr().and_then(|expr| expr.as_string()) {
+                    return name.set(value.into(), meta);
+                }
+                Err(meta.error("unrecognized attribute"))
+            }
+        })?;
+
+        let name = name.take(meta)?;
+        let discriminator = discriminator.option();
+
+        match payload.option() {
+            None => Ok(EnumEmptyVariantTypeNode {
+                name,
+                discriminator,
+                display: None,
+            }
+            .into()),
+            Some(TypeNode::Struct(node)) => Ok(EnumStructVariantTypeNode {
+                name,
+                discriminator,
+                r#struct: NestedTypeNode::Value(node),
+                display: None,
+            }
+            .into()),
+            Some(TypeNode::Tuple(node)) => Ok(EnumTupleVariantTypeNode {
+                name,
+                discriminator,
+                tuple: NestedTypeNode::Value(node),
+                display: None,
+            }
+            .into()),
+            Some(_) => Err(meta.error("a variant payload must be a struct or a tuple")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codama_nodes::{
+        NumberFormat::U8, NumberTypeNode, StructFieldTypeNode, StructTypeNode, TupleTypeNode,
+    };
+
+    fn parse(meta: Meta) -> syn::Result<EnumVariantTypeNode> {
+        EnumVariantTypeNode::from_meta(&meta)
+    }
+
+    #[test]
+    fn empty_variant() {
+        assert_eq!(
+            parse(syn::parse_quote! { variant("pending") }).unwrap(),
+            EnumEmptyVariantTypeNode::new("pending").into()
+        );
+    }
+
+    #[test]
+    fn struct_variant() {
+        assert_eq!(
+            parse(syn::parse_quote! { variant("point", struct(field("x", number(u8)))) }).unwrap(),
+            EnumStructVariantTypeNode::new(
+                "point",
+                StructTypeNode::new(vec![StructFieldTypeNode::new("x", NumberTypeNode::le(U8))])
+            )
+            .into()
+        );
+    }
+
+    #[test]
+    fn tuple_variant() {
+        assert_eq!(
+            parse(syn::parse_quote! { variant("pair", tuple(number(u8))) }).unwrap(),
+            EnumTupleVariantTypeNode::new(
+                "pair",
+                TupleTypeNode::new(vec![NumberTypeNode::le(U8).into()])
+            )
+            .into()
+        );
+    }
+
+    #[test]
+    fn explicit_name() {
+        assert_eq!(
+            parse(syn::parse_quote! { variant(name = "pending") }).unwrap(),
+            EnumEmptyVariantTypeNode::new("pending").into()
+        );
+    }
+
+    #[test]
+    fn discriminator() {
+        let node = parse(syn::parse_quote! { variant("pending", discriminator = 3) }).unwrap();
+        assert_eq!(
+            node,
+            EnumEmptyVariantTypeNode {
+                name: "pending".into(),
+                discriminator: Some(3),
+                display: None,
+            }
+            .into()
+        );
+    }
+
+    #[test]
+    fn name_missing() {
+        let error = parse(syn::parse_quote! { variant() }).unwrap_err();
+        assert_eq!(error.to_string(), "name is missing");
+    }
+
+    #[test]
+    fn invalid_payload() {
+        let error = parse(syn::parse_quote! { variant("a", number(u8)) }).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "a variant payload must be a struct or a tuple"
+        );
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        let error = parse(syn::parse_quote! { variant("a", foo = 42) }).unwrap_err();
+        assert_eq!(error.to_string(), "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/hidden_prefix_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/hidden_prefix_type_node.rs
@@ -1,0 +1,77 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{ConstantValueNode, HiddenPrefixTypeNode, TypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for HiddenPrefixTypeNode<TypeNode> {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("hidden_prefix")?.as_path_list()?;
+        let mut r#type: SetOnce<TypeNode> = SetOnce::new("type");
+        let mut prefix: Vec<ConstantValueNode> = Vec::new();
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "type" => r#type.set(TypeNode::from_meta(meta.as_value()?)?, meta),
+            // Every `constant(...)` is appended, so the prefix keeps its order.
+            "constant" => {
+                prefix.push(ConstantValueNode::from_meta(meta)?);
+                Ok(())
+            }
+            _ => {
+                if meta.is_path_or_list() {
+                    return r#type.set(TypeNode::from_meta(meta)?, meta);
+                }
+                Err(meta.error("unrecognized attribute"))
+            }
+        })?;
+
+        Ok(HiddenPrefixTypeNode::new(r#type.take(meta)?, prefix))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{NumberFormat::U8, NumberTypeNode, NumberValueNode, StringTypeNode};
+
+    fn constant(value: u64) -> ConstantValueNode {
+        ConstantValueNode::new(NumberTypeNode::le(U8), NumberValueNode::new(value))
+    }
+
+    #[test]
+    fn single_constant() {
+        assert_type!(
+            { hidden_prefix(string, constant(number(u8), 1)) },
+            HiddenPrefixTypeNode::new(StringTypeNode::utf8(), vec![constant(1)]).into()
+        );
+    }
+
+    #[test]
+    fn multiple_constants_keep_their_order() {
+        assert_type!(
+            { hidden_prefix(string, constant(number(u8), 1), constant(number(u8), 2)) },
+            HiddenPrefixTypeNode::new(StringTypeNode::utf8(), vec![constant(1), constant(2)])
+                .into()
+        );
+    }
+
+    #[test]
+    fn no_constants() {
+        assert_type!(
+            { hidden_prefix(string) },
+            HiddenPrefixTypeNode::new(StringTypeNode::utf8(), vec![]).into()
+        );
+    }
+
+    #[test]
+    fn type_missing() {
+        assert_type_err!(
+            { hidden_prefix(constant(number(u8), 1)) },
+            "type is missing"
+        );
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ hidden_prefix(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/hidden_suffix_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/hidden_suffix_type_node.rs
@@ -1,0 +1,69 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{ConstantValueNode, HiddenSuffixTypeNode, TypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for HiddenSuffixTypeNode<TypeNode> {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("hidden_suffix")?.as_path_list()?;
+        let mut r#type: SetOnce<TypeNode> = SetOnce::new("type");
+        let mut suffix: Vec<ConstantValueNode> = Vec::new();
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "type" => r#type.set(TypeNode::from_meta(meta.as_value()?)?, meta),
+            // Every `constant(...)` is appended, so the suffix keeps its order.
+            "constant" => {
+                suffix.push(ConstantValueNode::from_meta(meta)?);
+                Ok(())
+            }
+            _ => {
+                if meta.is_path_or_list() {
+                    return r#type.set(TypeNode::from_meta(meta)?, meta);
+                }
+                Err(meta.error("unrecognized attribute"))
+            }
+        })?;
+
+        Ok(HiddenSuffixTypeNode::new(r#type.take(meta)?, suffix))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{NumberFormat::U8, NumberTypeNode, NumberValueNode, StringTypeNode};
+
+    fn constant(value: u64) -> ConstantValueNode {
+        ConstantValueNode::new(NumberTypeNode::le(U8), NumberValueNode::new(value))
+    }
+
+    #[test]
+    fn single_constant() {
+        assert_type!(
+            { hidden_suffix(string, constant(number(u8), 1)) },
+            HiddenSuffixTypeNode::new(StringTypeNode::utf8(), vec![constant(1)]).into()
+        );
+    }
+
+    #[test]
+    fn multiple_constants_keep_their_order() {
+        assert_type!(
+            { hidden_suffix(string, constant(number(u8), 1), constant(number(u8), 2)) },
+            HiddenSuffixTypeNode::new(StringTypeNode::utf8(), vec![constant(1), constant(2)])
+                .into()
+        );
+    }
+
+    #[test]
+    fn type_missing() {
+        assert_type_err!(
+            { hidden_suffix(constant(number(u8), 1)) },
+            "type is missing"
+        );
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ hidden_suffix(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/map_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/map_type_node.rs
@@ -1,0 +1,126 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{CountNode, MapTypeNode, TypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for MapTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("map")?.as_path_list()?;
+        let mut key: SetOnce<TypeNode> = SetOnce::new("key");
+        let mut value: SetOnce<TypeNode> = SetOnce::new("value");
+        let mut count: SetOnce<CountNode> = SetOnce::new("count");
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "key" => key.set(TypeNode::from_meta(meta.as_value()?)?, meta),
+            "value" => value.set(TypeNode::from_meta(meta.as_value()?)?, meta),
+            "count" => count.set(CountNode::from_meta(meta.as_value()?)?, meta),
+            "fixed_count" | "prefixed_count" | "remainder_count" => {
+                count.set(CountNode::from_meta(meta)?, meta)
+            }
+            _ => {
+                // Key and value are both type nodes, so positional args fill
+                // `key` then `value` and are never swapped.
+                if meta.is_path_or_list() {
+                    return match key.is_set() {
+                        false => key.set(TypeNode::from_meta(meta)?, meta),
+                        true => value.set(TypeNode::from_meta(meta)?, meta),
+                    };
+                }
+                if meta.as_expr().is_ok() {
+                    return count.set(CountNode::from_meta(meta)?, meta);
+                }
+                Err(meta.error("unrecognized attribute"))
+            }
+        })?;
+
+        Ok(MapTypeNode::new(
+            key.take(meta)?,
+            value.take(meta)?,
+            count.take(meta)?,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{
+        FixedCountNode,
+        NumberFormat::{U32, U8},
+        NumberTypeNode, PrefixedCountNode, PublicKeyTypeNode, StringTypeNode,
+    };
+
+    #[test]
+    fn implicit() {
+        assert_type!(
+            { map(public_key, number(u8), fixed_count(3)) },
+            MapTypeNode::new(
+                PublicKeyTypeNode::new(),
+                NumberTypeNode::le(U8),
+                FixedCountNode::new(3)
+            )
+            .into()
+        );
+    }
+
+    #[test]
+    fn bare_integer_count() {
+        assert_type!(
+            { map(string, number(u8), 3) },
+            MapTypeNode::new(
+                StringTypeNode::utf8(),
+                NumberTypeNode::le(U8),
+                FixedCountNode::new(3)
+            )
+            .into()
+        );
+    }
+
+    #[test]
+    fn explicit() {
+        assert_type!(
+            {
+                map(
+                    key = string,
+                    value = number(u8),
+                    count = prefixed_count(number(u32)),
+                )
+            },
+            MapTypeNode::new(
+                StringTypeNode::utf8(),
+                NumberTypeNode::le(U8),
+                PrefixedCountNode::new(NumberTypeNode::le(U32))
+            )
+            .into()
+        );
+    }
+
+    #[test]
+    fn positional_order() {
+        // Positional args fill `key` then `value` and are never swapped.
+        assert_type!(
+            { map(string, public_key, 1) },
+            MapTypeNode::new(
+                StringTypeNode::utf8(),
+                PublicKeyTypeNode::new(),
+                FixedCountNode::new(1)
+            )
+            .into()
+        );
+    }
+
+    #[test]
+    fn value_missing() {
+        assert_type_err!({ map(string, fixed_count(3)) }, "value is missing");
+    }
+
+    #[test]
+    fn count_missing() {
+        assert_type_err!({ map(string, number(u8)) }, "count is missing");
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ map(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/mod.rs
@@ -3,11 +3,12 @@ mod array_type_node;
 mod boolean_type_node;
 mod bytes_type_node;
 mod date_time_type_node;
+mod enum_type_node;
+mod enum_variant_type_node;
 mod fixed_size_type_node;
 mod hidden_prefix_type_node;
 mod hidden_suffix_type_node;
 mod map_type_node;
-
 mod number_type_node;
 mod option_type_node;
 mod post_offset_type_node;

--- a/codama-attributes/src/codama_directives/type_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/mod.rs
@@ -1,13 +1,16 @@
 mod amount_type_node;
+mod array_type_node;
 mod boolean_type_node;
 mod bytes_type_node;
 mod date_time_type_node;
 mod fixed_size_type_node;
-mod nested_number;
+mod map_type_node;
+
 mod number_type_node;
 mod option_type_node;
 mod public_key_type_node;
 mod remainder_option_type_node;
+mod set_type_node;
 mod size_prefix_type_node;
 mod sol_amount_type_node;
 mod string_type_node;

--- a/codama-attributes/src/codama_directives/type_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/mod.rs
@@ -4,12 +4,17 @@ mod boolean_type_node;
 mod bytes_type_node;
 mod date_time_type_node;
 mod fixed_size_type_node;
+mod hidden_prefix_type_node;
+mod hidden_suffix_type_node;
 mod map_type_node;
 
 mod number_type_node;
 mod option_type_node;
+mod post_offset_type_node;
+mod pre_offset_type_node;
 mod public_key_type_node;
 mod remainder_option_type_node;
+mod sentinel_type_node;
 mod set_type_node;
 mod size_prefix_type_node;
 mod sol_amount_type_node;

--- a/codama-attributes/src/codama_directives/type_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/mod.rs
@@ -1,14 +1,20 @@
+mod amount_type_node;
 mod boolean_type_node;
 mod bytes_type_node;
+mod date_time_type_node;
 mod fixed_size_type_node;
+mod nested_number;
 mod number_type_node;
 mod option_type_node;
 mod public_key_type_node;
+mod remainder_option_type_node;
 mod size_prefix_type_node;
+mod sol_amount_type_node;
 mod string_type_node;
 mod struct_field_meta_consumer;
 mod struct_field_type_node;
 mod struct_type_node;
+mod tuple_type_node;
 mod type_node;
 mod zeroable_option_type_node;
 

--- a/codama-attributes/src/codama_directives/type_nodes/nested_number.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/nested_number.rs
@@ -1,0 +1,14 @@
+use crate::utils::FromMeta;
+use codama_nodes::{NestedTypeNode, NumberTypeNode, TypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+/// Parse a type node that must resolve to a number, allowing the wrappers
+/// `NestedTypeNode` accepts, e.g. `number(u32)` or `fixed_size(number(u32), 4)`.
+pub(super) fn nested_number(
+    meta: &Meta,
+    ident: &str,
+) -> syn::Result<NestedTypeNode<NumberTypeNode>> {
+    let node = TypeNode::from_meta(meta)?;
+    NestedTypeNode::<NumberTypeNode>::try_from(node)
+        .map_err(|_| meta.error(format!("{ident} must be a NumberTypeNode")))
+}

--- a/codama-attributes/src/codama_directives/type_nodes/post_offset_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/post_offset_type_node.rs
@@ -1,0 +1,127 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{PostOffsetStrategy, PostOffsetTypeNode, TypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for PostOffsetTypeNode<TypeNode> {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("post_offset")?.as_path_list()?;
+        let mut r#type: SetOnce<TypeNode> = SetOnce::new("type");
+        let mut offset: SetOnce<i32> = SetOnce::new("offset");
+        let mut strategy: SetOnce<PostOffsetStrategy> = SetOnce::new("strategy");
+
+        pl.each(|ref meta| {
+            // Strategies are written as bare paths. This also keeps the
+            // `pre_offset` strategy distinct from the `pre_offset(...)` type node,
+            // which is a list rather than a bare path.
+            if let Some(value) = bare_path(meta).as_deref().and_then(parse_strategy) {
+                return strategy.set(value, meta);
+            }
+            match meta.path_str().as_str() {
+                "type" => r#type.set(TypeNode::from_meta(meta.as_value()?)?, meta),
+                "offset" => offset.set(meta.as_value()?.as_expr()?.as_signed_integer()?, meta),
+                "strategy" => {
+                    let path = meta.as_value()?.as_expr()?.as_path()?;
+                    match parse_strategy(&path.to_string()) {
+                        Some(value) => strategy.set(value, meta),
+                        None => Err(path.error("invalid strategy")),
+                    }
+                }
+                _ => {
+                    if meta.is_path_or_list() {
+                        return r#type.set(TypeNode::from_meta(meta)?, meta);
+                    }
+                    if let Ok(expr) = meta.as_expr() {
+                        return offset.set(expr.as_signed_integer()?, meta);
+                    }
+                    Err(meta.error("unrecognized attribute"))
+                }
+            }
+        })?;
+
+        Ok(PostOffsetTypeNode::new(
+            r#type.take(meta)?,
+            strategy.take(meta)?,
+            offset.take(meta)?,
+        ))
+    }
+}
+
+fn bare_path(meta: &Meta) -> Option<String> {
+    meta.as_expr()
+        .ok()?
+        .as_path()
+        .ok()
+        .map(|path| path.to_string())
+}
+
+fn parse_strategy(name: &str) -> Option<PostOffsetStrategy> {
+    match name {
+        "absolute" => Some(PostOffsetStrategy::Absolute),
+        "padded" => Some(PostOffsetStrategy::Padded),
+        "pre_offset" => Some(PostOffsetStrategy::PreOffset),
+        "relative" => Some(PostOffsetStrategy::Relative),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{PreOffsetTypeNode, StringTypeNode};
+
+    #[test]
+    fn implicit() {
+        assert_type!(
+            { post_offset(string, 4, relative) },
+            PostOffsetTypeNode::relative(StringTypeNode::utf8(), 4).into()
+        );
+    }
+
+    #[test]
+    fn explicit() {
+        assert_type!(
+            { post_offset(type = string, offset = 4, strategy = absolute) },
+            PostOffsetTypeNode::absolute(StringTypeNode::utf8(), 4).into()
+        );
+    }
+
+    #[test]
+    fn pre_offset_strategy() {
+        assert_type!(
+            { post_offset(string, 0, pre_offset) },
+            PostOffsetTypeNode::pre_offset(StringTypeNode::utf8(), 0).into()
+        );
+    }
+
+    #[test]
+    fn wrapping_a_pre_offset_type_node() {
+        // A bare `pre_offset` is the strategy, `pre_offset(...)` is the type node.
+        assert_type!(
+            { post_offset(pre_offset(string, 4, relative), 0, pre_offset) },
+            PostOffsetTypeNode::pre_offset(
+                PreOffsetTypeNode::relative(StringTypeNode::utf8(), 4),
+                0
+            )
+            .into()
+        );
+    }
+
+    #[test]
+    fn strategy_missing() {
+        assert_type_err!({ post_offset(string, 4) }, "strategy is missing");
+    }
+
+    #[test]
+    fn invalid_strategy() {
+        assert_type_err!(
+            { post_offset(string, 4, strategy = nonsense) },
+            "invalid strategy"
+        );
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ post_offset(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/pre_offset_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/pre_offset_type_node.rs
@@ -1,0 +1,125 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{PreOffsetStrategy, PreOffsetTypeNode, TypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for PreOffsetTypeNode<TypeNode> {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("pre_offset")?.as_path_list()?;
+        let mut r#type: SetOnce<TypeNode> = SetOnce::new("type");
+        let mut offset: SetOnce<i32> = SetOnce::new("offset");
+        let mut strategy: SetOnce<PreOffsetStrategy> = SetOnce::new("strategy");
+
+        pl.each(|ref meta| {
+            // Strategies are written as bare paths, so they are claimed before a
+            // bare path could be read as a positional type node.
+            if let Some(value) = bare_path(meta).as_deref().and_then(parse_strategy) {
+                return strategy.set(value, meta);
+            }
+            match meta.path_str().as_str() {
+                "type" => r#type.set(TypeNode::from_meta(meta.as_value()?)?, meta),
+                "offset" => offset.set(meta.as_value()?.as_expr()?.as_signed_integer()?, meta),
+                "strategy" => {
+                    let path = meta.as_value()?.as_expr()?.as_path()?;
+                    match parse_strategy(&path.to_string()) {
+                        Some(value) => strategy.set(value, meta),
+                        None => Err(path.error("invalid strategy")),
+                    }
+                }
+                _ => {
+                    if meta.is_path_or_list() {
+                        return r#type.set(TypeNode::from_meta(meta)?, meta);
+                    }
+                    if let Ok(expr) = meta.as_expr() {
+                        return offset.set(expr.as_signed_integer()?, meta);
+                    }
+                    Err(meta.error("unrecognized attribute"))
+                }
+            }
+        })?;
+
+        Ok(PreOffsetTypeNode::new(
+            r#type.take(meta)?,
+            strategy.take(meta)?,
+            offset.take(meta)?,
+        ))
+    }
+}
+
+fn bare_path(meta: &Meta) -> Option<String> {
+    meta.as_expr()
+        .ok()?
+        .as_path()
+        .ok()
+        .map(|path| path.to_string())
+}
+
+fn parse_strategy(name: &str) -> Option<PreOffsetStrategy> {
+    match name {
+        "absolute" => Some(PreOffsetStrategy::Absolute),
+        "padded" => Some(PreOffsetStrategy::Padded),
+        "relative" => Some(PreOffsetStrategy::Relative),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::StringTypeNode;
+
+    #[test]
+    fn implicit() {
+        assert_type!(
+            { pre_offset(string, 4, relative) },
+            PreOffsetTypeNode::relative(StringTypeNode::utf8(), 4).into()
+        );
+    }
+
+    #[test]
+    fn explicit() {
+        assert_type!(
+            { pre_offset(type = string, offset = 4, strategy = absolute) },
+            PreOffsetTypeNode::absolute(StringTypeNode::utf8(), 4).into()
+        );
+    }
+
+    #[test]
+    fn padded() {
+        assert_type!(
+            { pre_offset(string, 8, padded) },
+            PreOffsetTypeNode::padded(StringTypeNode::utf8(), 8).into()
+        );
+    }
+
+    #[test]
+    fn negative_offset() {
+        assert_type!(
+            { pre_offset(string, -4, relative) },
+            PreOffsetTypeNode::relative(StringTypeNode::utf8(), -4).into()
+        );
+    }
+
+    #[test]
+    fn strategy_missing() {
+        assert_type_err!({ pre_offset(string, 4) }, "strategy is missing");
+    }
+
+    #[test]
+    fn offset_missing() {
+        assert_type_err!({ pre_offset(string, relative) }, "offset is missing");
+    }
+
+    #[test]
+    fn invalid_strategy() {
+        assert_type_err!(
+            { pre_offset(string, 4, strategy = nonsense) },
+            "invalid strategy"
+        );
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ pre_offset(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/remainder_option_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/remainder_option_type_node.rs
@@ -1,0 +1,75 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{RemainderOptionTypeNode, TypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for RemainderOptionTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("remainder_option")?.as_path_list()?;
+        let mut item: SetOnce<TypeNode> = SetOnce::new("item");
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "item" => item.set(TypeNode::from_meta(meta.as_value()?)?, meta),
+            _ => {
+                if meta.is_path_or_list() {
+                    return item.set(TypeNode::from_meta(meta)?, meta);
+                }
+                Err(meta.error("unrecognized attribute"))
+            }
+        })?;
+
+        Ok(RemainderOptionTypeNode::new(item.take(meta)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{NumberTypeNode, StringTypeNode, U8};
+
+    #[test]
+    fn implicit() {
+        assert_type!(
+            { remainder_option(number(u8)) },
+            RemainderOptionTypeNode::new(NumberTypeNode::le(U8)).into()
+        );
+    }
+
+    #[test]
+    fn explicit() {
+        assert_type!(
+            { remainder_option(item = number(u8)) },
+            RemainderOptionTypeNode::new(NumberTypeNode::le(U8)).into()
+        );
+    }
+
+    #[test]
+    fn nested() {
+        assert_type!(
+            { remainder_option(size_prefix(string, number(u8))) },
+            RemainderOptionTypeNode::new(codama_nodes::SizePrefixTypeNode::new(
+                StringTypeNode::utf8(),
+                NumberTypeNode::le(U8)
+            ))
+            .into()
+        );
+    }
+
+    #[test]
+    fn item_missing() {
+        assert_type_err!({ remainder_option() }, "item is missing");
+    }
+
+    #[test]
+    fn already_set() {
+        assert_type_err!(
+            { remainder_option(number(u8), string) },
+            "item is already set"
+        );
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ remainder_option(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/sentinel_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/sentinel_type_node.rs
@@ -1,0 +1,70 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{ConstantValueNode, SentinelTypeNode, TypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for SentinelTypeNode<TypeNode> {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("sentinel")?.as_path_list()?;
+        let mut r#type: SetOnce<TypeNode> = SetOnce::new("type");
+        let mut sentinel: SetOnce<ConstantValueNode> = SetOnce::new("sentinel");
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "type" => r#type.set(TypeNode::from_meta(meta.as_value()?)?, meta),
+            "sentinel" => sentinel.set(ConstantValueNode::from_meta(meta.as_value()?)?, meta),
+            "constant" => sentinel.set(ConstantValueNode::from_meta(meta)?, meta),
+            _ => {
+                if meta.is_path_or_list() {
+                    return r#type.set(TypeNode::from_meta(meta)?, meta);
+                }
+                Err(meta.error("unrecognized attribute"))
+            }
+        })?;
+
+        Ok(SentinelTypeNode::new(
+            r#type.take(meta)?,
+            sentinel.take(meta)?,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{NumberFormat::U8, NumberTypeNode, NumberValueNode, StringTypeNode};
+
+    fn sentinel_255() -> ConstantValueNode {
+        ConstantValueNode::new(NumberTypeNode::le(U8), NumberValueNode::new(255u64))
+    }
+
+    #[test]
+    fn implicit() {
+        assert_type!(
+            { sentinel(string, constant(number(u8), 255)) },
+            SentinelTypeNode::new(StringTypeNode::utf8(), sentinel_255()).into()
+        );
+    }
+
+    #[test]
+    fn explicit() {
+        assert_type!(
+            { sentinel(type = string, sentinel = constant(number(u8), 255)) },
+            SentinelTypeNode::new(StringTypeNode::utf8(), sentinel_255()).into()
+        );
+    }
+
+    #[test]
+    fn sentinel_missing() {
+        assert_type_err!({ sentinel(string) }, "sentinel is missing");
+    }
+
+    #[test]
+    fn type_missing() {
+        assert_type_err!({ sentinel(constant(number(u8), 255)) }, "type is missing");
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ sentinel(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/set_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/set_type_node.rs
@@ -1,0 +1,79 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{CountNode, SetTypeNode, TypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for SetTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("set")?.as_path_list()?;
+        let mut item: SetOnce<TypeNode> = SetOnce::new("item");
+        let mut count: SetOnce<CountNode> = SetOnce::new("count");
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "item" => item.set(TypeNode::from_meta(meta.as_value()?)?, meta),
+            "count" => count.set(CountNode::from_meta(meta.as_value()?)?, meta),
+            "fixed_count" | "prefixed_count" | "remainder_count" => {
+                count.set(CountNode::from_meta(meta)?, meta)
+            }
+            _ => {
+                if meta.is_path_or_list() {
+                    return item.set(TypeNode::from_meta(meta)?, meta);
+                }
+                if meta.as_expr().is_ok() {
+                    return count.set(CountNode::from_meta(meta)?, meta);
+                }
+                Err(meta.error("unrecognized attribute"))
+            }
+        })?;
+
+        Ok(SetTypeNode::new(item.take(meta)?, count.take(meta)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{
+        FixedCountNode,
+        NumberFormat::{U32, U8},
+        NumberTypeNode, PrefixedCountNode,
+    };
+
+    #[test]
+    fn implicit() {
+        assert_type!(
+            { set(number(u8), fixed_count(3)) },
+            SetTypeNode::new(NumberTypeNode::le(U8), FixedCountNode::new(3)).into()
+        );
+    }
+
+    #[test]
+    fn bare_integer_count() {
+        assert_type!(
+            { set(number(u8), 3) },
+            SetTypeNode::new(NumberTypeNode::le(U8), FixedCountNode::new(3)).into()
+        );
+    }
+
+    #[test]
+    fn explicit() {
+        assert_type!(
+            { set(item = number(u8), count = prefixed_count(number(u32))) },
+            SetTypeNode::new(
+                NumberTypeNode::le(U8),
+                PrefixedCountNode::new(NumberTypeNode::le(U32))
+            )
+            .into()
+        );
+    }
+
+    #[test]
+    fn count_missing() {
+        assert_type_err!({ set(number(u8)) }, "count is missing");
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ set(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/sol_amount_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/sol_amount_type_node.rs
@@ -1,0 +1,66 @@
+use super::nested_number::nested_number;
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{NestedTypeNode, NumberTypeNode, SolAmountTypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for SolAmountTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("sol_amount")?.as_path_list()?;
+        let mut number: SetOnce<NestedTypeNode<NumberTypeNode>> = SetOnce::new("number");
+
+        pl.each(|ref meta| {
+            // A positional `number(u64)` shares its path with the `number` field,
+            // so lists and bare paths are always read as the type node.
+            if meta.is_path_or_list() {
+                return number.set(nested_number(meta, "number")?, meta);
+            }
+            match meta.path_str().as_str() {
+                "number" => number.set(nested_number(meta.as_value()?, "number")?, meta),
+                _ => Err(meta.error("unrecognized attribute")),
+            }
+        })?;
+
+        Ok(SolAmountTypeNode::new(number.take(meta)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::NumberFormat::U64;
+
+    #[test]
+    fn implicit() {
+        assert_type!(
+            { sol_amount(number(u64)) },
+            SolAmountTypeNode::new(NumberTypeNode::le(U64)).into()
+        );
+    }
+
+    #[test]
+    fn explicit() {
+        assert_type!(
+            { sol_amount(number = number(u64)) },
+            SolAmountTypeNode::new(NumberTypeNode::le(U64)).into()
+        );
+    }
+
+    #[test]
+    fn invalid_number() {
+        assert_type_err!(
+            { sol_amount(public_key) },
+            "number must be a NumberTypeNode"
+        );
+    }
+
+    #[test]
+    fn number_missing() {
+        assert_type_err!({ sol_amount() }, "number is missing");
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ sol_amount(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/sol_amount_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/sol_amount_type_node.rs
@@ -1,4 +1,4 @@
-use super::nested_number::nested_number;
+use crate::codama_directives::nested_number::nested_number;
 use crate::utils::{FromMeta, SetOnce};
 use codama_nodes::{NestedTypeNode, NumberTypeNode, SolAmountTypeNode};
 use codama_syn_helpers::{extensions::*, Meta};

--- a/codama-attributes/src/codama_directives/type_nodes/tuple_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/tuple_type_node.rs
@@ -1,0 +1,76 @@
+use crate::utils::FromMeta;
+use codama_errors::IteratorCombineErrors;
+use codama_nodes::{TupleTypeNode, TypeNode};
+use codama_syn_helpers::Meta;
+
+impl FromMeta for TupleTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        meta.assert_directive("tuple")?;
+        if meta.is_path_or_empty_list() {
+            return Ok(TupleTypeNode::new(vec![]));
+        }
+
+        let items = meta
+            .as_path_list()?
+            .parse_metas()?
+            .iter()
+            .map(TypeNode::from_meta)
+            .collect_and_combine_errors()?;
+
+        Ok(TupleTypeNode::new(items))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{
+        NumberFormat::{U32, U8},
+        NumberTypeNode, PublicKeyTypeNode, StringTypeNode,
+    };
+
+    #[test]
+    fn empty() {
+        assert_type!({ tuple }, TupleTypeNode::new(vec![]).into());
+        assert_type!({ tuple() }, TupleTypeNode::new(vec![]).into());
+    }
+
+    #[test]
+    fn single_item() {
+        assert_type!(
+            { tuple(number(u32)) },
+            TupleTypeNode::new(vec![NumberTypeNode::le(U32).into()]).into()
+        );
+    }
+
+    #[test]
+    fn multiple_items() {
+        assert_type!(
+            { tuple(number(u32), string, public_key) },
+            TupleTypeNode::new(vec![
+                NumberTypeNode::le(U32).into(),
+                StringTypeNode::utf8().into(),
+                PublicKeyTypeNode::new().into(),
+            ])
+            .into()
+        );
+    }
+
+    #[test]
+    fn nested() {
+        assert_type!(
+            { tuple(option(number(u8)), tuple(string)) },
+            TupleTypeNode::new(vec![
+                codama_nodes::OptionTypeNode::new(NumberTypeNode::le(U8)).into(),
+                TupleTypeNode::new(vec![StringTypeNode::utf8().into()]).into(),
+            ])
+            .into()
+        );
+    }
+
+    #[test]
+    fn unrecognized_type() {
+        assert_type_err!({ tuple(unrecognized) }, "unrecognized type");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/type_node.rs
@@ -1,24 +1,30 @@
 use crate::{utils::FromMeta, TypeDirectiveNode};
 use codama_nodes::{
-    BooleanTypeNode, BytesTypeNode, FixedSizeTypeNode, NumberTypeNode, OptionTypeNode,
-    PublicKeyTypeNode, RegisteredTypeNode, SizePrefixTypeNode, StringTypeNode, StructFieldTypeNode,
-    StructTypeNode, TypeNode, ZeroableOptionTypeNode,
+    AmountTypeNode, BooleanTypeNode, BytesTypeNode, DateTimeTypeNode, FixedSizeTypeNode,
+    NumberTypeNode, OptionTypeNode, PublicKeyTypeNode, RegisteredTypeNode, RemainderOptionTypeNode,
+    SizePrefixTypeNode, SolAmountTypeNode, StringTypeNode, StructFieldTypeNode, StructTypeNode,
+    TupleTypeNode, TypeNode, ZeroableOptionTypeNode,
 };
 use codama_syn_helpers::{extensions::*, Meta};
 
 impl FromMeta for RegisteredTypeNode {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
         match meta.path_str().as_str() {
+            "amount" => AmountTypeNode::from_meta(meta).map(Self::from),
             "boolean" => BooleanTypeNode::from_meta(meta).map(Self::from),
             "bytes" => BytesTypeNode::from_meta(meta).map(Self::from),
+            "date_time" => DateTimeTypeNode::from_meta(meta).map(Self::from),
             "field" => StructFieldTypeNode::from_meta(meta).map(Self::from),
             "fixed_size" => FixedSizeTypeNode::from_meta(meta).map(Self::from),
             "number" => NumberTypeNode::from_meta(meta).map(Self::from),
             "option" => OptionTypeNode::from_meta(meta).map(Self::from),
             "public_key" => PublicKeyTypeNode::from_meta(meta).map(Self::from),
+            "remainder_option" => RemainderOptionTypeNode::from_meta(meta).map(Self::from),
             "size_prefix" => SizePrefixTypeNode::from_meta(meta).map(Self::from),
+            "sol_amount" => SolAmountTypeNode::from_meta(meta).map(Self::from),
             "string" => StringTypeNode::from_meta(meta).map(Self::from),
             "struct" => StructTypeNode::from_meta(meta).map(Self::from),
+            "tuple" => TupleTypeNode::from_meta(meta).map(Self::from),
             "zeroable_option" => ZeroableOptionTypeNode::from_meta(meta).map(Self::from),
             _ => Err(meta.error("unrecognized type")),
         }

--- a/codama-attributes/src/codama_directives/type_nodes/type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/type_node.rs
@@ -1,11 +1,11 @@
 use crate::{utils::FromMeta, TypeDirectiveNode};
 use codama_nodes::{
-    AmountTypeNode, ArrayTypeNode, BooleanTypeNode, BytesTypeNode, DateTimeTypeNode,
-    FixedSizeTypeNode, HiddenPrefixTypeNode, HiddenSuffixTypeNode, MapTypeNode, NumberTypeNode,
-    OptionTypeNode, PostOffsetTypeNode, PreOffsetTypeNode, PublicKeyTypeNode, RegisteredTypeNode,
-    RemainderOptionTypeNode, SentinelTypeNode, SetTypeNode, SizePrefixTypeNode, SolAmountTypeNode,
-    StringTypeNode, StructFieldTypeNode, StructTypeNode, TupleTypeNode, TypeNode,
-    ZeroableOptionTypeNode,
+    AmountTypeNode, ArrayTypeNode, BooleanTypeNode, BytesTypeNode, DateTimeTypeNode, EnumTypeNode,
+    EnumVariantTypeNode, FixedSizeTypeNode, HiddenPrefixTypeNode, HiddenSuffixTypeNode,
+    MapTypeNode, NumberTypeNode, OptionTypeNode, PostOffsetTypeNode, PreOffsetTypeNode,
+    PublicKeyTypeNode, RegisteredTypeNode, RemainderOptionTypeNode, SentinelTypeNode, SetTypeNode,
+    SizePrefixTypeNode, SolAmountTypeNode, StringTypeNode, StructFieldTypeNode, StructTypeNode,
+    TupleTypeNode, TypeNode, ZeroableOptionTypeNode,
 };
 use codama_syn_helpers::{extensions::*, Meta};
 
@@ -17,6 +17,7 @@ impl FromMeta for RegisteredTypeNode {
             "boolean" => BooleanTypeNode::from_meta(meta).map(Self::from),
             "bytes" => BytesTypeNode::from_meta(meta).map(Self::from),
             "date_time" => DateTimeTypeNode::from_meta(meta).map(Self::from),
+            "enum" => EnumTypeNode::from_meta(meta).map(Self::from),
             "field" => StructFieldTypeNode::from_meta(meta).map(Self::from),
             "fixed_size" => FixedSizeTypeNode::from_meta(meta).map(Self::from),
             "hidden_prefix" => HiddenPrefixTypeNode::from_meta(meta).map(Self::from),
@@ -35,6 +36,13 @@ impl FromMeta for RegisteredTypeNode {
             "string" => StringTypeNode::from_meta(meta).map(Self::from),
             "struct" => StructTypeNode::from_meta(meta).map(Self::from),
             "tuple" => TupleTypeNode::from_meta(meta).map(Self::from),
+            // `RegisteredTypeNode` holds the three variant kinds separately
+            // rather than the `EnumVariantTypeNode` union, so unwrap it here.
+            "variant" => EnumVariantTypeNode::from_meta(meta).map(|node| match node {
+                EnumVariantTypeNode::Empty(node) => Self::from(node),
+                EnumVariantTypeNode::Struct(node) => Self::from(node),
+                EnumVariantTypeNode::Tuple(node) => Self::from(node),
+            }),
             "zeroable_option" => ZeroableOptionTypeNode::from_meta(meta).map(Self::from),
             _ => Err(meta.error("unrecognized type")),
         }

--- a/codama-attributes/src/codama_directives/type_nodes/type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/type_node.rs
@@ -1,9 +1,10 @@
 use crate::{utils::FromMeta, TypeDirectiveNode};
 use codama_nodes::{
-    AmountTypeNode, BooleanTypeNode, BytesTypeNode, DateTimeTypeNode, FixedSizeTypeNode,
-    NumberTypeNode, OptionTypeNode, PublicKeyTypeNode, RegisteredTypeNode, RemainderOptionTypeNode,
-    SizePrefixTypeNode, SolAmountTypeNode, StringTypeNode, StructFieldTypeNode, StructTypeNode,
-    TupleTypeNode, TypeNode, ZeroableOptionTypeNode,
+    AmountTypeNode, ArrayTypeNode, BooleanTypeNode, BytesTypeNode, DateTimeTypeNode,
+    FixedSizeTypeNode, MapTypeNode, NumberTypeNode, OptionTypeNode, PublicKeyTypeNode,
+    RegisteredTypeNode, RemainderOptionTypeNode, SetTypeNode, SizePrefixTypeNode,
+    SolAmountTypeNode, StringTypeNode, StructFieldTypeNode, StructTypeNode, TupleTypeNode,
+    TypeNode, ZeroableOptionTypeNode,
 };
 use codama_syn_helpers::{extensions::*, Meta};
 
@@ -11,15 +12,18 @@ impl FromMeta for RegisteredTypeNode {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
         match meta.path_str().as_str() {
             "amount" => AmountTypeNode::from_meta(meta).map(Self::from),
+            "array" => ArrayTypeNode::from_meta(meta).map(Self::from),
             "boolean" => BooleanTypeNode::from_meta(meta).map(Self::from),
             "bytes" => BytesTypeNode::from_meta(meta).map(Self::from),
             "date_time" => DateTimeTypeNode::from_meta(meta).map(Self::from),
             "field" => StructFieldTypeNode::from_meta(meta).map(Self::from),
             "fixed_size" => FixedSizeTypeNode::from_meta(meta).map(Self::from),
+            "map" => MapTypeNode::from_meta(meta).map(Self::from),
             "number" => NumberTypeNode::from_meta(meta).map(Self::from),
             "option" => OptionTypeNode::from_meta(meta).map(Self::from),
             "public_key" => PublicKeyTypeNode::from_meta(meta).map(Self::from),
             "remainder_option" => RemainderOptionTypeNode::from_meta(meta).map(Self::from),
+            "set" => SetTypeNode::from_meta(meta).map(Self::from),
             "size_prefix" => SizePrefixTypeNode::from_meta(meta).map(Self::from),
             "sol_amount" => SolAmountTypeNode::from_meta(meta).map(Self::from),
             "string" => StringTypeNode::from_meta(meta).map(Self::from),

--- a/codama-attributes/src/codama_directives/type_nodes/type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/type_node.rs
@@ -1,10 +1,11 @@
 use crate::{utils::FromMeta, TypeDirectiveNode};
 use codama_nodes::{
     AmountTypeNode, ArrayTypeNode, BooleanTypeNode, BytesTypeNode, DateTimeTypeNode,
-    FixedSizeTypeNode, MapTypeNode, NumberTypeNode, OptionTypeNode, PublicKeyTypeNode,
-    RegisteredTypeNode, RemainderOptionTypeNode, SetTypeNode, SizePrefixTypeNode,
-    SolAmountTypeNode, StringTypeNode, StructFieldTypeNode, StructTypeNode, TupleTypeNode,
-    TypeNode, ZeroableOptionTypeNode,
+    FixedSizeTypeNode, HiddenPrefixTypeNode, HiddenSuffixTypeNode, MapTypeNode, NumberTypeNode,
+    OptionTypeNode, PostOffsetTypeNode, PreOffsetTypeNode, PublicKeyTypeNode, RegisteredTypeNode,
+    RemainderOptionTypeNode, SentinelTypeNode, SetTypeNode, SizePrefixTypeNode, SolAmountTypeNode,
+    StringTypeNode, StructFieldTypeNode, StructTypeNode, TupleTypeNode, TypeNode,
+    ZeroableOptionTypeNode,
 };
 use codama_syn_helpers::{extensions::*, Meta};
 
@@ -18,11 +19,16 @@ impl FromMeta for RegisteredTypeNode {
             "date_time" => DateTimeTypeNode::from_meta(meta).map(Self::from),
             "field" => StructFieldTypeNode::from_meta(meta).map(Self::from),
             "fixed_size" => FixedSizeTypeNode::from_meta(meta).map(Self::from),
+            "hidden_prefix" => HiddenPrefixTypeNode::from_meta(meta).map(Self::from),
+            "hidden_suffix" => HiddenSuffixTypeNode::from_meta(meta).map(Self::from),
             "map" => MapTypeNode::from_meta(meta).map(Self::from),
             "number" => NumberTypeNode::from_meta(meta).map(Self::from),
             "option" => OptionTypeNode::from_meta(meta).map(Self::from),
+            "post_offset" => PostOffsetTypeNode::from_meta(meta).map(Self::from),
+            "pre_offset" => PreOffsetTypeNode::from_meta(meta).map(Self::from),
             "public_key" => PublicKeyTypeNode::from_meta(meta).map(Self::from),
             "remainder_option" => RemainderOptionTypeNode::from_meta(meta).map(Self::from),
+            "sentinel" => SentinelTypeNode::from_meta(meta).map(Self::from),
             "set" => SetTypeNode::from_meta(meta).map(Self::from),
             "size_prefix" => SizePrefixTypeNode::from_meta(meta).map(Self::from),
             "sol_amount" => SolAmountTypeNode::from_meta(meta).map(Self::from),

--- a/codama-attributes/src/codama_directives/value_nodes/constant_value_node.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/constant_value_node.rs
@@ -1,0 +1,79 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{ConstantValueNode, TypeNode, ValueNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for ConstantValueNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("constant")?.as_path_list()?;
+        let mut r#type: SetOnce<TypeNode> = SetOnce::new("type");
+        let mut value: SetOnce<ValueNode> = SetOnce::new("value");
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "type" => r#type.set(TypeNode::from_meta(meta.as_value()?)?, meta),
+            "value" => value.set(ValueNode::from_meta(meta.as_value()?)?, meta),
+            // Positional args fill `type` then `value`, since some names such as
+            // `public_key` exist as both a type node and a value node. Anything
+            // else named is a typo rather than a positional arg.
+            _ => {
+                if !meta.is_path_or_list() && meta.as_expr().is_err() {
+                    return Err(meta.error("unrecognized attribute"));
+                }
+                match r#type.is_set() {
+                    false => r#type.set(TypeNode::from_meta(meta)?, meta),
+                    true => value.set(ValueNode::from_meta(meta)?, meta),
+                }
+            }
+        })?;
+
+        Ok(ConstantValueNode::new(
+            r#type.take(meta)?,
+            value.take(meta)?,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codama_nodes::{
+        NumberFormat::U8, NumberTypeNode, NumberValueNode, StringTypeNode, StringValueNode,
+    };
+
+    fn parse(meta: Meta) -> syn::Result<ConstantValueNode> {
+        ConstantValueNode::from_meta(&meta)
+    }
+
+    #[test]
+    fn implicit() {
+        assert_eq!(
+            parse(syn::parse_quote! { constant(number(u8), 42) }).unwrap(),
+            ConstantValueNode::new(NumberTypeNode::le(U8), NumberValueNode::new(42u64))
+        );
+    }
+
+    #[test]
+    fn explicit() {
+        assert_eq!(
+            parse(syn::parse_quote! { constant(type = string, value = "hello") }).unwrap(),
+            ConstantValueNode::new(StringTypeNode::utf8(), StringValueNode::new("hello"))
+        );
+    }
+
+    #[test]
+    fn value_missing() {
+        let error = parse(syn::parse_quote! { constant(number(u8)) }).unwrap_err();
+        assert_eq!(error.to_string(), "value is missing");
+    }
+
+    #[test]
+    fn type_missing() {
+        let error = parse(syn::parse_quote! { constant(value = 42) }).unwrap_err();
+        assert_eq!(error.to_string(), "type is missing");
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        let error = parse(syn::parse_quote! { constant(foo = 42) }).unwrap_err();
+        assert_eq!(error.to_string(), "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/value_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/value_nodes/mod.rs
@@ -2,6 +2,7 @@ mod account_bump_value_node;
 mod account_value_node;
 mod argument_value_node;
 mod boolean_value_node;
+mod constant_value_node;
 mod instruction_input_value_node;
 mod number_value_node;
 mod payer_value_node;

--- a/codama-macros/tests/codama_attribute/type_nodes/amount_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/amount_type_node/_pass.rs
@@ -1,0 +1,15 @@
+use codama_macros::codama;
+
+#[codama(type = amount(number(u64)))]
+pub struct NumberOnlyTest;
+
+#[codama(type = amount(number(u64), 9, "SOL"))]
+pub struct ImplicitTest;
+
+#[codama(type = amount(number = number(u64), decimals = 9, unit = "SOL"))]
+pub struct ExplicitTest;
+
+#[codama(type = amount(number(u64), 6))]
+pub struct DecimalsOnlyTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/array_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/array_type_node/_pass.rs
@@ -1,0 +1,18 @@
+use codama_macros::codama;
+
+#[codama(type = array(number(u8), fixed_count(3)))]
+pub struct ImplicitTest;
+
+#[codama(type = array(number(u8), 3))]
+pub struct BareIntegerCountTest;
+
+#[codama(type = array(item = number(u8), count = fixed_count(3)))]
+pub struct ExplicitTest;
+
+#[codama(type = array(string, prefixed_count(number(u32))))]
+pub struct PrefixedCountTest;
+
+#[codama(type = array(number(u8), remainder_count))]
+pub struct RemainderCountTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/date_time_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/date_time_type_node/_pass.rs
@@ -1,0 +1,12 @@
+use codama_macros::codama;
+
+#[codama(type = date_time(number(u64)))]
+pub struct ImplicitTest;
+
+#[codama(type = date_time(number = number(u64)))]
+pub struct ExplicitTest;
+
+#[codama(type = date_time(fixed_size(number(u64), 8)))]
+pub struct NestedNumberTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/_pass.rs
@@ -1,0 +1,21 @@
+use codama_macros::codama;
+
+#[codama(type = enum)]
+pub struct EmptyTest;
+
+#[codama(type = enum(variant("pending"), variant("done")))]
+pub struct EmptyVariantsTest;
+
+#[codama(type = enum(variant("point", struct(field("x", number(u8))))))]
+pub struct StructVariantTest;
+
+#[codama(type = enum(variant("pair", tuple(number(u8)))))]
+pub struct TupleVariantTest;
+
+#[codama(type = enum(variant("a", discriminator = 3)))]
+pub struct DiscriminatorTest;
+
+#[codama(type = enum(variant("a"), size = number(u16)))]
+pub struct ExplicitSizeTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/hidden_prefix_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/hidden_prefix_type_node/_pass.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(type = hidden_prefix(string, constant(number(u8), 1)))]
+pub struct SingleConstantTest;
+
+#[codama(type = hidden_prefix(string, constant(number(u8), 1), constant(number(u8), 2)))]
+pub struct MultipleConstantsTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/hidden_suffix_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/hidden_suffix_type_node/_pass.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(type = hidden_suffix(string, constant(number(u8), 1)))]
+pub struct SingleConstantTest;
+
+#[codama(type = hidden_suffix(string, constant(number(u8), 1), constant(number(u8), 2)))]
+pub struct MultipleConstantsTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/map_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/map_type_node/_pass.rs
@@ -1,0 +1,15 @@
+use codama_macros::codama;
+
+#[codama(type = map(public_key, number(u8), fixed_count(3)))]
+pub struct ImplicitTest;
+
+#[codama(type = map(string, number(u8), 3))]
+pub struct BareIntegerCountTest;
+
+#[codama(type = map(key = string, value = number(u8), count = prefixed_count(number(u32))))]
+pub struct ExplicitTest;
+
+#[codama(type = map(string, number(u8), remainder_count))]
+pub struct RemainderCountTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/post_offset_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/post_offset_type_node/_pass.rs
@@ -1,0 +1,15 @@
+use codama_macros::codama;
+
+#[codama(type = post_offset(string, 4, relative))]
+pub struct ImplicitTest;
+
+#[codama(type = post_offset(type = string, offset = 4, strategy = absolute))]
+pub struct ExplicitTest;
+
+#[codama(type = post_offset(string, 0, pre_offset))]
+pub struct PreOffsetStrategyTest;
+
+#[codama(type = post_offset(pre_offset(string, 4, relative), 0, pre_offset))]
+pub struct WrappingPreOffsetTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/pre_offset_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/pre_offset_type_node/_pass.rs
@@ -1,0 +1,12 @@
+use codama_macros::codama;
+
+#[codama(type = pre_offset(string, 4, relative))]
+pub struct ImplicitTest;
+
+#[codama(type = pre_offset(type = string, offset = 4, strategy = absolute))]
+pub struct ExplicitTest;
+
+#[codama(type = pre_offset(string, -4, padded))]
+pub struct NegativeOffsetTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/remainder_option_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/remainder_option_type_node/_pass.rs
@@ -1,0 +1,12 @@
+use codama_macros::codama;
+
+#[codama(type = remainder_option(number(u8)))]
+pub struct ImplicitTest;
+
+#[codama(type = remainder_option(item = number(u8)))]
+pub struct ExplicitTest;
+
+#[codama(type = remainder_option(size_prefix(string, number(u8))))]
+pub struct NestedTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/sentinel_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/sentinel_type_node/_pass.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(type = sentinel(string, constant(number(u8), 255)))]
+pub struct ImplicitTest;
+
+#[codama(type = sentinel(type = string, sentinel = constant(number(u8), 255)))]
+pub struct ExplicitTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/set_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/set_type_node/_pass.rs
@@ -1,0 +1,12 @@
+use codama_macros::codama;
+
+#[codama(type = set(number(u8), fixed_count(3)))]
+pub struct ImplicitTest;
+
+#[codama(type = set(number(u8), 3))]
+pub struct BareIntegerCountTest;
+
+#[codama(type = set(item = number(u8), count = prefixed_count(number(u32))))]
+pub struct ExplicitTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/sol_amount_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/sol_amount_type_node/_pass.rs
@@ -1,0 +1,9 @@
+use codama_macros::codama;
+
+#[codama(type = sol_amount(number(u64)))]
+pub struct ImplicitTest;
+
+#[codama(type = sol_amount(number = number(u64)))]
+pub struct ExplicitTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/tuple_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/tuple_type_node/_pass.rs
@@ -1,0 +1,18 @@
+use codama_macros::codama;
+
+#[codama(type = tuple)]
+pub struct EmptyTest;
+
+#[codama(type = tuple())]
+pub struct EmptyListTest;
+
+#[codama(type = tuple(number(u32)))]
+pub struct SingleItemTest;
+
+#[codama(type = tuple(number(u32), string, public_key))]
+pub struct MultipleItemsTest;
+
+#[codama(type = tuple(option(number(u8)), tuple(string)))]
+pub struct NestedTest;
+
+fn main() {}


### PR DESCRIPTION
Last of four, stacked on #118, #119 and #120. Until those merge this diff also shows their commits; I'll rebase once they land so only the enum commit remains.

Adds `enum` and its variants, which completes the set: all 28 `RegisteredTypeNode` variants now have a spelling, up from 11 before this series.

```rust
#[codama(type = enum(variant("pending"), variant("done")))]
#[codama(type = enum(variant("point", struct(field("x", number(u8))))))]
#[codama(type = enum(variant("pair", tuple(number(u8)))))]
#[codama(type = enum(variant("a", discriminator = 3)))]
#[codama(type = enum(variant("a"), size = number(u16)))]
```

Two decisions I'd like a second opinion on:

- One `variant(...)` that infers its kind from the payload, rather than three directives named after the three kinds. This mirrors how `field(...)` works for struct fields. `RegisteredTypeNode` keeps the three kinds separate instead of using the `EnumVariantTypeNode` union, so `variant` unwraps before converting.
- `enum` defaults its size to u8, matching `EnumTypeNode::new`.
