### PR TITLE
Apply display directives during extraction

### DIFF
--- a/codama-attributes/src/codama_directives/enum_discriminator_directive.rs
+++ b/codama-attributes/src/codama_directives/enum_discriminator_directive.rs
@@ -4,8 +4,8 @@ use crate::{
 };
 use codama_errors::CodamaError;
 use codama_nodes::{
-    CamelCaseString, InstructionArgumentNode, NestedTypeNode, Node, NumberFormat::U8,
-    NumberTypeNode, StructFieldTypeNode, TypeNode,
+    CamelCaseString, DisplaySkip, InstructionArgumentNode, NestedTypeNode, Node, NumberFormat::U8,
+    NumberTypeNode, StructFieldDisplayNode, StructFieldTypeNode, TypeNode,
 };
 use codama_syn_helpers::{extensions::*, Meta};
 
@@ -89,13 +89,16 @@ impl From<&Option<Node>> for EnumDiscriminatorDirective {
 
 impl From<&EnumDiscriminatorDirective> for StructFieldTypeNode {
     fn from(directive: &EnumDiscriminatorDirective) -> Self {
-        StructFieldTypeNode::new(
-            directive.name.clone().unwrap_or("discriminator".into()),
-            directive
-                .size
-                .clone()
-                .unwrap_or(NumberTypeNode::le(U8).into()),
-        )
+        StructFieldTypeNode {
+            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
+            ..StructFieldTypeNode::new(
+                directive.name.clone().unwrap_or("discriminator".into()),
+                directive
+                    .size
+                    .clone()
+                    .unwrap_or(NumberTypeNode::le(U8).into()),
+            )
+        }
     }
 }
 
@@ -157,6 +160,28 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "enum_discriminator must specify at least one of: name, size"
+        );
+    }
+
+    #[test]
+    fn creates_hidden_struct_fields() {
+        let directive = EnumDiscriminatorDirective::default();
+        let field = StructFieldTypeNode::from(&directive);
+
+        assert_eq!(
+            field.display,
+            Some(StructFieldDisplayNode::skipped(DisplaySkip::Always))
+        );
+    }
+
+    #[test]
+    fn creates_hidden_instruction_arguments() {
+        let directive = EnumDiscriminatorDirective::default();
+        let argument = InstructionArgumentNode::from(&directive);
+
+        assert_eq!(
+            argument.display,
+            Some(StructFieldDisplayNode::skipped(DisplaySkip::Always))
         );
     }
 }

