### PR TITLE
Add number displays to the type DSL

### DIFF
--- a/codama-attributes/src/codama_directives/display_directive.rs
+++ b/codama-attributes/src/codama_directives/display_directive.rs
@@ -3,9 +3,7 @@ use crate::{
     Attribute, CodamaAttribute, CodamaDirective,
 };
 use codama_errors::CodamaError;
-use codama_nodes::{
-    AmountNumberDisplayNode, DateTimeNumberDisplayNode, DisplaySkip, NumberDisplayNode,
-};
+use codama_nodes::{DisplaySkip, NumberDisplayNode};
 use codama_syn_helpers::{extensions::*, Meta};
 
 #[derive(Debug, Default, PartialEq, Clone)]
@@ -39,18 +37,11 @@ impl DisplayDirective {
             "skip" => skip.set(DisplaySkip::from_meta(meta.as_value()?)?, meta),
             "flatten" => flatten.set(bool::from_meta(meta)?, meta),
             "flatten_prefix" => flatten_prefix.set(meta.as_value()?.as_expr()?.as_string()?, meta),
-            "amount" => number_display.set(
-                NumberDisplayNode::Amount(AmountNumberDisplayNode::from_meta(meta)?),
-                meta,
-            ),
-            "date_time" => number_display.set(
-                NumberDisplayNode::DateTime(DateTimeNumberDisplayNode::from_meta(meta)?),
-                meta,
-            ),
-            "duration" => Err(meta.error("duration display is not supported yet")),
+            "amount" | "date_time" | "duration" | "injected" => {
+                number_display.set(NumberDisplayNode::from_meta(meta)?, meta)
+            }
             "string" => Err(meta.error("string display is not supported yet")),
             "skip_inner_data" => Err(meta.error("enum variant display is not supported yet")),
-            "injected" => Err(meta.error("injected display values are not supported yet")),
             _ => Err(meta.error("unrecognized display attribute")),
         })?;
 
