### PR TITLE
feat: add array, set and map type nodes plus the count node DSL

### DIFF
--- a/codama-attributes/src/codama_directives/count_nodes/count_node.rs
+++ b/codama-attributes/src/codama_directives/count_nodes/count_node.rs
@@ -1,0 +1,90 @@
+use crate::utils::FromMeta;
+use codama_nodes::{CountNode, FixedCountNode, PrefixedCountNode, RemainderCountNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for CountNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        // A bare integer is the common case, so `3` is short for `fixed_count(3)`.
+        if let Ok(expr) = meta.as_expr() {
+            if let Ok(value) = expr.as_unsigned_integer() {
+                return Ok(FixedCountNode::new(value).into());
+            }
+        }
+
+        match meta.path_str().as_str() {
+            "fixed_count" => FixedCountNode::from_meta(meta).map(Self::from),
+            "prefixed_count" => PrefixedCountNode::from_meta(meta).map(Self::from),
+            "remainder_count" => RemainderCountNode::from_meta(meta).map(Self::from),
+            _ => Err(meta.error("unrecognized count")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codama_nodes::{NumberFormat::U32, NumberTypeNode};
+
+    fn parse(meta: Meta) -> syn::Result<CountNode> {
+        CountNode::from_meta(&meta)
+    }
+
+    #[test]
+    fn fixed() {
+        let expected: CountNode = FixedCountNode::new(3).into();
+        assert_eq!(
+            parse(syn::parse_quote! { fixed_count(3) }).unwrap(),
+            expected
+        );
+        assert_eq!(
+            parse(syn::parse_quote! { fixed_count(value = 3) }).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn bare_integer_is_a_fixed_count() {
+        assert_eq!(
+            parse(syn::parse_quote! { 3 }).unwrap(),
+            FixedCountNode::new(3).into()
+        );
+    }
+
+    #[test]
+    fn prefixed() {
+        let expected: CountNode = PrefixedCountNode::new(NumberTypeNode::le(U32)).into();
+        assert_eq!(
+            parse(syn::parse_quote! { prefixed_count(number(u32)) }).unwrap(),
+            expected
+        );
+        assert_eq!(
+            parse(syn::parse_quote! { prefixed_count(prefix = number(u32)) }).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn remainder() {
+        let expected: CountNode = RemainderCountNode::new().into();
+        assert_eq!(
+            parse(syn::parse_quote! { remainder_count }).unwrap(),
+            expected
+        );
+        assert_eq!(
+            parse(syn::parse_quote! { remainder_count() }).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn invalid_prefix() {
+        let error = parse(syn::parse_quote! { prefixed_count(string) }).unwrap_err();
+        assert_eq!(error.to_string(), "prefix must be a NumberTypeNode");
+    }
+
+    #[test]
+    fn unrecognized_count() {
+        let error = parse(syn::parse_quote! { unrecognized }).unwrap_err();
+        assert_eq!(error.to_string(), "unrecognized count");
+    }
+}

--- a/codama-attributes/src/codama_directives/count_nodes/fixed_count_node.rs
+++ b/codama-attributes/src/codama_directives/count_nodes/fixed_count_node.rs
@@ -1,0 +1,22 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::FixedCountNode;
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for FixedCountNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("fixed_count")?.as_path_list()?;
+        let mut value: SetOnce<u64> = SetOnce::new("value");
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "value" => value.set(meta.as_value()?.as_expr()?.as_unsigned_integer()?, meta),
+            _ => {
+                if let Ok(expr) = meta.as_expr() {
+                    return value.set(expr.as_unsigned_integer()?, meta);
+                }
+                Err(meta.error("unrecognized attribute"))
+            }
+        })?;
+
+        Ok(FixedCountNode::new(value.take(meta)?))
+    }
+}

--- a/codama-attributes/src/codama_directives/count_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/count_nodes/mod.rs
@@ -1,0 +1,4 @@
+mod count_node;
+mod fixed_count_node;
+mod prefixed_count_node;
+mod remainder_count_node;

--- a/codama-attributes/src/codama_directives/count_nodes/prefixed_count_node.rs
+++ b/codama-attributes/src/codama_directives/count_nodes/prefixed_count_node.rs
@@ -1,0 +1,28 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{NestedTypeNode, NumberTypeNode, PrefixedCountNode, TypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for PrefixedCountNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("prefixed_count")?.as_path_list()?;
+        let mut prefix: SetOnce<NestedTypeNode<NumberTypeNode>> = SetOnce::new("prefix");
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "prefix" => prefix.set(parse_prefix(meta.as_value()?)?, meta),
+            _ => {
+                if meta.is_path_or_list() {
+                    return prefix.set(parse_prefix(meta)?, meta);
+                }
+                Err(meta.error("unrecognized attribute"))
+            }
+        })?;
+
+        Ok(PrefixedCountNode::new(prefix.take(meta)?))
+    }
+}
+
+fn parse_prefix(meta: &Meta) -> syn::Result<NestedTypeNode<NumberTypeNode>> {
+    let node = TypeNode::from_meta(meta)?;
+    NestedTypeNode::<NumberTypeNode>::try_from(node)
+        .map_err(|_| meta.error("prefix must be a NumberTypeNode"))
+}

--- a/codama-attributes/src/codama_directives/count_nodes/remainder_count_node.rs
+++ b/codama-attributes/src/codama_directives/count_nodes/remainder_count_node.rs
@@ -1,0 +1,13 @@
+use crate::utils::FromMeta;
+use codama_nodes::RemainderCountNode;
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for RemainderCountNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        meta.assert_directive("remainder_count")?;
+        if meta.is_path_or_empty_list() {
+            return Ok(RemainderCountNode::new());
+        }
+        Err(meta.error("remainder_count does not take any argument"))
+    }
+}