--- a/codama-korok-visitors/src/apply_display_visitor.rs
+++ b/codama-korok-visitors/src/apply_display_visitor.rs
@@ -1,0 +1,171 @@
+use crate::KorokVisitor;
+use codama_attributes::{
+    Attribute, CodamaAttribute, CodamaDirective, DisplayDirective, TryFromFilter,
+};
+use codama_errors::CodamaResult;
+use codama_koroks::{KorokMut, KorokTrait};
+use codama_nodes::{
+    HasKind, Node, NumberDisplayNode, RegisteredTypeNode, StructFieldDisplayNode, TypeNode,
+};
+use codama_syn_helpers::extensions::ToTokensExtension;
+
+#[derive(Default)]
+pub struct ApplyDisplayVisitor;
+
+impl ApplyDisplayVisitor {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl KorokVisitor for ApplyDisplayVisitor {
+    fn visit_field(&mut self, korok: &mut codama_koroks::FieldKorok) -> CodamaResult<()> {
+        apply_displays(korok.into())
+    }
+}
+
+fn apply_displays(mut korok: KorokMut) -> CodamaResult<()> {
+    let Some(attributes) = korok.attributes() else {
+        return Ok(());
+    };
+    if attributes.get_first(DisplayDirective::filter).is_none() {
+        return Ok(());
+    }
+
+    let node = attributes
+        .iter()
+        .filter_map(|attribute| match attribute {
+            Attribute::Codama(attribute) => Some(attribute),
+            _ => None,
+        })
+        .try_fold(korok.node().clone(), |node, attribute| {
+            let CodamaDirective::Display(directive) = attribute.directive.as_ref() else {
+                return Ok(node);
+            };
+            apply_display(node, directive, attribute)
+        })?;
+
+    korok.set_node(node);
+    Ok(())
+}
+
+fn apply_display(
+    node: Option<Node>,
+    directive: &DisplayDirective,
+    attribute: &CodamaAttribute,
+) -> CodamaResult<Option<Node>> {
+    let Some(node) = node else {
+        return Err(attribute
+            .ast
+            .error("Cannot apply attribute `#[codama(display)]` on an empty node")
+            .into());
+    };
+
+    match node {
+        Node::Type(RegisteredTypeNode::StructField(mut field)) => {
+            apply_struct_field_display(&mut field.display, directive);
+            apply_optional_number_display(&mut field.r#type, directive, attribute)?;
+            Ok(Some(field.into()))
+        }
+        Node::InstructionArgument(mut argument) => {
+            apply_struct_field_display(&mut argument.display, directive);
+            apply_optional_number_display(&mut argument.r#type, directive, attribute)?;
+            Ok(Some(argument.into()))
+        }
+        node => apply_display_to_type_node(node, directive, attribute).map(Some),
+    }
+}
+
+fn apply_display_to_type_node(
+    node: Node,
+    directive: &DisplayDirective,
+    attribute: &CodamaAttribute,
+) -> CodamaResult<Node> {
+    let Some(display) = &directive.number_display else {
+        return Ok(node);
+    };
+    let kind = node.kind();
+    let mut type_node = TypeNode::try_from(node).map_err(|_| {
+        attribute.ast.error(format!(
+            "Cannot apply attribute `#[codama(display)]` as a number display on a node of kind `{kind}`"
+        ))
+    })?;
+    apply_number_display(&mut type_node, display, attribute)?;
+    Ok(type_node.into())
+}
+
+pub(crate) fn apply_struct_field_display(
+    display: &mut Option<StructFieldDisplayNode>,
+    directive: &DisplayDirective,
+) {
+    if directive.label.is_none()
+        && directive.skip.is_none()
+        && directive.flatten.is_none()
+        && directive.flatten_prefix.is_none()
+    {
+        return;
+    }
+
+    let display = display.get_or_insert_default();
+    if let Some(label) = &directive.label {
+        display.label = Some(label.clone());
+    }
+    if let Some(skip) = directive.skip {
+        display.skip = Some(skip);
+    }
+    if let Some(flatten) = directive.flatten {
+        display.flatten = Some(flatten);
+    }
+    if let Some(flatten_prefix) = &directive.flatten_prefix {
+        display.flatten_prefix = Some(flatten_prefix.clone());
+    }
+}
+
+fn apply_optional_number_display(
+    type_node: &mut TypeNode,
+    directive: &DisplayDirective,
+    attribute: &CodamaAttribute,
+) -> CodamaResult<()> {
+    let Some(display) = &directive.number_display else {
+        return Ok(());
+    };
+    apply_number_display(type_node, display, attribute)
+}
+
+fn apply_number_display(
+    type_node: &mut TypeNode,
+    display: &NumberDisplayNode,
+    attribute: &CodamaAttribute,
+) -> CodamaResult<()> {
+    // Follow only value-bearing edges. Nested type modifiers preserve the decoded value,
+    // option encodings expose one optional payload, and arrays apply presentation per item.
+    // Framing children and semantic number wrappers must keep their own display semantics.
+    match type_node {
+        TypeNode::Number(number) => {
+            *number.display = Some(display.clone());
+            Ok(())
+        }
+        TypeNode::FixedSize(node) => apply_number_display(&mut node.r#type, display, attribute),
+        TypeNode::SizePrefix(node) => apply_number_display(&mut node.r#type, display, attribute),
+        TypeNode::PreOffset(node) => apply_number_display(&mut node.r#type, display, attribute),
+        TypeNode::PostOffset(node) => apply_number_display(&mut node.r#type, display, attribute),
+        TypeNode::HiddenPrefix(node) => apply_number_display(&mut node.r#type, display, attribute),
+        TypeNode::HiddenSuffix(node) => apply_number_display(&mut node.r#type, display, attribute),
+        TypeNode::Sentinel(node) => apply_number_display(&mut node.r#type, display, attribute),
+        TypeNode::Option(node) => apply_number_display(&mut node.item, display, attribute),
+        TypeNode::RemainderOption(node) => {
+            apply_number_display(&mut node.item, display, attribute)
+        }
+        TypeNode::ZeroableOption(node) => {
+            apply_number_display(&mut node.item, display, attribute)
+        }
+        TypeNode::Array(node) => apply_number_display(&mut node.item, display, attribute),
+        node => Err(attribute
+            .ast
+            .error(format!(
+                "Cannot apply attribute `#[codama(display)]` as a number display on a node of kind `{}`",
+                node.kind()
+            ))
+            .into()),
+    }
+}

--- a/codama-korok-visitors/src/lib.rs
+++ b/codama-korok-visitors/src/lib.rs
@@ -1,3 +1,4 @@
+mod apply_display_visitor;
 mod apply_type_modifiers_visitor;
 mod apply_type_overrides_visitor;
 mod combine_modules_visitor;
@@ -18,6 +19,7 @@ mod uniform_visitor;
 mod visitable;
 mod visitor;
 
+pub use apply_display_visitor::*;
 pub use apply_type_modifiers_visitor::*;
 pub use apply_type_overrides_visitor::*;
 pub use combine_modules_visitor::*;

--- a/codama-korok-visitors/src/set_instructions_visitors.rs
+++ b/codama-korok-visitors/src/set_instructions_visitors.rs
@@ -1,15 +1,16 @@
-use crate::{CombineTypesVisitor, KorokVisitor};
+use crate::{apply_struct_field_display, CombineTypesVisitor, KorokVisitor};
 use codama_attributes::{
     AccountDirective, ArgumentDirective, Attributes, DefaultValueDirective, DiscriminatorDirective,
-    EnumDiscriminatorDirective, OptionalAccountStrategyDirective, ProgramDirective, TryFromFilter,
+    DisplayDirective, EnumDiscriminatorDirective, OptionalAccountStrategyDirective,
+    ProgramDirective, TryFromFilter,
 };
 use codama_errors::CodamaResult;
 use codama_koroks::FieldKorok;
 use codama_nodes::{
     CamelCaseString, DefaultValueStrategy, EnumVariantTypeNode, FieldDiscriminatorNode,
-    InstructionAccountNode, InstructionArgumentNode, InstructionNode, NestedTypeNode, Node,
-    NumberValueNode, OptionalAccountStrategy, ProgramNode, StructFieldTypeNode, StructTypeNode,
-    TypeNode,
+    InstructionAccountNode, InstructionArgumentNode, InstructionDisplayNode, InstructionNode,
+    NestedTypeNode, Node, NumberValueNode, OptionalAccountStrategy, ProgramNode,
+    StructFieldDisplayNode, StructFieldTypeNode, StructTypeNode, TypeNode,
 };
 use codama_syn_helpers::extensions::{ExprExtension, ToTokensExtension};
 
@@ -69,6 +70,7 @@ impl KorokVisitor for SetInstructionsVisitor {
             accounts: parse_accounts(&korok.attributes, &korok.fields)?,
             arguments: parse_arguments(&korok.attributes, &korok.fields, data, None)?,
             discriminators: DiscriminatorDirective::nodes(&korok.attributes),
+            display: parse_instruction_display(&korok.attributes),
             ..InstructionNode::default()
         };
 
@@ -169,6 +171,7 @@ impl KorokVisitor for SetInstructionsVisitor {
                     Some(discriminator),
                 )?,
                 discriminators,
+                display: parse_instruction_display(&korok.attributes),
                 ..InstructionNode::default()
             }
             .into(),
@@ -182,6 +185,28 @@ fn parse_optional_account_strategy(attributes: &Attributes) -> Option<OptionalAc
     attributes
         .get_last(OptionalAccountStrategyDirective::filter)
         .map(|directive| directive.strategy)
+}
+
+fn parse_instruction_display(attributes: &Attributes) -> Option<InstructionDisplayNode> {
+    // Display properties are host-specific. Field properties are intentionally left for
+    // field and enum-variant display handling rather than interpreted as instruction metadata.
+    attributes
+        .get_all(DisplayDirective::filter)
+        .into_iter()
+        .fold(None, |display, directive| {
+            if directive.intent.is_none() && directive.interpolated_intent.is_none() {
+                return display;
+            }
+
+            let mut display = display.unwrap_or_default();
+            if let Some(intent) = &directive.intent {
+                display.intent = Some(intent.clone());
+            }
+            if let Some(interpolated_intent) = &directive.interpolated_intent {
+                display.interpolated_intent = Some(interpolated_intent.clone());
+            }
+            Some(display)
+        })
 }
 
 fn parse_accounts(
@@ -330,7 +355,11 @@ fn parse_enum_variant(
                                     .get(i)
                                     .and_then(|f| f.name())
                                     .unwrap_or_else(|| format!("arg{}", i).into());
-                                StructFieldTypeNode::new(name, item)
+                                let display = korok.fields.get(i).and_then(parse_field_display);
+                                StructFieldTypeNode {
+                                    display,
+                                    ..StructFieldTypeNode::new(name, item)
+                                }
                             })
                             .collect();
                         return Ok((node.name, StructTypeNode::new(fields)));
@@ -347,4 +376,14 @@ fn parse_enum_variant(
         korok.ast.ident
     );
     Err(korok.ast.error(message).into())
+}
+
+fn parse_field_display(field: &FieldKorok) -> Option<StructFieldDisplayNode> {
+    // Unnamed fields cannot carry StructFieldDisplayNode metadata during field traversal.
+    // Recover it here when an instruction tuple variant turns those fields into named arguments.
+    let mut display = None;
+    for directive in field.attributes.get_all(DisplayDirective::filter) {
+        apply_struct_field_display(&mut display, directive);
+    }
+    display
 }

--- a/codama-korok-visitors/tests/apply_display_visitor/mod.rs
+++ b/codama-korok-visitors/tests/apply_display_visitor/mod.rs
@@ -1,0 +1,2 @@
+mod number_display;
+mod struct_field_display;

--- a/codama-korok-visitors/tests/apply_display_visitor/number_display.rs
+++ b/codama-korok-visitors/tests/apply_display_visitor/number_display.rs
@@ -1,0 +1,519 @@
+use codama_errors::CodamaResult;
+use codama_korok_visitors::{
+    ApplyDisplayVisitor, ApplyTypeOverridesVisitor, IdentifyFieldTypesVisitor, KorokVisitable,
+};
+use codama_koroks::{FieldKorok, KorokTrait};
+use codama_nodes::{
+    AmountNumberDisplayNode, AmountTypeNode, ArrayTypeNode, BooleanTypeNode, ConstantValueNode,
+    DateTimeNumberDisplayNode, DateTimeTypeNode, DefinedTypeLinkNode, FixedSizeTypeNode,
+    HiddenPrefixTypeNode, HiddenSuffixTypeNode, MapTypeNode, NestedTypeNode, NumberDisplayNode,
+    NumberFormat::{U32, U64, U8},
+    NumberTypeNode, NumberValueNode, OptionTypeNode, PostOffsetTypeNode, PreOffsetTypeNode,
+    RemainderOptionTypeNode, SentinelTypeNode, SetTypeNode, SizePrefixTypeNode, SolAmountTypeNode,
+    StringTypeNode, StringValueNode, StructFieldTypeNode, TupleTypeNode, TypeNode,
+    ZeroableOptionTypeNode,
+};
+
+#[test]
+fn it_applies_number_displays_without_creating_field_displays() -> CodamaResult<()> {
+    let ast: syn::Field = syn::parse_quote! {
+        #[codama(display(amount(decimals = 9, unit = "SOL")))]
+        amount: u64
+    };
+    let mut korok = FieldKorok::parse(&ast)?;
+
+    korok.accept(&mut IdentifyFieldTypesVisitor::new())?;
+    korok.accept(&mut ApplyDisplayVisitor::new())?;
+
+    assert_eq!(
+        korok.node,
+        Some(
+            StructFieldTypeNode::new(
+                "amount",
+                NumberTypeNode {
+                    display: Box::new(Some(NumberDisplayNode::Amount(
+                        AmountNumberDisplayNode::new(
+                            NumberValueNode::new(9u64),
+                            StringValueNode::new("SOL"),
+                        ),
+                    ))),
+                    ..NumberTypeNode::le(U64)
+                },
+            )
+            .into(),
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn it_replaces_existing_number_displays() -> CodamaResult<()> {
+    let ast: syn::Field = syn::parse_quote! {
+        #[codama(type = number(u64, display = date_time))]
+        #[codama(display(amount(decimals = 9, unit = "SOL")))]
+        amount: u64
+    };
+    let mut korok = FieldKorok::parse(&ast)?;
+
+    korok.accept(&mut ApplyTypeOverridesVisitor::new())?;
+    korok.accept(&mut ApplyDisplayVisitor::new())?;
+
+    assert_eq!(
+        korok.node,
+        Some(
+            StructFieldTypeNode::new(
+                "amount",
+                NumberTypeNode {
+                    display: Box::new(Some(NumberDisplayNode::Amount(
+                        AmountNumberDisplayNode::new(
+                            NumberValueNode::new(9u64),
+                            StringValueNode::new("SOL"),
+                        ),
+                    ))),
+                    ..NumberTypeNode::le(U64)
+                },
+            )
+            .into(),
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn it_applies_multiple_number_displays_in_source_order() -> CodamaResult<()> {
+    let ast: syn::Field = syn::parse_quote! {
+        #[codama(display(date_time))]
+        #[codama(display(amount(decimals = 9, unit = "SOL")))]
+        amount: u64
+    };
+    let mut korok = FieldKorok::parse(&ast)?;
+
+    korok.accept(&mut IdentifyFieldTypesVisitor::new())?;
+    korok.accept(&mut ApplyDisplayVisitor::new())?;
+
+    assert_eq!(
+        korok.node,
+        Some(
+            StructFieldTypeNode::new(
+                "amount",
+                NumberTypeNode {
+                    display: Box::new(Some(NumberDisplayNode::Amount(
+                        AmountNumberDisplayNode::new(
+                            NumberValueNode::new(9u64),
+                            StringValueNode::new("SOL"),
+                        ),
+                    ))),
+                    ..NumberTypeNode::le(U64)
+                },
+            )
+            .into(),
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn it_traverses_supported_number_wrappers() -> CodamaResult<()> {
+    let ast: syn::Field = syn::parse_quote! {
+        #[codama(display(date_time(ticks_per_second = 1_000)))]
+        values: Vec<Option<u64>>
+    };
+    let mut korok = FieldKorok::parse(&ast)?;
+    let prefix = NumberTypeNode::le(U32);
+    let expected_prefix = prefix.clone();
+    let display = NumberDisplayNode::DateTime(DateTimeNumberDisplayNode::new(Some(1_000)));
+    korok.set_node(Some(
+        StructFieldTypeNode::new(
+            "values",
+            FixedSizeTypeNode::new(
+                SizePrefixTypeNode::new(
+                    OptionTypeNode {
+                        fixed: None,
+                        item: Box::new(ArrayTypeNode::fixed(NumberTypeNode::le(U64), 2).into()),
+                        prefix: NumberTypeNode::le(U8).into(),
+                    },
+                    prefix,
+                ),
+                42,
+            ),
+        )
+        .into(),
+    ));
+
+    korok.accept(&mut ApplyDisplayVisitor::new())?;
+
+    assert_eq!(
+        korok.node,
+        Some(
+            StructFieldTypeNode::new(
+                "values",
+                FixedSizeTypeNode::new(
+                    SizePrefixTypeNode::new(
+                        OptionTypeNode {
+                            fixed: None,
+                            item: Box::new(
+                                ArrayTypeNode::fixed(
+                                    NumberTypeNode {
+                                        display: Box::new(Some(display)),
+                                        ..NumberTypeNode::le(U64)
+                                    },
+                                    2,
+                                )
+                                .into(),
+                            ),
+                            prefix: NumberTypeNode::le(U8).into(),
+                        },
+                        expected_prefix,
+                    ),
+                    42,
+                ),
+            )
+            .into()
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn it_traverses_all_nested_type_modifiers() -> CodamaResult<()> {
+    let ast: syn::Field = syn::parse_quote! {
+        #[codama(display(amount))]
+        value: u64
+    };
+    let mut korok = FieldKorok::parse(&ast)?;
+    let hidden_prefix = ConstantValueNode::new(NumberTypeNode::le(U8), NumberValueNode::new(1u8));
+    let hidden_suffix = ConstantValueNode::new(NumberTypeNode::le(U8), NumberValueNode::new(2u8));
+    let sentinel = ConstantValueNode::new(NumberTypeNode::le(U8), NumberValueNode::new(255u8));
+    korok.set_node(Some(
+        StructFieldTypeNode::new(
+            "value",
+            PreOffsetTypeNode::relative(
+                PostOffsetTypeNode::padded(
+                    HiddenPrefixTypeNode::new(
+                        HiddenSuffixTypeNode::new(
+                            SentinelTypeNode::new(
+                                RemainderOptionTypeNode::new(NumberTypeNode::le(U64)),
+                                sentinel.clone(),
+                            ),
+                            vec![hidden_suffix.clone()],
+                        ),
+                        vec![hidden_prefix.clone()],
+                    ),
+                    8,
+                ),
+                4,
+            ),
+        )
+        .into(),
+    ));
+
+    korok.accept(&mut ApplyDisplayVisitor::new())?;
+
+    assert_eq!(
+        korok.node,
+        Some(
+            StructFieldTypeNode::new(
+                "value",
+                PreOffsetTypeNode::relative(
+                    PostOffsetTypeNode::padded(
+                        HiddenPrefixTypeNode::new(
+                            HiddenSuffixTypeNode::new(
+                                SentinelTypeNode::new(
+                                    RemainderOptionTypeNode::new(NumberTypeNode {
+                                        display: Box::new(Some(NumberDisplayNode::Amount(
+                                            AmountNumberDisplayNode::default(),
+                                        ))),
+                                        ..NumberTypeNode::le(U64)
+                                    }),
+                                    sentinel,
+                                ),
+                                vec![hidden_suffix],
+                            ),
+                            vec![hidden_prefix],
+                        ),
+                        8,
+                    ),
+                    4,
+                ),
+            )
+            .into(),
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn it_traverses_alternative_option_encodings() -> CodamaResult<()> {
+    let remainder_ast: syn::Field = syn::parse_quote! {
+        #[codama(display(date_time))]
+        value: u64
+    };
+    let mut remainder_korok = FieldKorok::parse(&remainder_ast)?;
+    remainder_korok.set_node(Some(
+        StructFieldTypeNode::new(
+            "value",
+            RemainderOptionTypeNode::new(NumberTypeNode::le(U64)),
+        )
+        .into(),
+    ));
+
+    remainder_korok.accept(&mut ApplyDisplayVisitor::new())?;
+
+    assert_eq!(
+        remainder_korok.node,
+        Some(
+            StructFieldTypeNode::new(
+                "value",
+                RemainderOptionTypeNode::new(NumberTypeNode {
+                    display: Box::new(Some(NumberDisplayNode::DateTime(
+                        DateTimeNumberDisplayNode::default(),
+                    ))),
+                    ..NumberTypeNode::le(U64)
+                }),
+            )
+            .into(),
+        )
+    );
+
+    let zeroable_ast: syn::Field = syn::parse_quote! {
+        #[codama(display(amount))]
+        value: u64
+    };
+    let mut zeroable_korok = FieldKorok::parse(&zeroable_ast)?;
+    let zero_value = ConstantValueNode::new(NumberTypeNode::le(U64), NumberValueNode::new(0u64));
+    zeroable_korok.set_node(Some(
+        StructFieldTypeNode::new(
+            "value",
+            ZeroableOptionTypeNode::custom(NumberTypeNode::le(U64), zero_value.clone()),
+        )
+        .into(),
+    ));
+
+    zeroable_korok.accept(&mut ApplyDisplayVisitor::new())?;
+
+    assert_eq!(
+        zeroable_korok.node,
+        Some(
+            StructFieldTypeNode::new(
+                "value",
+                ZeroableOptionTypeNode::custom(
+                    NumberTypeNode {
+                        display: Box::new(Some(NumberDisplayNode::Amount(
+                            AmountNumberDisplayNode::default(),
+                        ))),
+                        ..NumberTypeNode::le(U64)
+                    },
+                    zero_value,
+                ),
+            )
+            .into(),
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn it_traverses_wrappers_from_type_overrides() -> CodamaResult<()> {
+    let ast: syn::Field = syn::parse_quote! {
+        #[codama(type = pre_offset(number(u64), 4, relative))]
+        #[codama(display(amount))]
+        value: u64
+    };
+    let mut korok = FieldKorok::parse(&ast)?;
+
+    korok.accept(&mut ApplyTypeOverridesVisitor::new())?;
+    korok.accept(&mut ApplyDisplayVisitor::new())?;
+
+    assert_eq!(
+        korok.node,
+        Some(
+            StructFieldTypeNode::new(
+                "value",
+                PreOffsetTypeNode::relative(
+                    NumberTypeNode {
+                        display: Box::new(Some(NumberDisplayNode::Amount(
+                            AmountNumberDisplayNode::default(),
+                        ))),
+                        ..NumberTypeNode::le(U64)
+                    },
+                    4,
+                ),
+            )
+            .into(),
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn it_reports_errors_at_the_logical_leaf() -> CodamaResult<()> {
+    let ast: syn::Field = syn::parse_quote! {
+        #[codama(display(amount))]
+        value: u64
+    };
+    let wrapped_types: Vec<TypeNode> = vec![
+        PreOffsetTypeNode::relative(StringTypeNode::utf8(), 4).into(),
+        RemainderOptionTypeNode::new(StringTypeNode::utf8()).into(),
+    ];
+
+    for wrapped_type in wrapped_types {
+        let mut korok = FieldKorok::parse(&ast)?;
+        korok.set_node(Some(StructFieldTypeNode::new("value", wrapped_type).into()));
+
+        let error = korok.accept(&mut ApplyDisplayVisitor::new()).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "Cannot apply attribute `#[codama(display)]` as a number display on a node of kind `stringTypeNode`"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn it_traverses_rust_arrays_and_vectors() -> CodamaResult<()> {
+    let array_ast: syn::Field = syn::parse_quote! {
+        #[codama(display(amount))]
+        amounts: [u64; 2]
+    };
+    let vector_ast: syn::Field = syn::parse_quote! {
+        #[codama(display(amount))]
+        amounts: Vec<u64>
+    };
+
+    for ast in [&array_ast, &vector_ast] {
+        let mut korok = FieldKorok::parse(ast)?;
+        korok.accept(&mut IdentifyFieldTypesVisitor::new())?;
+        korok.accept(&mut ApplyDisplayVisitor::new())?;
+
+        let Some(codama_nodes::Node::Type(codama_nodes::RegisteredTypeNode::StructField(field))) =
+            korok.node
+        else {
+            panic!("Expected a struct field type node");
+        };
+        let TypeNode::Array(array) = *field.r#type else {
+            panic!("Expected an array type node");
+        };
+        let TypeNode::Number(number) = *array.item else {
+            panic!("Expected a number type node");
+        };
+        assert_eq!(
+            *number.display,
+            Some(NumberDisplayNode::Amount(AmountNumberDisplayNode::default()))
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn it_does_not_traverse_composite_type_nodes() -> CodamaResult<()> {
+    let ast: syn::Field = syn::parse_quote! {
+        #[codama(display(amount))]
+        value: u64
+    };
+    let unsupported: Vec<(TypeNode, &str)> = vec![
+        (BooleanTypeNode::default().into(), "booleanTypeNode"),
+        (
+            SetTypeNode::fixed(NumberTypeNode::le(U64), 2).into(),
+            "setTypeNode",
+        ),
+        (
+            MapTypeNode::fixed(NumberTypeNode::le(U64), NumberTypeNode::le(U64), 2).into(),
+            "mapTypeNode",
+        ),
+        (
+            TupleTypeNode::new(vec![NumberTypeNode::le(U64).into()]).into(),
+            "tupleTypeNode",
+        ),
+        (
+            DefinedTypeLinkNode::new("external_number").into(),
+            "definedTypeLinkNode",
+        ),
+    ];
+
+    for (type_node, kind) in unsupported {
+        let mut korok = FieldKorok::parse(&ast)?;
+        korok.set_node(Some(StructFieldTypeNode::new("value", type_node).into()));
+
+        let error = korok.accept(&mut ApplyDisplayVisitor::new()).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "Cannot apply attribute `#[codama(display)]` as a number display on a node of kind `{kind}`"
+            )
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn it_does_not_traverse_semantic_number_types() -> CodamaResult<()> {
+    let ast: syn::Field = syn::parse_quote! {
+        #[codama(display(amount))]
+        value: u64
+    };
+    let unsupported: Vec<(TypeNode, &str)> = vec![
+        (
+            AmountTypeNode::new(NumberTypeNode::le(U64), 9, Some("SOL".to_string())).into(),
+            "amountTypeNode",
+        ),
+        (
+            DateTimeTypeNode::new(NumberTypeNode::le(U64)).into(),
+            "dateTimeTypeNode",
+        ),
+        (
+            SolAmountTypeNode::new(NumberTypeNode::le(U64)).into(),
+            "solAmountTypeNode",
+        ),
+    ];
+
+    for (type_node, kind) in unsupported {
+        let mut korok = FieldKorok::parse(&ast)?;
+        korok.set_node(Some(StructFieldTypeNode::new("value", type_node).into()));
+
+        let error = korok.accept(&mut ApplyDisplayVisitor::new()).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "Cannot apply attribute `#[codama(display)]` as a number display on a node of kind `{kind}`"
+            )
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn it_does_not_update_wrapper_metadata() -> CodamaResult<()> {
+    let ast: syn::Field = syn::parse_quote! {
+        #[codama(display(amount))]
+        value: u64
+    };
+    let mut korok = FieldKorok::parse(&ast)?;
+    let prefix = NumberTypeNode::le(U32);
+    korok.set_node(Some(
+        StructFieldTypeNode::new(
+            "value",
+            SizePrefixTypeNode::new(NumberTypeNode::le(U64), prefix.clone()),
+        )
+        .into(),
+    ));
+
+    korok.accept(&mut ApplyDisplayVisitor::new())?;
+
+    let Some(codama_nodes::Node::Type(codama_nodes::RegisteredTypeNode::StructField(field))) =
+        korok.node
+    else {
+        panic!("Expected a struct field type node");
+    };
+    let TypeNode::SizePrefix(size_prefix) = *field.r#type else {
+        panic!("Expected a size prefix type node");
+    };
+    assert_eq!(*size_prefix.prefix, NestedTypeNode::Value(prefix));
+    let TypeNode::Number(number) = *size_prefix.r#type else {
+        panic!("Expected a number type node");
+    };
+    assert_eq!(
+        *number.display,
+        Some(NumberDisplayNode::Amount(AmountNumberDisplayNode::default()))
+    );
+    Ok(())
+}

--- a/codama-korok-visitors/tests/apply_display_visitor/struct_field_display.rs
+++ b/codama-korok-visitors/tests/apply_display_visitor/struct_field_display.rs
@@ -1,0 +1,119 @@
+use codama_errors::CodamaResult;
+use codama_korok_visitors::{ApplyDisplayVisitor, IdentifyFieldTypesVisitor, KorokVisitable};
+use codama_koroks::{FieldKorok, KorokTrait};
+use codama_nodes::{
+    DisplaySkip, NumberFormat::U64, NumberTypeNode, StringValueNode, StructFieldDisplayNode,
+    StructFieldTypeNode,
+};
+
+#[test]
+fn it_applies_struct_field_displays() -> CodamaResult<()> {
+    let ast: syn::Field = syn::parse_quote! {
+        #[codama(display(
+            label = "Amount",
+            skip = when_injected,
+            flatten,
+            flatten_prefix = "Inner "
+        ))]
+        amount: u64
+    };
+    let mut korok = FieldKorok::parse(&ast)?;
+
+    korok.accept(&mut IdentifyFieldTypesVisitor::new())?;
+    korok.accept(&mut ApplyDisplayVisitor::new())?;
+
+    assert_eq!(
+        korok.node,
+        Some(
+            StructFieldTypeNode {
+                display: Some(StructFieldDisplayNode {
+                    label: Some("Amount".to_string()),
+                    skip: Some(DisplaySkip::WhenInjected),
+                    flatten: Some(true),
+                    flatten_prefix: Some("Inner ".to_string()),
+                }),
+                ..StructFieldTypeNode::new("amount", NumberTypeNode::le(U64))
+            }
+            .into()
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn it_overlays_multiple_displays_in_source_order() -> CodamaResult<()> {
+    let ast: syn::Field = syn::parse_quote! {
+        #[codama(display(label = "First", skip = always, flatten))]
+        #[codama(display(label = "Second", flatten = false))]
+        amount: u64
+    };
+    let mut korok = FieldKorok::parse(&ast)?;
+
+    korok.accept(&mut IdentifyFieldTypesVisitor::new())?;
+    korok.accept(&mut ApplyDisplayVisitor::new())?;
+
+    assert_eq!(
+        korok.node,
+        Some(
+            StructFieldTypeNode {
+                display: Some(StructFieldDisplayNode {
+                    label: Some("Second".to_string()),
+                    skip: Some(DisplaySkip::Always),
+                    flatten: Some(false),
+                    flatten_prefix: None,
+                }),
+                ..StructFieldTypeNode::new("amount", NumberTypeNode::le(U64))
+            }
+            .into()
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn it_ignores_struct_field_properties_on_unnamed_fields() -> CodamaResult<()> {
+    let ast: syn::Field = syn::parse_quote! {
+        #[codama(display(label = "Amount"))]
+        u64
+    };
+    let mut korok = FieldKorok::parse(&ast)?;
+
+    korok.accept(&mut IdentifyFieldTypesVisitor::new())?;
+    korok.accept(&mut ApplyDisplayVisitor::new())?;
+
+    assert_eq!(korok.node, Some(NumberTypeNode::le(U64).into()));
+    Ok(())
+}
+
+#[test]
+fn it_fails_on_empty_nodes() -> CodamaResult<()> {
+    let ast: syn::Field = syn::parse_quote! {
+        #[codama(display(label = "Amount"))]
+        Unknown
+    };
+    let mut korok = FieldKorok::parse(&ast)?;
+
+    let error = korok.accept(&mut ApplyDisplayVisitor::new()).unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Cannot apply attribute `#[codama(display)]` on an empty node"
+    );
+    Ok(())
+}
+
+#[test]
+fn it_fails_to_apply_number_displays_on_non_type_nodes() -> CodamaResult<()> {
+    let ast: syn::Field = syn::parse_quote! {
+        #[codama(display(amount))]
+        Invalid
+    };
+    let mut korok = FieldKorok::parse(&ast)?;
+    korok.set_node(Some(StringValueNode::new("value").into()));
+
+    let error = korok.accept(&mut ApplyDisplayVisitor::new()).unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Cannot apply attribute `#[codama(display)]` as a number display on a node of kind `stringValueNode`"
+    );
+    Ok(())
+}

--- a/codama-korok-visitors/tests/lib.rs
+++ b/codama-korok-visitors/tests/lib.rs
@@ -1,3 +1,4 @@
+mod apply_display_visitor;
 mod apply_type_modifiers_visitor;
 mod apply_type_overrides_visitor;
 mod combine_modules_visitor;

--- a/codama-korok-visitors/tests/set_accounts_visitor/from_codama_accounts.rs
+++ b/codama-korok-visitors/tests/set_accounts_visitor/from_codama_accounts.rs
@@ -3,11 +3,11 @@ use codama_korok_visitors::{IdentifyFieldTypesVisitor, KorokVisitable, SetAccoun
 use codama_koroks::{EnumKorok, StructKorok};
 use codama_nodes::{
     AccountNode, BooleanTypeNode, BytesEncoding, ConstantDiscriminatorNode, ConstantPdaSeedNode,
-    ConstantValueNode, DefaultValueStrategy, Docs, FieldDiscriminatorNode,
+    ConstantValueNode, DefaultValueStrategy, DisplaySkip, Docs, FieldDiscriminatorNode,
     NumberFormat::{U32, U64, U8},
     NumberTypeNode, NumberValueNode, OptionTypeNode, PdaLinkNode, PdaNode, ProgramNode,
-    PublicKeyTypeNode, SizeDiscriminatorNode, StringTypeNode, StringValueNode, StructFieldTypeNode,
-    StructTypeNode, VariablePdaSeedNode,
+    PublicKeyTypeNode, SizeDiscriminatorNode, StringTypeNode, StringValueNode,
+    StructFieldDisplayNode, StructFieldTypeNode, StructTypeNode, VariablePdaSeedNode,
 };
 
 #[test]
@@ -48,7 +48,7 @@ fn from_enum() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             StructFieldTypeNode::new("mint_authority", PublicKeyTypeNode::new()),
                             StructFieldTypeNode::new("freeze_authority", OptionTypeNode::new(PublicKeyTypeNode::new())),
@@ -68,7 +68,7 @@ fn from_enum() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(1u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             StructFieldTypeNode::new("mint", PublicKeyTypeNode::new()),
                             StructFieldTypeNode::new("owner", PublicKeyTypeNode::new()),
@@ -115,7 +115,7 @@ fn from_enum_with_empty_variants() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             }
                         ]).into(),
                         pda: None,
@@ -132,7 +132,7 @@ fn from_enum_with_empty_variants() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(1u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             }
                         ]).into(),
                         pda: None,
@@ -177,7 +177,7 @@ fn from_enum_with_custom_enum_size() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U32).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(0u32).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                         ]).into(),
                         pda: None,
@@ -194,7 +194,7 @@ fn from_enum_with_custom_enum_size() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U32).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(1u32).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                         ]).into(),
                         pda: None,
@@ -240,7 +240,7 @@ fn from_enum_with_explicit_discriminators() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             }
                         ]).into(),
                         pda: None,
@@ -257,7 +257,7 @@ fn from_enum_with_explicit_discriminators() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(42u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             }
                         ]).into(),
                         pda: None,
@@ -274,7 +274,7 @@ fn from_enum_with_explicit_discriminators() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(43u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             }
                         ]).into(),
                         pda: None,
@@ -291,7 +291,7 @@ fn from_enum_with_explicit_discriminators() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(100u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             }
                         ]).into(),
                         pda: None,
@@ -367,7 +367,7 @@ fn with_name_directives() -> CodamaResult<()> {
                         docs: Docs::default(),
                         r#type: Box::new(NumberTypeNode::le(U8).into()),
                         default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                        display: None,
+                        display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                     }])
                     .into(),
                     pda: None,
@@ -409,7 +409,7 @@ fn with_discriminator_directives() -> CodamaResult<()> {
                         docs: Docs::default(),
                         r#type: Box::new(NumberTypeNode::le(U8).into()),
                         default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                        display: None,
+                        display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                     }])
                     .into(),
                     pda: None,
@@ -458,7 +458,7 @@ fn with_enum_discriminator_directive() -> CodamaResult<()> {
                         docs: Docs::default(),
                         r#type: Box::new(NumberTypeNode::le(U64).into()),
                         default_value: Box::new(Some(NumberValueNode::new(0u64).into())),
-                        display: None,
+                        display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                     }])
                     .into(),
                     pda: None,
@@ -509,7 +509,7 @@ fn with_seed_directives() -> CodamaResult<()> {
                                     docs: Docs::default(),
                                     r#type: Box::new(NumberTypeNode::le(U8).into()),
                                     default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                                    display: None,
+                                    display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                                 },
                                 StructFieldTypeNode::new("authority", PublicKeyTypeNode::new()),
                             ])
@@ -526,7 +526,7 @@ fn with_seed_directives() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(1u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },])
                         )
                     }
@@ -587,7 +587,7 @@ fn with_pda_directive() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         },])
                     )
                 }],
