### PR TITLE
feat: add enum and enum variant type nodes to the DSL

### DIFF
--- a/codama-attributes/src/codama_directives/type_nodes/enum_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/enum_type_node.rs
@@ -1,7 +1,5 @@
 use crate::utils::{FromMeta, SetOnce};
-use codama_nodes::{
-    EnumTypeNode, EnumVariantTypeNode, NestedTypeNode, NumberTypeNode, TypeNode, U8,
-};
+use codama_nodes::{EnumTypeNode, EnumVariantTypeNode, NestedTypeNode, NumberTypeNode, TypeNode};
 use codama_syn_helpers::{extensions::*, Meta};
 
 impl FromMeta for EnumTypeNode {
@@ -30,12 +28,11 @@ impl FromMeta for EnumTypeNode {
                 })?;
         }
 
-        Ok(EnumTypeNode {
-            variants,
-            size: size
-                .option()
-                .unwrap_or(NestedTypeNode::Value(NumberTypeNode::le(U8))),
-        })
+        let mut node = EnumTypeNode::new(variants);
+        if let Some(size) = size.option() {
+            node.size = size;
+        }
+        Ok(node)
     }
 }
 
@@ -44,7 +41,9 @@ mod tests {
     use super::*;
     use crate::{assert_type, assert_type_err};
     use codama_nodes::{
-        EnumEmptyVariantTypeNode, EnumTupleVariantTypeNode, NumberFormat::U16, TupleTypeNode,
+        EnumEmptyVariantTypeNode, EnumTupleVariantTypeNode,
+        NumberFormat::{U16, U8},
+        TupleTypeNode,
     };
 
     #[test]

--- a/codama-attributes/src/codama_directives/type_nodes/enum_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/enum_type_node.rs
@@ -1,0 +1,117 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{
+    EnumTypeNode, EnumVariantTypeNode, NestedTypeNode, NumberTypeNode, TypeNode, U8,
+};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for EnumTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        meta.assert_directive("enum")?;
+        let mut variants: Vec<EnumVariantTypeNode> = Vec::new();
+        let mut size: SetOnce<NestedTypeNode<NumberTypeNode>> = SetOnce::new("size");
+
+        if !meta.is_path_or_empty_list() {
+            meta.as_path_list()?
+                .each(|ref meta| match meta.path_str().as_str() {
+                    "size" => {
+                        let value = meta.as_value()?;
+                        let node = TypeNode::from_meta(value)?;
+                        let size_node = match NestedTypeNode::<NumberTypeNode>::try_from(node) {
+                            Ok(node) => node,
+                            Err(_) => return Err(value.error("size must be a NumberTypeNode")),
+                        };
+                        size.set(size_node, meta)
+                    }
+                    "variant" => {
+                        variants.push(EnumVariantTypeNode::from_meta(meta)?);
+                        Ok(())
+                    }
+                    _ => Err(meta.error("expected variant(...) or size = ...")),
+                })?;
+        }
+
+        Ok(EnumTypeNode {
+            variants,
+            size: size
+                .option()
+                .unwrap_or(NestedTypeNode::Value(NumberTypeNode::le(U8))),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{assert_type, assert_type_err};
+    use codama_nodes::{
+        EnumEmptyVariantTypeNode, EnumTupleVariantTypeNode, NumberFormat::U16, TupleTypeNode,
+    };
+
+    #[test]
+    fn empty() {
+        assert_type!({ enum }, EnumTypeNode::new(vec![]).into());
+        assert_type!({ enum() }, EnumTypeNode::new(vec![]).into());
+    }
+
+    #[test]
+    fn empty_variants() {
+        assert_type!(
+            { enum(variant("pending"), variant("done")) },
+            EnumTypeNode::new(vec![
+                EnumEmptyVariantTypeNode::new("pending").into(),
+                EnumEmptyVariantTypeNode::new("done").into(),
+            ])
+            .into()
+        );
+    }
+
+    #[test]
+    fn tuple_variant() {
+        assert_type!(
+            { enum(variant("pair", tuple(number(u8)))) },
+            EnumTypeNode::new(vec![EnumTupleVariantTypeNode::new(
+                "pair",
+                TupleTypeNode::new(vec![NumberTypeNode::le(U8).into()])
+            )
+            .into()])
+            .into()
+        );
+    }
+
+    #[test]
+    fn size_defaults_to_u8() {
+        assert_type!(
+            { enum(variant("a")) },
+            EnumTypeNode {
+                variants: vec![EnumEmptyVariantTypeNode::new("a").into()],
+                size: NestedTypeNode::Value(NumberTypeNode::le(U8)),
+            }
+            .into()
+        );
+    }
+
+    #[test]
+    fn explicit_size() {
+        assert_type!(
+            { enum(variant("a"), size = number(u16)) },
+            EnumTypeNode {
+                variants: vec![EnumEmptyVariantTypeNode::new("a").into()],
+                size: NestedTypeNode::Value(NumberTypeNode::le(U16)),
+            }
+            .into()
+        );
+    }
+
+    #[test]
+    fn invalid_size() {
+        assert_type_err!(
+            { enum(size = string) },
+            "size must be a NumberTypeNode"
+        );
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        assert_type_err!({ enum(foo = 42) }, "expected variant(...) or size = ...");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/enum_variant_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/enum_variant_type_node.rs
@@ -1,0 +1,147 @@
+use crate::utils::{FromMeta, SetOnce};
+use codama_nodes::{
+    CamelCaseString, EnumEmptyVariantTypeNode, EnumStructVariantTypeNode, EnumTupleVariantTypeNode,
+    EnumVariantTypeNode, NestedTypeNode, TypeNode,
+};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for EnumVariantTypeNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        let pl = meta.assert_directive("variant")?.as_path_list()?;
+        let mut name: SetOnce<CamelCaseString> = SetOnce::new("name");
+        let mut discriminator: SetOnce<u32> = SetOnce::new("discriminator");
+        let mut payload: SetOnce<TypeNode> = SetOnce::new("payload");
+
+        pl.each(|ref meta| match meta.path_str().as_str() {
+            "name" => name.set(meta.as_value()?.as_expr()?.as_string()?.into(), meta),
+            "discriminator" => {
+                discriminator.set(meta.as_value()?.as_expr()?.as_unsigned_integer()?, meta)
+            }
+            _ => {
+                // The payload decides the variant kind: `struct(...)` or
+                // `tuple(...)`, and no payload at all means an empty variant.
+                if meta.is_path_or_list() {
+                    return payload.set(TypeNode::from_meta(meta)?, meta);
+                }
+                if let Ok(value) = meta.as_expr().and_then(|expr| expr.as_string()) {
+                    return name.set(value.into(), meta);
+                }
+                Err(meta.error("unrecognized attribute"))
+            }
+        })?;
+
+        let name = name.take(meta)?;
+        let discriminator = discriminator.option();
+
+        match payload.option() {
+            None => Ok(EnumEmptyVariantTypeNode {
+                name,
+                discriminator,
+                display: None,
+            }
+            .into()),
+            Some(TypeNode::Struct(node)) => Ok(EnumStructVariantTypeNode {
+                name,
+                discriminator,
+                r#struct: NestedTypeNode::Value(node),
+                display: None,
+            }
+            .into()),
+            Some(TypeNode::Tuple(node)) => Ok(EnumTupleVariantTypeNode {
+                name,
+                discriminator,
+                tuple: NestedTypeNode::Value(node),
+                display: None,
+            }
+            .into()),
+            Some(_) => Err(meta.error("a variant payload must be a struct or a tuple")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codama_nodes::{
+        NumberFormat::U8, NumberTypeNode, StructFieldTypeNode, StructTypeNode, TupleTypeNode,
+    };
+
+    fn parse(meta: Meta) -> syn::Result<EnumVariantTypeNode> {
+        EnumVariantTypeNode::from_meta(&meta)
+    }
+
+    #[test]
+    fn empty_variant() {
+        assert_eq!(
+            parse(syn::parse_quote! { variant("pending") }).unwrap(),
+            EnumEmptyVariantTypeNode::new("pending").into()
+        );
+    }
+
+    #[test]
+    fn struct_variant() {
+        assert_eq!(
+            parse(syn::parse_quote! { variant("point", struct(field("x", number(u8)))) }).unwrap(),
+            EnumStructVariantTypeNode::new(
+                "point",
+                StructTypeNode::new(vec![StructFieldTypeNode::new("x", NumberTypeNode::le(U8))])
+            )
+            .into()
+        );
+    }
+
+    #[test]
+    fn tuple_variant() {
+        assert_eq!(
+            parse(syn::parse_quote! { variant("pair", tuple(number(u8))) }).unwrap(),
+            EnumTupleVariantTypeNode::new(
+                "pair",
+                TupleTypeNode::new(vec![NumberTypeNode::le(U8).into()])
+            )
+            .into()
+        );
+    }
+
+    #[test]
+    fn explicit_name() {
+        assert_eq!(
+            parse(syn::parse_quote! { variant(name = "pending") }).unwrap(),
+            EnumEmptyVariantTypeNode::new("pending").into()
+        );
+    }
+
+    #[test]
+    fn discriminator() {
+        let node = parse(syn::parse_quote! { variant("pending", discriminator = 3) }).unwrap();
+        assert_eq!(
+            node,
+            EnumEmptyVariantTypeNode {
+                name: "pending".into(),
+                discriminator: Some(3),
+                display: None,
+            }
+            .into()
+        );
+    }
+
+    #[test]
+    fn name_missing() {
+        let error = parse(syn::parse_quote! { variant() }).unwrap_err();
+        assert_eq!(error.to_string(), "name is missing");
+    }
+
+    #[test]
+    fn invalid_payload() {
+        let error = parse(syn::parse_quote! { variant("a", number(u8)) }).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "a variant payload must be a struct or a tuple"
+        );
+    }
+
+    #[test]
+    fn unrecognized_attribute() {
+        let error = parse(syn::parse_quote! { variant("a", foo = 42) }).unwrap_err();
+        assert_eq!(error.to_string(), "unrecognized attribute");
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/mod.rs
@@ -3,6 +3,8 @@ mod array_type_node;
 mod boolean_type_node;
 mod bytes_type_node;
 mod date_time_type_node;
+mod enum_type_node;
+mod enum_variant_type_node;
 mod fixed_size_type_node;
 mod hidden_prefix_type_node;
 mod hidden_suffix_type_node;

--- a/codama-attributes/src/codama_directives/type_nodes/type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/type_node.rs
@@ -1,11 +1,11 @@
 use crate::{utils::FromMeta, TypeDirectiveNode};
 use codama_nodes::{
-    AmountTypeNode, ArrayTypeNode, BooleanTypeNode, BytesTypeNode, DateTimeTypeNode,
-    FixedSizeTypeNode, HiddenPrefixTypeNode, HiddenSuffixTypeNode, MapTypeNode, NumberTypeNode,
-    OptionTypeNode, PostOffsetTypeNode, PreOffsetTypeNode, PublicKeyTypeNode, RegisteredTypeNode,
-    RemainderOptionTypeNode, SentinelTypeNode, SetTypeNode, SizePrefixTypeNode, SolAmountTypeNode,
-    StringTypeNode, StructFieldTypeNode, StructTypeNode, TupleTypeNode, TypeNode,
-    ZeroableOptionTypeNode,
+    AmountTypeNode, ArrayTypeNode, BooleanTypeNode, BytesTypeNode, DateTimeTypeNode, EnumTypeNode,
+    EnumVariantTypeNode, FixedSizeTypeNode, HiddenPrefixTypeNode, HiddenSuffixTypeNode,
+    MapTypeNode, NumberTypeNode, OptionTypeNode, PostOffsetTypeNode, PreOffsetTypeNode,
+    PublicKeyTypeNode, RegisteredTypeNode, RemainderOptionTypeNode, SentinelTypeNode, SetTypeNode,
+    SizePrefixTypeNode, SolAmountTypeNode, StringTypeNode, StructFieldTypeNode, StructTypeNode,
+    TupleTypeNode, TypeNode, ZeroableOptionTypeNode,
 };
 use codama_syn_helpers::{extensions::*, Meta};
 
@@ -17,6 +17,7 @@ impl FromMeta for RegisteredTypeNode {
             "boolean" => BooleanTypeNode::from_meta(meta).map(Self::from),
             "bytes" => BytesTypeNode::from_meta(meta).map(Self::from),
             "date_time" => DateTimeTypeNode::from_meta(meta).map(Self::from),
+            "enum" => EnumTypeNode::from_meta(meta).map(Self::from),
             "field" => StructFieldTypeNode::from_meta(meta).map(Self::from),
             "fixed_size" => FixedSizeTypeNode::from_meta(meta).map(Self::from),
             "hidden_prefix" => HiddenPrefixTypeNode::from_meta(meta).map(Self::from),
@@ -35,6 +36,13 @@ impl FromMeta for RegisteredTypeNode {
             "string" => StringTypeNode::from_meta(meta).map(Self::from),
             "struct" => StructTypeNode::from_meta(meta).map(Self::from),
             "tuple" => TupleTypeNode::from_meta(meta).map(Self::from),
+            // `RegisteredTypeNode` holds the three variant kinds separately
+            // rather than the `EnumVariantTypeNode` union, so unwrap it here.
+            "variant" => EnumVariantTypeNode::from_meta(meta).map(|node| match node {
+                EnumVariantTypeNode::Empty(node) => Self::from(node),
+                EnumVariantTypeNode::Struct(node) => Self::from(node),
+                EnumVariantTypeNode::Tuple(node) => Self::from(node),
+            }),
             "zeroable_option" => ZeroableOptionTypeNode::from_meta(meta).map(Self::from),
             _ => Err(meta.error("unrecognized type")),
         }

--- a/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/_pass.rs
@@ -1,0 +1,21 @@
+use codama_macros::codama;
+
+#[codama(type = enum)]
+pub struct EmptyTest;
+
+#[codama(type = enum(variant("pending"), variant("done")))]
+pub struct EmptyVariantsTest;
+
+#[codama(type = enum(variant("point", struct(field("x", number(u8))))))]
+pub struct StructVariantTest;
+
+#[codama(type = enum(variant("pair", tuple(number(u8)))))]
+pub struct TupleVariantTest;
+
+#[codama(type = enum(variant("a", discriminator = 3)))]
+pub struct DiscriminatorTest;
+
+#[codama(type = enum(variant("a"), size = number(u16)))]
+pub struct ExplicitSizeTest;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/invalid_size.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/invalid_size.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = enum(size = string))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/invalid_size.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/invalid_size.fail.stderr
@@ -1,0 +1,5 @@
+error: size must be a NumberTypeNode
+ --> tests/codama_attribute/type_nodes/enum_type_node/invalid_size.fail.rs:3:29
+  |
+3 | #[codama(type = enum(size = string))]
+  |                             ^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/invalid_variant_payload.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/invalid_variant_payload.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = enum(variant("a", number(u8))))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/invalid_variant_payload.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/invalid_variant_payload.fail.stderr
@@ -1,0 +1,5 @@
+error: a variant payload must be a struct or a tuple
+ --> tests/codama_attribute/type_nodes/enum_type_node/invalid_variant_payload.fail.rs:3:22
+  |
+3 | #[codama(type = enum(variant("a", number(u8))))]
+  |                      ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/unrecognized_attribute.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/unrecognized_attribute.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = enum(foo = 42))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/unrecognized_attribute.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/unrecognized_attribute.fail.stderr
@@ -1,0 +1,5 @@
+error: expected variant(...) or size = ...
+ --> tests/codama_attribute/type_nodes/enum_type_node/unrecognized_attribute.fail.rs:3:22
+  |
+3 | #[codama(type = enum(foo = 42))]
+  |                      ^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/variant_name_missing.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/variant_name_missing.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = enum(variant()))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/variant_name_missing.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/variant_name_missing.fail.stderr
@@ -1,0 +1,5 @@
+error: name is missing
+ --> tests/codama_attribute/type_nodes/enum_type_node/variant_name_missing.fail.rs:3:22
+  |
+3 | #[codama(type = enum(variant()))]
+  |                      ^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/variant_unrecognized_attribute.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/variant_unrecognized_attribute.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = enum(variant("a", foo = 42)))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/variant_unrecognized_attribute.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/enum_type_node/variant_unrecognized_attribute.fail.stderr
@@ -1,0 +1,5 @@
+error: unrecognized attribute
+ --> tests/codama_attribute/type_nodes/enum_type_node/variant_unrecognized_attribute.fail.rs:3:35
+  |
+3 | #[codama(type = enum(variant("a", foo = 42)))]
+  |                                   ^^^^^^^^


### PR DESCRIPTION
Last part of splitting the remaining type nodes, as you asked on #117. Adds `enum` and `variant`.

```rust
#[codama(type = enum(variant("pending"), variant("done")))]
#[codama(type = enum(variant("point", struct(field("x", number(u8))))))]
#[codama(type = enum(variant("pair", tuple(number(u8)))))]
#[codama(type = enum(variant("a", discriminator = 3)))]
#[codama(type = enum(variant("a"), size = number(u16)))]
```

`variant(...)` is one directive that picks its kind from the payload, rather than three named after the three kinds. Same shape as `field(...)` for struct fields. Size defaults to u8 from `EnumTypeNode::new`.

The parser only takes a plain `struct(...)` or `tuple(...)` payload, so `variant("a", fixed_size(struct(...), 8))` is rejected even though both node fields are `NestedTypeNode`. `display` has no spelling.