--- a/codama-attributes/src/codama_directives/mod.rs
+++ b/codama-attributes/src/codama_directives/mod.rs
@@ -1,3 +1,4 @@
+mod count_nodes;
 mod link_nodes;
 mod type_nodes;
 mod value_nodes;

--- a/codama-attributes/src/codama_directives/type_nodes/array_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/array_type_node.rs
@@ -1,0 +1,102 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{ArrayTypeNode, CountNode, TypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for ArrayTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("array")?.as_path_list()?;
+        let mut item: SetOnce<TypeNode> = SetOnce::new("item");
+        let mut count: SetOnce<CountNode> = SetOnce::new("count");
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "item" => item.set(TypeNode::from_meta(meta.as_value()?)?, meta),
+            "count" => count.set(CountNode::from_meta(meta.as_value()?)?, meta),
+            // The count nodes have their own directives, so they are recognised
+            // by name before falling through to the item.
+            "fixed_count" | "prefixed_count" | "remainder_count" => {
+                count.set(CountNode::from_meta(meta)?, meta)
+            }
+            _ => {
+                if meta.is_path_or_list() {
+                    return item.set(TypeNode::from_meta(meta)?, meta);
+                }
+                if meta.as_expr().is_ok() {
+                    return count.set(CountNode::from_meta(meta)?, meta);
+                }
+                Err(meta.error("unrecognized attribute"))
+            }
+        })?;
+
+        Ok(ArrayTypeNode::new(item.take(meta)?, count.take(meta)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{
+        FixedCountNode,
+        NumberFormat::{U32, U8},
+        NumberTypeNode, PrefixedCountNode, RemainderCountNode, StringTypeNode,
+    };
+
+    #[test]
+    fn implicit() {
+        assert_type!(
+            { array(number(u8), fixed_count(3)) },
+            ArrayTypeNode::new(NumberTypeNode::le(U8), FixedCountNode::new(3)).into()
+        );
+    }
+
+    #[test]
+    fn bare_integer_count() {
+        assert_type!(
+            { array(number(u8), 3) },
+            ArrayTypeNode::new(NumberTypeNode::le(U8), FixedCountNode::new(3)).into()
+        );
+    }
+
+    #[test]
+    fn explicit() {
+        assert_type!(
+            { array(item = number(u8), count = fixed_count(3)) },
+            ArrayTypeNode::new(NumberTypeNode::le(U8), FixedCountNode::new(3)).into()
+        );
+    }
+
+    #[test]
+    fn prefixed_count() {
+        assert_type!(
+            { array(string, prefixed_count(number(u32))) },
+            ArrayTypeNode::new(
+                StringTypeNode::utf8(),
+                PrefixedCountNode::new(NumberTypeNode::le(U32))
+            )
+            .into()
+        );
+    }
+
+    #[test]
+    fn remainder_count() {
+        assert_type!(
+            { array(number(u8), remainder_count) },
+            ArrayTypeNode::new(NumberTypeNode::le(U8), RemainderCountNode::new()).into()
+        );
+    }
+
+    #[test]
+    fn item_missing() {
+        assert_type_err!({ array(fixed_count(3)) }, "item is missing");
+    }
+
+    #[test]
+    fn count_missing() {
+        assert_type_err!({ array(number(u8)) }, "count is missing");
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ array(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/map_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/map_type_node.rs
@@ -1,0 +1,126 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{CountNode, MapTypeNode, TypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for MapTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("map")?.as_path_list()?;
+        let mut key: SetOnce<TypeNode> = SetOnce::new("key");
+        let mut value: SetOnce<TypeNode> = SetOnce::new("value");
+        let mut count: SetOnce<CountNode> = SetOnce::new("count");
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "key" => key.set(TypeNode::from_meta(meta.as_value()?)?, meta),
+            "value" => value.set(TypeNode::from_meta(meta.as_value()?)?, meta),
+            "count" => count.set(CountNode::from_meta(meta.as_value()?)?, meta),
+            "fixed_count" | "prefixed_count" | "remainder_count" => {
+                count.set(CountNode::from_meta(meta)?, meta)
+            }
+            _ => {
+                // Key and value are both type nodes, so positional args fill
+                // `key` then `value` and are never swapped.
+                if meta.is_path_or_list() {
+                    return match key.is_set() {
+                        false => key.set(TypeNode::from_meta(meta)?, meta),
+                        true => value.set(TypeNode::from_meta(meta)?, meta),
+                    };
+                }
+                if meta.as_expr().is_ok() {
+                    return count.set(CountNode::from_meta(meta)?, meta);
+                }
+                Err(meta.error("unrecognized attribute"))
+            }
+        })?;
+
+        Ok(MapTypeNode::new(
+            key.take(meta)?,
+            value.take(meta)?,
+            count.take(meta)?,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{
+        FixedCountNode,
+        NumberFormat::{U32, U8},
+        NumberTypeNode, PrefixedCountNode, PublicKeyTypeNode, StringTypeNode,
+    };
+
+    #[test]
+    fn implicit() {
+        assert_type!(
+            { map(public_key, number(u8), fixed_count(3)) },
+            MapTypeNode::new(
+                PublicKeyTypeNode::new(),
+                NumberTypeNode::le(U8),
+                FixedCountNode::new(3)
+            )
+            .into()
+        );
+    }
+
+    #[test]
+    fn bare_integer_count() {
+        assert_type!(
+            { map(string, number(u8), 3) },
+            MapTypeNode::new(
+                StringTypeNode::utf8(),
+                NumberTypeNode::le(U8),
+                FixedCountNode::new(3)
+            )
+            .into()
+        );
+    }
+
+    #[test]
+    fn explicit() {
+        assert_type!(
+            {
+                map(
+                    key = string,
+                    value = number(u8),
+                    count = prefixed_count(number(u32)),
+                )
+            },
+            MapTypeNode::new(
+                StringTypeNode::utf8(),
+                NumberTypeNode::le(U8),
+                PrefixedCountNode::new(NumberTypeNode::le(U32))
+            )
+            .into()
+        );
+    }
+
+    #[test]
+    fn positional_order() {
+        // Positional args fill `key` then `value` and are never swapped.
+        assert_type!(
+            { map(string, public_key, 1) },
+            MapTypeNode::new(
+                StringTypeNode::utf8(),
+                PublicKeyTypeNode::new(),
+                FixedCountNode::new(1)
+            )
+            .into()
+        );
+    }
+
+    #[test]
+    fn value_missing() {
+        assert_type_err!({ map(string, fixed_count(3)) }, "value is missing");
+    }
+
+    #[test]
+    fn count_missing() {
+        assert_type_err!({ map(string, number(u8)) }, "count is missing");
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ map(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/mod.rs
@@ -1,9 +1,12 @@
+mod array_type_node;
 mod boolean_type_node;
 mod bytes_type_node;
 mod fixed_size_type_node;
+mod map_type_node;
 mod number_type_node;
 mod option_type_node;
 mod public_key_type_node;
+mod set_type_node;
 mod size_prefix_type_node;
 mod string_type_node;
 mod struct_field_meta_consumer;

--- a/codama-attributes/src/codama_directives/type_nodes/set_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/set_type_node.rs
@@ -1,0 +1,79 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{CountNode, SetTypeNode, TypeNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for SetTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("set")?.as_path_list()?;
+        let mut item: SetOnce<TypeNode> = SetOnce::new("item");
+        let mut count: SetOnce<CountNode> = SetOnce::new("count");
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "item" => item.set(TypeNode::from_meta(meta.as_value()?)?, meta),
+            "count" => count.set(CountNode::from_meta(meta.as_value()?)?, meta),
+            "fixed_count" | "prefixed_count" | "remainder_count" => {
+                count.set(CountNode::from_meta(meta)?, meta)
+            }
+            _ => {
+                if meta.is_path_or_list() {
+                    return item.set(TypeNode::from_meta(meta)?, meta);
+                }
+                if meta.as_expr().is_ok() {
+                    return count.set(CountNode::from_meta(meta)?, meta);
+                }
+                Err(meta.error("unrecognized attribute"))
+            }
+        })?;
+
+        Ok(SetTypeNode::new(item.take(meta)?, count.take(meta)?))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{
+        FixedCountNode,
+        NumberFormat::{U32, U8},
+        NumberTypeNode, PrefixedCountNode,
+    };
+
+    #[test]
+    fn implicit() {
+        assert_type!(
+            { set(number(u8), fixed_count(3)) },
+            SetTypeNode::new(NumberTypeNode::le(U8), FixedCountNode::new(3)).into()
+        );
+    }
+
+    #[test]
+    fn bare_integer_count() {
+        assert_type!(
+            { set(number(u8), 3) },
+            SetTypeNode::new(NumberTypeNode::le(U8), FixedCountNode::new(3)).into()
+        );
+    }
+
+    #[test]
+    fn explicit() {
+        assert_type!(
+            { set(item = number(u8), count = prefixed_count(number(u32))) },
+            SetTypeNode::new(
+                NumberTypeNode::le(U8),
+                PrefixedCountNode::new(NumberTypeNode::le(U32))
+            )
+            .into()
+        );
+    }
+
+    #[test]
+    fn count_missing() {
+        assert_type_err!({ set(number(u8)) }, "count is missing");
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ set(foo = 42) }, "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/type_node.rs
@@ -1,21 +1,24 @@
 use crate::{utils::FromMeta, TypeDirectiveNode};
 use codama_nodes::{
-    BooleanTypeNode, BytesTypeNode, FixedSizeTypeNode, NumberTypeNode, OptionTypeNode,
-    PublicKeyTypeNode, RegisteredTypeNode, SizePrefixTypeNode, StringTypeNode, StructFieldTypeNode,
-    StructTypeNode, TypeNode, ZeroableOptionTypeNode,
+    ArrayTypeNode, BooleanTypeNode, BytesTypeNode, FixedSizeTypeNode, MapTypeNode, NumberTypeNode,
+    OptionTypeNode, PublicKeyTypeNode, RegisteredTypeNode, SetTypeNode, SizePrefixTypeNode,
+    StringTypeNode, StructFieldTypeNode, StructTypeNode, TypeNode, ZeroableOptionTypeNode,
 };
 use codama_syn_helpers::{extensions::*, Meta};
 
 impl FromMeta for RegisteredTypeNode {
     fn from_meta(meta: &Meta) -> syn::Result<Self> {
         match meta.path_str().as_str() {
+            "array" => ArrayTypeNode::from_meta(meta).map(Self::from),
             "boolean" => BooleanTypeNode::from_meta(meta).map(Self::from),
             "bytes" => BytesTypeNode::from_meta(meta).map(Self::from),
             "field" => StructFieldTypeNode::from_meta(meta).map(Self::from),
             "fixed_size" => FixedSizeTypeNode::from_meta(meta).map(Self::from),
+            "map" => MapTypeNode::from_meta(meta).map(Self::from),
             "number" => NumberTypeNode::from_meta(meta).map(Self::from),
             "option" => OptionTypeNode::from_meta(meta).map(Self::from),
             "public_key" => PublicKeyTypeNode::from_meta(meta).map(Self::from),
+            "set" => SetTypeNode::from_meta(meta).map(Self::from),
             "size_prefix" => SizePrefixTypeNode::from_meta(meta).map(Self::from),
             "string" => StringTypeNode::from_meta(meta).map(Self::from),
             "struct" => StructTypeNode::from_meta(meta).map(Self::from),

--- a/codama-macros/tests/codama_attribute/type_nodes/array_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/array_type_node/_pass.rs
@@ -1,0 +1,18 @@
+use codama_macros::codama;
+
+#[codama(type = array(number(u8), fixed_count(3)))]
+pub struct ImplicitTest;
+
+#[codama(type = array(number(u8), 3))]
+pub struct BareIntegerCountTest;
+
+#[codama(type = array(item = number(u8), count = fixed_count(3)))]
+pub struct ExplicitTest;
+
+#[codama(type = array(string, prefixed_count(number(u32))))]
+pub struct PrefixedCountTest;
+
+#[codama(type = array(number(u8), remainder_count))]
+pub struct RemainderCountTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/array_type_node/count_missing.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/array_type_node/count_missing.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = array(number(u8)))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/array_type_node/count_missing.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/array_type_node/count_missing.fail.stderr
@@ -1,0 +1,5 @@
+error: count is missing
+ --> tests/codama_attribute/type_nodes/array_type_node/count_missing.fail.rs:3:17
+  |
+3 | #[codama(type = array(number(u8)))]
+  |                 ^^^^^^^^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/array_type_node/invalid_prefix.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/array_type_node/invalid_prefix.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = array(number(u8), prefixed_count(string)))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/array_type_node/invalid_prefix.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/array_type_node/invalid_prefix.fail.stderr
@@ -1,0 +1,5 @@
+error: prefix must be a NumberTypeNode
+ --> tests/codama_attribute/type_nodes/array_type_node/invalid_prefix.fail.rs:3:50
+  |
+3 | #[codama(type = array(number(u8), prefixed_count(string)))]
+  |                                                  ^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/array_type_node/item_missing.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/array_type_node/item_missing.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = array(count = 3))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/array_type_node/item_missing.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/array_type_node/item_missing.fail.stderr
@@ -1,0 +1,5 @@
+error: item is missing
+ --> tests/codama_attribute/type_nodes/array_type_node/item_missing.fail.rs:3:17
+  |
+3 | #[codama(type = array(count = 3))]
+  |                 ^^^^^^^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/array_type_node/unrecognized_attribute.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/array_type_node/unrecognized_attribute.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = array(foo = 42))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/array_type_node/unrecognized_attribute.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/array_type_node/unrecognized_attribute.fail.stderr
@@ -1,0 +1,5 @@
+error: unrecognized attribute
+ --> tests/codama_attribute/type_nodes/array_type_node/unrecognized_attribute.fail.rs:3:23
+  |
+3 | #[codama(type = array(foo = 42))]
+  |                       ^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/array_type_node/unrecognized_count.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/array_type_node/unrecognized_count.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = array(number(u8), count = nonsense))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/array_type_node/unrecognized_count.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/array_type_node/unrecognized_count.fail.stderr
@@ -1,0 +1,5 @@
+error: unrecognized count
+ --> tests/codama_attribute/type_nodes/array_type_node/unrecognized_count.fail.rs:3:43
+  |
+3 | #[codama(type = array(number(u8), count = nonsense))]
+  |                                           ^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/map_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/map_type_node/_pass.rs
@@ -1,0 +1,15 @@
+use codama_macros::codama;
+
+#[codama(type = map(public_key, number(u8), fixed_count(3)))]
+pub struct ImplicitTest;
+
+#[codama(type = map(string, number(u8), 3))]
+pub struct BareIntegerCountTest;
+
+#[codama(type = map(key = string, value = number(u8), count = prefixed_count(number(u32))))]
+pub struct ExplicitTest;
+
+#[codama(type = map(string, number(u8), remainder_count))]
+pub struct RemainderCountTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/map_type_node/count_missing.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/map_type_node/count_missing.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = map(string, number(u8)))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/map_type_node/count_missing.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/map_type_node/count_missing.fail.stderr
@@ -1,0 +1,5 @@
+error: count is missing
+ --> tests/codama_attribute/type_nodes/map_type_node/count_missing.fail.rs:3:17
+  |
+3 | #[codama(type = map(string, number(u8)))]
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/map_type_node/unrecognized_attribute.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/map_type_node/unrecognized_attribute.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = map(foo = 42))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/map_type_node/unrecognized_attribute.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/map_type_node/unrecognized_attribute.fail.stderr
@@ -1,0 +1,5 @@
+error: unrecognized attribute
+ --> tests/codama_attribute/type_nodes/map_type_node/unrecognized_attribute.fail.rs:3:21
+  |
+3 | #[codama(type = map(foo = 42))]
+  |                     ^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/map_type_node/value_missing.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/map_type_node/value_missing.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = map(string, count = 3))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/map_type_node/value_missing.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/map_type_node/value_missing.fail.stderr
@@ -1,0 +1,5 @@
+error: value is missing
+ --> tests/codama_attribute/type_nodes/map_type_node/value_missing.fail.rs:3:17
+  |
+3 | #[codama(type = map(string, count = 3))]
+  |                 ^^^^^^^^^^^^^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/set_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/set_type_node/_pass.rs
@@ -1,0 +1,12 @@
+use codama_macros::codama;
+
+#[codama(type = set(number(u8), fixed_count(3)))]
+pub struct ImplicitTest;
+
+#[codama(type = set(number(u8), 3))]
+pub struct BareIntegerCountTest;
+
+#[codama(type = set(item = number(u8), count = prefixed_count(number(u32))))]
+pub struct ExplicitTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/set_type_node/count_missing.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/set_type_node/count_missing.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = set(number(u8)))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/set_type_node/count_missing.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/set_type_node/count_missing.fail.stderr
@@ -1,0 +1,5 @@
+error: count is missing
+ --> tests/codama_attribute/type_nodes/set_type_node/count_missing.fail.rs:3:17
+  |
+3 | #[codama(type = set(number(u8)))]
+  |                 ^^^^^^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/set_type_node/item_missing.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/set_type_node/item_missing.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = set(count = 3))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/set_type_node/item_missing.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/set_type_node/item_missing.fail.stderr
@@ -1,0 +1,5 @@
+error: item is missing
+ --> tests/codama_attribute/type_nodes/set_type_node/item_missing.fail.rs:3:17
+  |
+3 | #[codama(type = set(count = 3))]
+  |                 ^^^^^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/set_type_node/unrecognized_attribute.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/set_type_node/unrecognized_attribute.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = set(foo = 42))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/set_type_node/unrecognized_attribute.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/set_type_node/unrecognized_attribute.fail.stderr
@@ -1,0 +1,5 @@
+error: unrecognized attribute
+ --> tests/codama_attribute/type_nodes/set_type_node/unrecognized_attribute.fail.rs:3:21
+  |
+3 | #[codama(type = set(foo = 42))]
+  |                     ^^^^^^^^