@@ -632,7 +632,7 @@ fn with_pda_and_seed_directives() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             StructFieldTypeNode::new("authority", PublicKeyTypeNode::new()),
                         ])

--- a/codama-korok-visitors/tests/set_accounts_visitor/skip_directive.rs
+++ b/codama-korok-visitors/tests/set_accounts_visitor/skip_directive.rs
@@ -2,9 +2,10 @@ use codama_errors::CodamaResult;
 use codama_korok_visitors::{IdentifyFieldTypesVisitor, KorokVisitable, SetAccountsVisitor};
 use codama_koroks::EnumKorok;
 use codama_nodes::{
-    AccountNode, DefaultValueStrategy, Docs, FieldDiscriminatorNode,
+    AccountNode, DefaultValueStrategy, DisplaySkip, Docs, FieldDiscriminatorNode,
     NumberFormat::{U64, U8},
-    NumberTypeNode, NumberValueNode, ProgramNode, StructFieldTypeNode, StructTypeNode,
+    NumberTypeNode, NumberValueNode, ProgramNode, StructFieldDisplayNode, StructFieldTypeNode,
+    StructTypeNode,
 };
 
 #[test]
@@ -42,7 +43,7 @@ fn skip_variant_in_enum() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             StructFieldTypeNode::new("supply", NumberTypeNode::le(U64)),
                         ])