@@ -95,7 +86,10 @@ impl<'a> TryFrom<&'a Attribute<'a>> for &'a DisplayDirective {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use codama_nodes::{InstructionAccountDisplayNode, NumberValueNode, StringValueNode};
+    use codama_nodes::{
+        AmountNumberDisplayNode, DateTimeNumberDisplayNode, InstructionAccountDisplayNode,
+        NumberValueNode, StringValueNode,
+    };
 
     fn parse_display(tokens: proc_macro2::TokenStream) -> syn::Result<DisplayDirective> {
         let meta: Meta = syn::parse2(tokens)?;

--- a/codama-attributes/src/codama_directives/display_nodes/date_time_number_display_node.rs
+++ b/codama-attributes/src/codama_directives/display_nodes/date_time_number_display_node.rs
@@ -13,7 +13,12 @@ impl FromMeta for DateTimeNumberDisplayNode {
 
         pl.each(|ref meta| match meta.path_str().as_str() {
             "ticks_per_second" => {
-                ticks_per_second.set(meta.as_value()?.as_expr()?.as_unsigned_integer()?, meta)
+                let value = meta.as_value()?;
+                let ticks_per_second_value = value.as_expr()?.as_unsigned_integer()?;
+                if ticks_per_second_value == 0 {
+                    return Err(value.error("ticks_per_second must be greater than zero"));
+                }
+                ticks_per_second.set(ticks_per_second_value, meta)
             }
             _ => Err(meta.error("unrecognized date_time display attribute")),
         })?;
@@ -56,5 +61,16 @@ mod tests {
     fn rejects_positional_attributes() {
         let meta: Meta = syn::parse_quote! { date_time(1_000) };
         assert!(DateTimeNumberDisplayNode::from_meta(&meta).is_err());
+    }
+
+    #[test]
+    fn rejects_zero_ticks_per_second() {
+        let meta: Meta = syn::parse_quote! { date_time(ticks_per_second = 0) };
+        assert_eq!(
+            DateTimeNumberDisplayNode::from_meta(&meta)
+                .unwrap_err()
+                .to_string(),
+            "ticks_per_second must be greater than zero"
+        );
     }
 }

--- a/codama-attributes/src/codama_directives/display_nodes/mod.rs
+++ b/codama-attributes/src/codama_directives/display_nodes/mod.rs
@@ -2,3 +2,4 @@ mod amount_number_display_node;
 mod date_time_number_display_node;
 mod display_skip;
 mod instruction_account_display_node;
+mod number_display_node;

--- a/codama-attributes/src/codama_directives/display_nodes/number_display_node.rs
+++ b/codama-attributes/src/codama_directives/display_nodes/number_display_node.rs
@@ -1,0 +1,62 @@
+use crate::utils::FromMeta;
+use codama_nodes::{AmountNumberDisplayNode, DateTimeNumberDisplayNode, NumberDisplayNode};
+use codama_syn_helpers::{extensions::*, Meta};
+
+impl FromMeta for NumberDisplayNode {
+    fn from_meta(meta: &Meta) -> syn::Result<Self> {
+        match meta.path_str().as_str() {
+            "amount" => AmountNumberDisplayNode::from_meta(meta).map(Self::Amount),
+            "date_time" => DateTimeNumberDisplayNode::from_meta(meta).map(Self::DateTime),
+            "duration" => Err(meta.error("duration display is not supported yet")),
+            "injected" => Err(meta.error("injected display values are not supported yet")),
+            _ => Err(meta.error("unrecognized number display")),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_supported_displays() {
+        let amount: Meta = syn::parse_quote! { amount(decimals = 9, unit = "SOL") };
+        assert!(matches!(
+            NumberDisplayNode::from_meta(&amount).unwrap(),
+            NumberDisplayNode::Amount(_)
+        ));
+
+        let date_time: Meta = syn::parse_quote! { date_time };
+        assert!(matches!(
+            NumberDisplayNode::from_meta(&date_time).unwrap(),
+            NumberDisplayNode::DateTime(_)
+        ));
+    }
+
+    #[test]
+    fn rejects_unsupported_displays() {
+        let duration: Meta = syn::parse_quote! { duration };
+        assert_eq!(
+            NumberDisplayNode::from_meta(&duration)
+                .unwrap_err()
+                .to_string(),
+            "duration display is not supported yet"
+        );
+
+        let string: Meta = syn::parse_quote! { string };
+        assert_eq!(
+            NumberDisplayNode::from_meta(&string)
+                .unwrap_err()
+                .to_string(),
+            "unrecognized number display"
+        );
+
+        let injected: Meta = syn::parse_quote! { injected("decimals") };
+        assert_eq!(
+            NumberDisplayNode::from_meta(&injected)
+                .unwrap_err()
+                .to_string(),
+            "injected display values are not supported yet"
+        );
+    }
+}

--- a/codama-attributes/src/codama_directives/type_nodes/number_type_node.rs
+++ b/codama-attributes/src/codama_directives/type_nodes/number_type_node.rs
@@ -1,5 +1,5 @@
 use crate::utils::{FromMeta, SetOnce};
-use codama_nodes::{Endianness, NumberFormat, NumberTypeNode};
+use codama_nodes::{Endianness, NumberDisplayNode, NumberFormat, NumberTypeNode};
 use codama_syn_helpers::{extensions::*, Meta};
 
 impl FromMeta for NumberTypeNode {
@@ -7,6 +7,7 @@ impl FromMeta for NumberTypeNode {
         let pl = meta.assert_directive("number")?.as_path_list()?;
         let mut format = SetOnce::<NumberFormat>::new("format");
         let mut endian = SetOnce::<Endianness>::new("endian").initial_value(Endianness::Le);
+        let mut display = SetOnce::<NumberDisplayNode>::new("display");
 
         pl.each(|ref meta| match meta.path_str().as_str() {
             "format" => {
@@ -23,6 +24,7 @@ impl FromMeta for NumberTypeNode {
                     _ => Err(path.error("invalid endian")),
                 }
             }
+            "display" => display.set(NumberDisplayNode::from_meta(meta.as_value()?)?, meta),
             _ => {
                 if let Ok(path) = meta.as_path() {
                     if let Ok(value) = NumberFormat::try_from(path.to_string()) {
@@ -36,7 +38,11 @@ impl FromMeta for NumberTypeNode {
             }
         })?;
 
-        Ok(Self::new(format.take(meta)?, endian.take(meta)?))
+        Ok(NumberTypeNode {
+            format: format.take(meta)?,
+            endian: endian.take(meta)?,
+            display: Box::new(display.option()),
+        })
     }
 }
 
@@ -44,7 +50,10 @@ impl FromMeta for NumberTypeNode {
 mod tests {
     use super::*;
     use crate::{assert_type, assert_type_err};
-    use NumberFormat::{U16, U64};
+    use codama_nodes::{
+        AmountNumberDisplayNode, DateTimeNumberDisplayNode, NumberValueNode, StringValueNode,
+    };
+    use NumberFormat::{I64, U16, U64};
 
     #[test]
     fn implicit() {
@@ -91,6 +100,47 @@ mod tests {
     }
 
     #[test]
+    fn amount_display() {
+        assert_type!(
+            { number(u64, display = amount(decimals = 9, unit = "SOL")) },
+            NumberTypeNode {
+                display: Box::new(Some(NumberDisplayNode::Amount(AmountNumberDisplayNode {
+                    decimals: Box::new(Some(NumberValueNode::new(9u64).into())),
+                    unit: Box::new(Some(StringValueNode::new("SOL").into())),
+                }))),
+                ..NumberTypeNode::le(U64)
+            }
+            .into()
+        );
+    }
+
+    #[test]
+    fn date_time_display() {
+        assert_type!(
+            { number(i64, display = date_time) },
+            NumberTypeNode {
+                display: Box::new(Some(NumberDisplayNode::DateTime(
+                    DateTimeNumberDisplayNode::default()
+                ))),
+                ..NumberTypeNode::le(I64)
+            }
+            .into()
+        );
+        assert_type!(
+            { number(i64, display = date_time(ticks_per_second = 1_000)) },
+            NumberTypeNode {
+                display: Box::new(Some(NumberDisplayNode::DateTime(
+                    DateTimeNumberDisplayNode {
+                        ticks_per_second: Some(1_000),
+                    }
+                ))),
+                ..NumberTypeNode::le(I64)
+            }
+            .into()
+        );
+    }
+
+    #[test]
     fn missing_format() {
         assert_type_err!({ number(le) }, "format is missing");
     }
@@ -103,6 +153,14 @@ mod tests {
     #[test]
     fn endian_already_set() {
         assert_type_err!({ number(le, be) }, "endian is already set");
+    }
+
+    #[test]
+    fn display_already_set() {
+        assert_type_err!(
+            { number(u64, display = amount, display = date_time) },
+            "display is already set"
+        );
     }
 
     #[test]

--- a/codama-korok-visitors/tests/apply_type_overrides_visitor.rs
+++ b/codama-korok-visitors/tests/apply_type_overrides_visitor.rs
@@ -1,7 +1,10 @@
 use codama_errors::CodamaResult;
 use codama_korok_visitors::{ApplyTypeOverridesVisitor, KorokVisitable};
 use codama_koroks::{FieldKorok, StructKorok};
-use codama_nodes::{BooleanTypeNode, DefinedTypeLinkNode, StructFieldTypeNode};
+use codama_nodes::{
+    AmountNumberDisplayNode, BooleanTypeNode, DefinedTypeLinkNode, NumberDisplayNode,
+    NumberFormat::U64, NumberTypeNode, NumberValueNode, StringValueNode, StructFieldTypeNode,
+};
 
 #[test]
 fn it_set_the_node_on_the_korok() -> CodamaResult<()> {
@@ -82,6 +85,37 @@ fn it_uses_the_name_directive() -> CodamaResult<()> {
     assert_eq!(
         korok.node,
         Some(StructFieldTypeNode::new("isValid", BooleanTypeNode::default()).into())
+    );
+    Ok(())
+}
+
+#[test]
+fn it_preserves_number_display_metadata() -> CodamaResult<()> {
+    let item: syn::Field = syn::parse_quote! {
+        #[codama(type = number(
+            u64,
+            display = amount(decimals = 9, unit = "SOL")
+        ))]
+        pub amount: u64
+    };
+    let mut korok = FieldKorok::parse(&item)?;
+
+    korok.accept(&mut ApplyTypeOverridesVisitor::new())?;
+    assert_eq!(
+        korok.node,
+        Some(
+            StructFieldTypeNode::new(
+                "amount",
+                NumberTypeNode {
+                    display: Box::new(Some(NumberDisplayNode::Amount(AmountNumberDisplayNode {
+                        decimals: Box::new(Some(NumberValueNode::new(9u64).into())),
+                        unit: Box::new(Some(StringValueNode::new("SOL").into())),
+                    }))),
+                    ..NumberTypeNode::le(U64)
+                }
+            )
+            .into()
+        )
     );
     Ok(())
 }

--- a/codama-macros/tests/codama_attribute/display_directive/zero_ticks_per_second.fail.rs
+++ b/codama-macros/tests/codama_attribute/display_directive/zero_ticks_per_second.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(display(date_time(ticks_per_second = 0)))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/display_directive/zero_ticks_per_second.fail.stderr
+++ b/codama-macros/tests/codama_attribute/display_directive/zero_ticks_per_second.fail.stderr
@@ -1,0 +1,5 @@
+error: ticks_per_second must be greater than zero
+ --> tests/codama_attribute/display_directive/zero_ticks_per_second.fail.rs:3:47
+  |
+3 | #[codama(display(date_time(ticks_per_second = 0)))]
+  |                                               ^

--- a/codama-macros/tests/codama_attribute/type_nodes/number_type_node/_pass.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/number_type_node/_pass.rs
@@ -6,6 +6,15 @@ use codama_macros::codama;
 #[codama(type = number(le, u32))]
 #[codama(type = number(format = u32, endian = le))]
 #[codama(type = number(endian = le, format = u32))]
+#[codama(type = number(
+    u64,
+    display = amount(decimals = 9, unit = "SOL")
+))]
+#[codama(type = number(i64, display = date_time))]
+#[codama(type = number(
+    i64,
+    display = date_time(ticks_per_second = 1_000)
+))]
 pub struct Test;
 
 fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/number_type_node/display_already_set.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/number_type_node/display_already_set.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = number(u64, display = amount, display = date_time))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/number_type_node/display_already_set.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/number_type_node/display_already_set.fail.stderr
@@ -1,0 +1,5 @@
+error: display is already set
+ --> tests/codama_attribute/type_nodes/number_type_node/display_already_set.fail.rs:3:47
+  |
+3 | #[codama(type = number(u64, display = amount, display = date_time))]
+  |                                               ^^^^^^^^^^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/number_type_node/injected_display.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/number_type_node/injected_display.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = number(u64, display = injected("amount")))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/number_type_node/injected_display.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/number_type_node/injected_display.fail.stderr
@@ -1,0 +1,5 @@
+error: injected display values are not supported yet
+ --> tests/codama_attribute/type_nodes/number_type_node/injected_display.fail.rs:3:39
+  |
+3 | #[codama(type = number(u64, display = injected("amount")))]
+  |                                       ^^^^^^^^^^^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/number_type_node/invalid_display.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/number_type_node/invalid_display.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = number(u64, display = string))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/number_type_node/invalid_display.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/number_type_node/invalid_display.fail.stderr
@@ -1,0 +1,5 @@
+error: unrecognized number display
+ --> tests/codama_attribute/type_nodes/number_type_node/invalid_display.fail.rs:3:39
+  |
+3 | #[codama(type = number(u64, display = string))]
+  |                                       ^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/number_type_node/unsupported_display.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/number_type_node/unsupported_display.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = number(u64, display = duration))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/number_type_node/unsupported_display.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/number_type_node/unsupported_display.fail.stderr
@@ -1,0 +1,5 @@
+error: duration display is not supported yet
+ --> tests/codama_attribute/type_nodes/number_type_node/unsupported_display.fail.rs:3:39
+  |
+3 | #[codama(type = number(u64, display = duration))]
+  |                                       ^^^^^^^^