### PR DESCRIPTION
Part of splitting the remaining type nodes into separate PRs, as you asked on #117. This one is independent of the others in content, so the order is up to you. Every PR in this series registers its nodes in `type_nodes/mod.rs` and `type_node.rs`, so whichever merges after the first will show a conflict in those two sorted lists. Ping me and I will rebase right away.

Adds `array`, `set` and `map`, plus the count node DSL they need.

```rust
#[codama(type = array(number(u8), fixed_count(3)))]
#[codama(type = array(string, prefixed_count(number(u32))))]
#[codama(type = array(number(u8), remainder_count))]
#[codama(type = set(item = number(u8), count = prefixed_count(number(u32))))]
#[codama(type = map(key = string, value = number(u8), count = prefixed_count(number(u32))))]
```

The count nodes are new: `fixed_count`, `prefixed_count` and `remainder_count`. A bare integer is shorthand for a fixed count, so `array(number(u8), 3)` and `array(number(u8), fixed_count(3))` mean the same thing.

For positional args in `map`, `key` fills before `value`, since both are type nodes and there is no way to tell them apart by shape.

`prefixed_count` needs to check that its prefix resolves to a number, so it has a file-local `parse_prefix`, matching the one already in `size_prefix_type_node.rs`. Nothing shared with the other PRs in this series, so they can land in any order.