@@ -63,7 +64,7 @@ fn skip_variant_in_enum() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(2u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             StructFieldTypeNode::new("amount", NumberTypeNode::le(U64)),
                         ])
@@ -112,7 +113,7 @@ fn skip_variant_with_explicit_discriminator() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }])
                         .into(),
                         pda: None,
@@ -130,7 +131,7 @@ fn skip_variant_with_explicit_discriminator() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(1u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }])
                         .into(),
                         pda: None,
@@ -179,7 +180,7 @@ fn skip_preserves_sibling_discriminator_counting() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }])
                         .into(),
                         pda: None,
@@ -197,7 +198,7 @@ fn skip_preserves_sibling_discriminator_counting() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(2u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }])
                         .into(),
                         pda: None,

--- a/codama-korok-visitors/tests/set_events_visitor/from_codama_events.rs
+++ b/codama-korok-visitors/tests/set_events_visitor/from_codama_events.rs
@@ -2,11 +2,11 @@ use codama_errors::CodamaResult;
 use codama_korok_visitors::{IdentifyFieldTypesVisitor, KorokVisitable, SetEventsVisitor};
 use codama_koroks::{CrateKorok, EnumKorok, StructKorok};
 use codama_nodes::{
-    BooleanTypeNode, DefaultValueStrategy, DefinedTypeLinkNode, Docs, EventNode,
+    BooleanTypeNode, DefaultValueStrategy, DefinedTypeLinkNode, DisplaySkip, Docs, EventNode,
     FieldDiscriminatorNode,
     NumberFormat::{U32, U64, U8},
-    NumberTypeNode, NumberValueNode, ProgramNode, PublicKeyTypeNode, StructFieldTypeNode,
-    StructTypeNode,
+    NumberTypeNode, NumberValueNode, ProgramNode, PublicKeyTypeNode, StructFieldDisplayNode,
+    StructFieldTypeNode, StructTypeNode,
 };
 use codama_stores::CrateStore;
 use quote::quote;