--- a/codama-macros/tests/codama_attribute/type_nodes/number_type_node/zero_ticks_per_second.fail.rs
+++ b/codama-macros/tests/codama_attribute/type_nodes/number_type_node/zero_ticks_per_second.fail.rs
@@ -1,0 +1,6 @@
+use codama_macros::codama;
+
+#[codama(type = number(i64, display = date_time(ticks_per_second = 0)))]
+pub struct Test;
+
+fn main() {}

--- a/codama-macros/tests/codama_attribute/type_nodes/number_type_node/zero_ticks_per_second.fail.stderr
+++ b/codama-macros/tests/codama_attribute/type_nodes/number_type_node/zero_ticks_per_second.fail.stderr
@@ -1,0 +1,5 @@
+error: ticks_per_second must be greater than zero
+ --> tests/codama_attribute/type_nodes/number_type_node/zero_ticks_per_second.fail.rs:3:68
+  |
+3 | #[codama(type = number(i64, display = date_time(ticks_per_second = 0)))]
+  |                                                                    ^


### PR DESCRIPTION
This PR adds display metadata to the `number` type DSL, supporting literal amount and date-time presentation directly within type overrides. It shares number-display parsing with standalone display directives, rejects unusable zero tick rates, and preserves clear diagnostics for deferred display features.