@@ -46,7 +46,7 @@ fn from_enum() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             StructFieldTypeNode::new("authority", PublicKeyTypeNode::new()),
                             StructFieldTypeNode::new("amount", NumberTypeNode::le(U64)),
@@ -66,7 +66,7 @@ fn from_enum() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(1u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             StructFieldTypeNode::new("mint", PublicKeyTypeNode::new()),
                             StructFieldTypeNode::new("amount", NumberTypeNode::le(U64)),
@@ -112,7 +112,7 @@ fn from_enum_with_empty_variants() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }])
                         .into()),
                         discriminators: vec![
@@ -128,7 +128,7 @@ fn from_enum_with_empty_variants() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(1u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }])
                         .into()),
                         discriminators: vec![
@@ -172,7 +172,7 @@ fn from_enum_with_custom_enum_size() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U32).into()),
                             default_value: Box::new(Some(NumberValueNode::new(0u32).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }])
                         .into()),
                         discriminators: vec![
@@ -188,7 +188,7 @@ fn from_enum_with_custom_enum_size() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U32).into()),
                             default_value: Box::new(Some(NumberValueNode::new(1u32).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }])
                         .into()),
                         discriminators: vec![
@@ -233,7 +233,7 @@ fn from_enum_with_explicit_discriminators() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }])
                         .into()),
                         discriminators: vec![
@@ -249,7 +249,7 @@ fn from_enum_with_explicit_discriminators() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(42u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }])
                         .into()),
                         discriminators: vec![
@@ -265,7 +265,7 @@ fn from_enum_with_explicit_discriminators() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(43u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }])
                         .into()),
                         discriminators: vec![
@@ -281,7 +281,7 @@ fn from_enum_with_explicit_discriminators() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(100u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }])
                         .into()),
                         discriminators: vec![
@@ -356,7 +356,7 @@ fn with_name_directives() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }])
                         .into()
                     ),
@@ -406,7 +406,7 @@ fn from_enum_with_tuple_variants() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             StructFieldTypeNode::new(
                                 "arg0",
@@ -461,7 +461,7 @@ fn from_enum_with_mixed_variants() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             StructFieldTypeNode::new("amount", NumberTypeNode::le(U64)),
                         ])
@@ -480,7 +480,7 @@ fn from_enum_with_mixed_variants() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(1u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             StructFieldTypeNode::new("arg0", BooleanTypeNode::default()),
                         ])
@@ -498,7 +498,7 @@ fn from_enum_with_mixed_variants() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(2u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }])
                         .into()),
                         discriminators: vec![

--- a/codama-korok-visitors/tests/set_events_visitor/skip_directive.rs
+++ b/codama-korok-visitors/tests/set_events_visitor/skip_directive.rs
@@ -2,9 +2,10 @@ use codama_errors::CodamaResult;
 use codama_korok_visitors::{IdentifyFieldTypesVisitor, KorokVisitable, SetEventsVisitor};
 use codama_koroks::EnumKorok;
 use codama_nodes::{
-    DefaultValueStrategy, Docs, EventNode, FieldDiscriminatorNode,
+    DefaultValueStrategy, DisplaySkip, Docs, EventNode, FieldDiscriminatorNode,
     NumberFormat::{U64, U8},
-    NumberTypeNode, NumberValueNode, ProgramNode, StructFieldTypeNode, StructTypeNode,
+    NumberTypeNode, NumberValueNode, ProgramNode, StructFieldDisplayNode, StructFieldTypeNode,
+    StructTypeNode,
 };
 
 #[test]
@@ -41,7 +42,7 @@ fn skip_variant_in_enum() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             StructFieldTypeNode::new("amount", NumberTypeNode::le(U64)),
                         ])
@@ -60,7 +61,7 @@ fn skip_variant_in_enum() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(2u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             StructFieldTypeNode::new("amount", NumberTypeNode::le(U64)),
                         ])
@@ -109,7 +110,7 @@ fn skip_preserves_sibling_discriminator_counting() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }])
                         .into()),
                         discriminators: vec![
@@ -125,7 +126,7 @@ fn skip_preserves_sibling_discriminator_counting() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(2u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }])
                         .into()),
                         discriminators: vec![

--- a/codama-korok-visitors/tests/set_instructions_visitor/display_directive.rs
+++ b/codama-korok-visitors/tests/set_instructions_visitor/display_directive.rs
@@ -1,0 +1,176 @@
+use codama_errors::CodamaResult;
+use codama_korok_visitors::{
+    ApplyDisplayVisitor, IdentifyFieldTypesVisitor, KorokVisitable, SetInstructionsVisitor,
+};
+use codama_koroks::{EnumKorok, StructKorok};
+use codama_nodes::{
+    AmountNumberDisplayNode, DisplaySkip, FieldDiscriminatorNode, InstructionArgumentNode,
+    InstructionDisplayNode, InstructionNode, NumberDisplayNode, NumberFormat::U8, NumberTypeNode,
+    NumberValueNode, ProgramNode, StringValueNode, StructFieldDisplayNode,
+};
+
+#[test]
+fn it_applies_displays_to_instruction_structs() -> CodamaResult<()> {
+    let item: syn::Item = syn::parse_quote! {
+        #[derive(CodamaInstruction)]
+        #[codama(display(intent = "Transfer tokens"))]
+        #[codama(display(
+            intent = "Transfer SOL",
+            interpolated_intent = "Transfer ${data.amount} SOL"
+        ))]
+        struct Transfer {
+            #[codama(display(
+                label = "Amount",
+                amount(decimals = 9, unit = "SOL")
+            ))]
+            amount: u64,
+        }
+    };
+    let mut korok = StructKorok::parse(&item)?;
+
+    korok.accept(&mut IdentifyFieldTypesVisitor::new())?;
+    korok.accept(&mut ApplyDisplayVisitor::new())?;
+    korok.accept(&mut SetInstructionsVisitor::new())?;
+
+    assert_eq!(
+        korok.node,
+        Some(
+            InstructionNode {
+                name: "transfer".into(),
+                arguments: vec![InstructionArgumentNode {
+                    display: Some(StructFieldDisplayNode::new("Amount")),
+                    r#type: Box::new(
+                        NumberTypeNode {
+                            display: Box::new(Some(NumberDisplayNode::Amount(
+                                AmountNumberDisplayNode::new(
+                                    NumberValueNode::new(9u64),
+                                    StringValueNode::new("SOL"),
+                                ),
+                            ))),
+                            ..NumberTypeNode::le(codama_nodes::U64)
+                        }
+                        .into()
+                    ),
+                    ..InstructionArgumentNode::new("amount", NumberTypeNode::le(codama_nodes::U64))
+                }],
+                display: Some(InstructionDisplayNode {
+                    intent: Some("Transfer SOL".to_string()),
+                    interpolated_intent: Some("Transfer ${data.amount} SOL".to_string()),
+                }),
+                ..InstructionNode::default()
+            }
+            .into()
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn it_applies_displays_to_instruction_enum_variants() -> CodamaResult<()> {
+    let item: syn::Item = syn::parse_quote! {
+        #[derive(CodamaInstructions)]
+        enum Instructions {
+            #[codama(display(
+                intent = "Withdraw stake",
+                interpolated_intent = "Withdraw ${data.amount}"
+            ))]
+            Withdraw { amount: u64 },
+            Deposit,
+        }
+    };
+    let mut korok = EnumKorok::parse(&item)?;
+
+    korok.accept(&mut IdentifyFieldTypesVisitor::new())?;
+    korok.accept(&mut SetInstructionsVisitor::new())?;
+
+    let skipped = Some(StructFieldDisplayNode::skipped(DisplaySkip::Always));
+    assert_eq!(
+        korok.node,
+        Some(
+            ProgramNode {
+                instructions: vec![
+                    InstructionNode {
+                        name: "withdraw".into(),
+                        arguments: vec![
+                            InstructionArgumentNode {
+                                default_value_strategy: Some(
+                                    codama_nodes::DefaultValueStrategy::Omitted,
+                                ),
+                                default_value: Box::new(Some(NumberValueNode::new(0u64).into())),
+                                display: skipped.clone(),
+                                ..InstructionArgumentNode::new(
+                                    "discriminator",
+                                    NumberTypeNode::le(U8),
+                                )
+                            },
+                            InstructionArgumentNode::new(
+                                "amount",
+                                NumberTypeNode::le(codama_nodes::U64),
+                            ),
+                        ],
+                        discriminators: vec![
+                            FieldDiscriminatorNode::new("discriminator", 0).into(),
+                        ],
+                        display: Some(InstructionDisplayNode {
+                            intent: Some("Withdraw stake".to_string()),
+                            interpolated_intent: Some("Withdraw ${data.amount}".to_string()),
+                        }),
+                        ..InstructionNode::default()
+                    },
+                    InstructionNode {
+                        name: "deposit".into(),
+                        arguments: vec![InstructionArgumentNode {
+                            default_value_strategy: Some(
+                                codama_nodes::DefaultValueStrategy::Omitted,
+                            ),
+                            default_value: Box::new(Some(NumberValueNode::new(1u64).into())),
+                            display: skipped,
+                            ..InstructionArgumentNode::new("discriminator", NumberTypeNode::le(U8),)
+                        }],
+                        discriminators: vec![
+                            FieldDiscriminatorNode::new("discriminator", 0).into(),
+                        ],
+                        ..InstructionNode::default()
+                    },
+                ],
+                ..ProgramNode::default()
+            }
+            .into()
+        )
+    );
+    Ok(())
+}
+
+#[test]
+fn it_preserves_tuple_argument_displays() -> CodamaResult<()> {
+    let item: syn::Item = syn::parse_quote! {
+        #[derive(CodamaInstructions)]
+        enum Instructions {
+            Withdraw(
+                #[codama(name = "amount")]
+                #[codama(display(label = "First", skip = when_injected))]
+                #[codama(display(label = "Amount", flatten))]
+                u64,
+            ),
+        }
+    };
+    let mut korok = EnumKorok::parse(&item)?;
+
+    korok.accept(&mut IdentifyFieldTypesVisitor::new())?;
+    korok.accept(&mut ApplyDisplayVisitor::new())?;
+    korok.accept(&mut SetInstructionsVisitor::new())?;
+
+    let Some(codama_nodes::Node::Program(program)) = korok.node else {
+        panic!("Expected a program node");
+    };
+    assert_eq!(
+        program.instructions[0].arguments[1].display,
+        Some(StructFieldDisplayNode {
+            label: Some("Amount".to_string()),
+            skip: Some(DisplaySkip::WhenInjected),
+            flatten: Some(true),
+            flatten_prefix: None,
+        })
+    );
+    Ok(())
+}

--- a/codama-korok-visitors/tests/set_instructions_visitor/from_codama_instructions.rs
+++ b/codama-korok-visitors/tests/set_instructions_visitor/from_codama_instructions.rs
@@ -3,10 +3,10 @@ use codama_korok_visitors::{IdentifyFieldTypesVisitor, KorokVisitable, SetInstru
 use codama_koroks::{CrateKorok, EnumKorok, StructKorok};
 use codama_nodes::{
     BooleanTypeNode, BytesEncoding, ConstantDiscriminatorNode, ConstantValueNode,
-    DefaultValueStrategy, DefinedTypeLinkNode, Docs, FieldDiscriminatorNode,
+    DefaultValueStrategy, DefinedTypeLinkNode, DisplaySkip, Docs, FieldDiscriminatorNode,
     InstructionAccountNode, InstructionArgumentNode, InstructionNode,
     NumberFormat::{U32, U64, U8},
-    NumberTypeNode, NumberValueNode, ProgramNode, SizeDiscriminatorNode,
+    NumberTypeNode, NumberValueNode, ProgramNode, SizeDiscriminatorNode, StructFieldDisplayNode,
 };
 use codama_stores::CrateStore;
 use quote::quote;
@@ -53,7 +53,7 @@ fn from_enum() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             InstructionArgumentNode::new("amount", NumberTypeNode::le(U64))
                         ],
@@ -70,7 +70,7 @@ fn from_enum() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(1u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             InstructionArgumentNode::new("amount", NumberTypeNode::le(U64))
                         ],
@@ -118,7 +118,7 @@ fn from_enum_with_arguments_only() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             InstructionArgumentNode::new("amount", NumberTypeNode::le(U64))
                         ],
@@ -134,7 +134,7 @@ fn from_enum_with_arguments_only() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(1u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             InstructionArgumentNode::new("amount", NumberTypeNode::le(U64))
                         ],
@@ -190,7 +190,7 @@ fn from_enum_with_accounts_only() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             }
                         ],
                         discriminators: vec![FieldDiscriminatorNode::new("discriminator", 0).into()],
@@ -206,7 +206,7 @@ fn from_enum_with_accounts_only() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(1u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             }
                         ],
                         discriminators: vec![FieldDiscriminatorNode::new("discriminator", 0).into()],
@@ -248,7 +248,7 @@ fn from_enum_with_empty_variants() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             }
                         ],
                         discriminators: vec![FieldDiscriminatorNode::new("discriminator", 0).into()],
@@ -263,7 +263,7 @@ fn from_enum_with_empty_variants() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(1u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             }
                         ],
                         discriminators: vec![FieldDiscriminatorNode::new("discriminator", 0).into()],
@@ -317,7 +317,7 @@ fn from_enum_with_accounts_as_struct_attributes() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             InstructionArgumentNode::new("amount", NumberTypeNode::le(U64))
                         ],
@@ -334,7 +334,7 @@ fn from_enum_with_accounts_as_struct_attributes() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(1u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             InstructionArgumentNode::new("amount", NumberTypeNode::le(U64))
                         ],
@@ -378,7 +378,7 @@ fn from_enum_with_custom_enum_size() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U32).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(0u32).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                         ],
                         discriminators: vec![FieldDiscriminatorNode::new("discriminator", 0).into()],
@@ -393,7 +393,7 @@ fn from_enum_with_custom_enum_size() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U32).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(1u32).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                         ],
                         discriminators: vec![FieldDiscriminatorNode::new("discriminator", 0).into()],
@@ -437,7 +437,7 @@ fn from_enum_with_explicit_discriminators() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             }
                         ],
                         discriminators: vec![FieldDiscriminatorNode::new("discriminator", 0).into()],
@@ -452,7 +452,7 @@ fn from_enum_with_explicit_discriminators() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(42u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             }
                         ],
                         discriminators: vec![FieldDiscriminatorNode::new("discriminator", 0).into()],
@@ -467,7 +467,7 @@ fn from_enum_with_explicit_discriminators() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(43u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             }
                         ],
                         discriminators: vec![FieldDiscriminatorNode::new("discriminator", 0).into()],
@@ -482,7 +482,7 @@ fn from_enum_with_explicit_discriminators() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(100u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             }
                         ],
                         discriminators: vec![FieldDiscriminatorNode::new("discriminator", 0).into()],
@@ -558,7 +558,7 @@ fn with_name_directives() -> CodamaResult<()> {
                         docs: Docs::default(),
                         r#type: Box::new(NumberTypeNode::le(U8).into()),
                         default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                        display: None,
+                        display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                     }],
                     discriminators: vec![FieldDiscriminatorNode::new("discriminator", 0).into()],
                     ..InstructionNode::default()
@@ -597,7 +597,7 @@ fn with_discriminator_directives() -> CodamaResult<()> {
                         docs: Docs::default(),
                         r#type: Box::new(NumberTypeNode::le(U8).into()),
                         default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                        display: None,
+                        display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                     }],
                     discriminators: vec![
                         FieldDiscriminatorNode::new("discriminator", 0).into(),
@@ -643,7 +643,7 @@ fn with_enum_discriminator_directive() -> CodamaResult<()> {
                         docs: Docs::default(),
                         r#type: Box::new(NumberTypeNode::le(U64).into()),
                         default_value: Box::new(Some(NumberValueNode::new(0u64).into())),
-                        display: None,
+                        display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                     }],
                     discriminators: vec![FieldDiscriminatorNode::new("banana", 0).into()],
                     ..InstructionNode::default()
@@ -680,6 +680,7 @@ fn with_argument_attributes_only() -> CodamaResult<()> {
                         InstructionArgumentNode {
                             default_value: Box::new(Some(NumberValueNode::new(0u64).into())),
                             default_value_strategy: Some(DefaultValueStrategy::Omitted),
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             ..InstructionArgumentNode::new("discriminator", NumberTypeNode::le(U8))
                         },
                         InstructionArgumentNode::new("space", NumberTypeNode::le(U64)),
@@ -720,6 +721,7 @@ fn with_prepended_argument_attributes() -> CodamaResult<()> {
                         InstructionArgumentNode {
                             default_value: Box::new(Some(NumberValueNode::new(0u64).into())),
                             default_value_strategy: Some(DefaultValueStrategy::Omitted),
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             ..InstructionArgumentNode::new("discriminator", NumberTypeNode::le(U8))
                         },
                         InstructionArgumentNode::new("space", NumberTypeNode::le(U64)),
@@ -760,6 +762,7 @@ fn with_appended_argument_attributes() -> CodamaResult<()> {
                         InstructionArgumentNode {
                             default_value: Box::new(Some(NumberValueNode::new(0u64).into())),
                             default_value_strategy: Some(DefaultValueStrategy::Omitted),
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             ..InstructionArgumentNode::new("discriminator", NumberTypeNode::le(U8))
                         },
                         InstructionArgumentNode::new("lamports", NumberTypeNode::le(U64)),
@@ -813,7 +816,7 @@ fn from_enum_with_tuple_variants() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         },
                         InstructionArgumentNode::new(
                             "arg0",
@@ -876,7 +879,7 @@ fn from_enum_with_mixed_variants() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             InstructionArgumentNode::new("factor", NumberTypeNode::le(U64)),
                         ],
@@ -892,7 +895,7 @@ fn from_enum_with_mixed_variants() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(1u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             InstructionArgumentNode::new("arg0", DefinedTypeLinkNode::new("direction")),
                         ],
@@ -907,7 +910,7 @@ fn from_enum_with_mixed_variants() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(2u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }],
                         discriminators: vec![FieldDiscriminatorNode::new("discriminator", 0).into()],
                         ..InstructionNode::default()
@@ -963,7 +966,7 @@ fn from_enum_with_tuple_variants_with_custom_names() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         },
                         InstructionArgumentNode::new(
                             "percentage",

--- a/codama-korok-visitors/tests/set_instructions_visitor/mod.rs
+++ b/codama-korok-visitors/tests/set_instructions_visitor/mod.rs
@@ -1,3 +1,4 @@
+mod display_directive;
 mod from_codama_instruction;
 mod from_codama_instructions;
 mod optional_account_strategy_directive;

--- a/codama-korok-visitors/tests/set_instructions_visitor/skip_directive.rs
+++ b/codama-korok-visitors/tests/set_instructions_visitor/skip_directive.rs
@@ -2,9 +2,10 @@ use codama_errors::CodamaResult;
 use codama_korok_visitors::{IdentifyFieldTypesVisitor, KorokVisitable, SetInstructionsVisitor};
 use codama_koroks::EnumKorok;
 use codama_nodes::{
-    DefaultValueStrategy, Docs, FieldDiscriminatorNode, InstructionArgumentNode, InstructionNode,
+    DefaultValueStrategy, DisplaySkip, Docs, FieldDiscriminatorNode, InstructionArgumentNode,
+    InstructionNode,
     NumberFormat::{U64, U8},
-    NumberTypeNode, NumberValueNode, ProgramNode,
+    NumberTypeNode, NumberValueNode, ProgramNode, StructFieldDisplayNode,
 };
 
 #[test]
@@ -40,7 +41,7 @@ fn skip_variant_in_enum() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             InstructionArgumentNode::new("amount", NumberTypeNode::le(U64))
                         ],
@@ -58,7 +59,7 @@ fn skip_variant_in_enum() -> CodamaResult<()> {
                                 docs: Docs::default(),
                                 r#type: Box::new(NumberTypeNode::le(U8).into()),
                                 default_value: Box::new(Some(NumberValueNode::new(2u8).into())),
-                                display: None,
+                                display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                             },
                             InstructionArgumentNode::new("amount", NumberTypeNode::le(U64))
                         ],
@@ -105,7 +106,7 @@ fn skip_variant_with_explicit_discriminator() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }],
                         discriminators: vec![
                             FieldDiscriminatorNode::new("discriminator", 0).into()
@@ -120,7 +121,7 @@ fn skip_variant_with_explicit_discriminator() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(1u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }],
                         discriminators: vec![
                             FieldDiscriminatorNode::new("discriminator", 0).into()
@@ -166,7 +167,7 @@ fn skip_preserves_sibling_discriminator_counting() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(0u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }],
                         discriminators: vec![
                             FieldDiscriminatorNode::new("discriminator", 0).into()
@@ -181,7 +182,7 @@ fn skip_preserves_sibling_discriminator_counting() -> CodamaResult<()> {
                             docs: Docs::default(),
                             r#type: Box::new(NumberTypeNode::le(U8).into()),
                             default_value: Box::new(Some(NumberValueNode::new(2u8).into())),
-                            display: None,
+                            display: Some(StructFieldDisplayNode::skipped(DisplaySkip::Always)),
                         }],
                         discriminators: vec![
                             FieldDiscriminatorNode::new("discriminator", 0).into()

--- a/codama-plugin-core/src/default_plugin.rs
+++ b/codama-plugin-core/src/default_plugin.rs
@@ -1,10 +1,10 @@
 use crate::KorokPlugin;
 use codama_errors::CodamaResult;
 use codama_korok_visitors::{
-    ApplyTypeModifiersVisitor, ApplyTypeOverridesVisitor, CombineModulesVisitor,
-    IdentifyFieldTypesVisitor, KorokVisitable, SetAccountsVisitor, SetDefaultValuesVisitor,
-    SetDefinedTypesVisitor, SetErrorsVisitor, SetEventsVisitor, SetInstructionsVisitor,
-    SetPdasVisitor, SetProgramMetadataVisitor,
+    ApplyDisplayVisitor, ApplyTypeModifiersVisitor, ApplyTypeOverridesVisitor,
+    CombineModulesVisitor, IdentifyFieldTypesVisitor, KorokVisitable, SetAccountsVisitor,
+    SetDefaultValuesVisitor, SetDefinedTypesVisitor, SetErrorsVisitor, SetEventsVisitor,
+    SetInstructionsVisitor, SetPdasVisitor, SetProgramMetadataVisitor,
 };
 
 pub struct DefaultPlugin;
@@ -13,6 +13,7 @@ impl KorokPlugin for DefaultPlugin {
         visitable.accept(&mut IdentifyFieldTypesVisitor::new())?;
         visitable.accept(&mut ApplyTypeOverridesVisitor::new())?;
         visitable.accept(&mut ApplyTypeModifiersVisitor::new())?;
+        visitable.accept(&mut ApplyDisplayVisitor::new())?;
         visitable.accept(&mut SetDefaultValuesVisitor::new())?;
         Ok(())
     }

--- a/codama/tests/system/crate/src/instructions.rs
+++ b/codama/tests/system/crate/src/instructions.rs
@@ -15,9 +15,16 @@ pub enum SystemInstruction {
     #[codama(account(name = "account", signer, writable))]
     Assign { program_address: Pubkey },
 
-    #[codama(account(name = "source", signer, writable))]
-    #[codama(account(name = "destination", writable))]
-    TransferSol { amount: u64 },
+    #[codama(display(
+        intent = "Transfer SOL",
+        interpolated_intent = "Transfer ${data.amount} from ${accounts.source} to ${accounts.destination}"
+    ))]
+    #[codama(account(name = "source", signer, writable, display(label = "From")))]
+    #[codama(account(name = "destination", writable, display(label = "To")))]
+    TransferSol {
+        #[codama(display(label = "Amount", amount(decimals = 9, unit = "SOL")))]
+        amount: u64,
+    },
 
     #[codama(account(name = "payer", signer, writable))]
     #[codama(account(name = "new_account", writable))]

--- a/codama/tests/system/mod.rs
+++ b/codama/tests/system/mod.rs
@@ -101,6 +101,10 @@ fn get_idl() {
             "defaultValue": {
               "kind": "numberValueNode",
               "number": 0
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
             }
           },
           {
@@ -161,6 +165,10 @@ fn get_idl() {
             "defaultValue": {
               "kind": "numberValueNode",
               "number": 1
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
             }
           },
           {
@@ -187,13 +195,21 @@ fn get_idl() {
             "kind": "instructionAccountNode",
             "name": "source",
             "isWritable": true,
-            "isSigner": true
+            "isSigner": true,
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "From"
+            }
           },
           {
             "kind": "instructionAccountNode",
             "name": "destination",
             "isWritable": true,
-            "isSigner": false
+            "isSigner": false,
+            "display": {
+              "kind": "instructionAccountDisplayNode",
+              "label": "To"
+            }
           }
         ],
         "arguments": [
@@ -209,6 +225,10 @@ fn get_idl() {
             "defaultValue": {
               "kind": "numberValueNode",
               "number": 2
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
             }
           },
           {
@@ -217,7 +237,22 @@ fn get_idl() {
             "type": {
               "kind": "numberTypeNode",
               "format": "u64",
-              "endian": "le"
+              "endian": "le",
+              "display": {
+                "kind": "amountNumberDisplayNode",
+                "decimals": {
+                  "kind": "numberValueNode",
+                  "number": 9
+                },
+                "unit": {
+                  "kind": "stringValueNode",
+                  "string": "SOL"
+                }
+              }
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "label": "Amount"
             }
           }
         ],
@@ -227,7 +262,12 @@ fn get_idl() {
             "name": "discriminator",
             "offset": 0
           }
-        ]
+        ],
+        "display": {
+          "kind": "instructionDisplayNode",
+          "intent": "Transfer SOL",
+          "interpolatedIntent": "Transfer ${data.amount} from ${accounts.source} to ${accounts.destination}"
+        }
       },
       {
         "kind": "instructionNode",
@@ -265,6 +305,10 @@ fn get_idl() {
             "defaultValue": {
               "kind": "numberValueNode",
               "number": 3
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
             }
           },
           {
@@ -364,6 +408,10 @@ fn get_idl() {
             "defaultValue": {
               "kind": "numberValueNode",
               "number": 4
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
             }
           }
         ],
@@ -431,6 +479,10 @@ fn get_idl() {
             "defaultValue": {
               "kind": "numberValueNode",
               "number": 5
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
             }
           },
           {
@@ -495,6 +547,10 @@ fn get_idl() {
             "defaultValue": {
               "kind": "numberValueNode",
               "number": 6
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
             }
           },
           {
@@ -543,6 +599,10 @@ fn get_idl() {
             "defaultValue": {
               "kind": "numberValueNode",
               "number": 7
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
             }
           },
           {
@@ -585,6 +645,10 @@ fn get_idl() {
             "defaultValue": {
               "kind": "numberValueNode",
               "number": 8
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
             }
           },
           {
@@ -635,6 +699,10 @@ fn get_idl() {
             "defaultValue": {
               "kind": "numberValueNode",
               "number": 9
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
             }
           },
           {
@@ -715,6 +783,10 @@ fn get_idl() {
             "defaultValue": {
               "kind": "numberValueNode",
               "number": 10
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
             }
           },
           {
@@ -792,6 +864,10 @@ fn get_idl() {
             "defaultValue": {
               "kind": "numberValueNode",
               "number": 11
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
             }
           },
           {
@@ -859,6 +935,10 @@ fn get_idl() {
             "defaultValue": {
               "kind": "numberValueNode",
               "number": 12
+            },
+            "display": {
+              "kind": "structFieldDisplayNode",
+              "skip": "always"
             }
           }
         ],


### PR DESCRIPTION
This PR applies standalone display directives to resolved field and number nodes, extracts instruction displays from instruction structs and enum variants, preserves display metadata on tuple arguments, and hides generated enum discriminators from fallback displays across instructions, accounts, and events. It also adds focused visitor tests and end-to-end system-program coverage.