### PR TITLE
fix: preserve tuple field displays on events

### DIFF
--- a/codama-korok-visitors/src/apply_display_visitor.rs
+++ b/codama-korok-visitors/src/apply_display_visitor.rs
@@ -3,7 +3,7 @@ use codama_attributes::{
     Attribute, CodamaAttribute, CodamaDirective, DisplayDirective, TryFromFilter,
 };
 use codama_errors::CodamaResult;
-use codama_koroks::{KorokMut, KorokTrait};
+use codama_koroks::{FieldKorok, KorokMut, KorokTrait};
 use codama_nodes::{
     HasKind, Node, NumberDisplayNode, RegisteredTypeNode, StructFieldDisplayNode, TypeNode,
 };
@@ -94,7 +94,7 @@ fn apply_display_to_type_node(
     Ok(type_node.into())
 }
 
-pub(crate) fn apply_struct_field_display(
+fn apply_struct_field_display(
     display: &mut Option<StructFieldDisplayNode>,
     directive: &DisplayDirective,
 ) {
@@ -119,6 +119,16 @@ pub(crate) fn apply_struct_field_display(
     if let Some(flatten_prefix) = &directive.flatten_prefix {
         display.flatten_prefix = Some(flatten_prefix.clone());
     }
+}
+
+pub(crate) fn parse_field_display(field: &FieldKorok) -> Option<StructFieldDisplayNode> {
+    // Unnamed fields cannot carry StructFieldDisplayNode metadata during field traversal.
+    // Recover it here when a tuple variant turns those fields into named struct fields.
+    let mut display = None;
+    for directive in field.attributes.get_all(DisplayDirective::filter) {
+        apply_struct_field_display(&mut display, directive);
+    }
+    display
 }
 
 fn apply_optional_number_display(

--- a/codama-korok-visitors/src/set_events_visitor.rs
+++ b/codama-korok-visitors/src/set_events_visitor.rs
@@ -1,4 +1,4 @@
-use crate::{CombineTypesVisitor, KorokVisitor};
+use crate::{parse_field_display, CombineTypesVisitor, KorokVisitor};
 use codama_attributes::{
     DiscriminatorDirective, EnumDiscriminatorDirective, ProgramDirective, TryFromFilter,
 };
@@ -216,8 +216,11 @@ fn parse_enum_variant(
                                     .get(i)
                                     .and_then(|f| f.name())
                                     .unwrap_or_else(|| format!("arg{}", i).into());
-
-                                StructFieldTypeNode::new(name, item)
+                                let display = korok.fields.get(i).and_then(parse_field_display);
+                                StructFieldTypeNode {
+                                    display,
+                                    ..StructFieldTypeNode::new(name, item)
+                                }
                             })
                             .collect();
 

--- a/codama-korok-visitors/src/set_instructions_visitors.rs
+++ b/codama-korok-visitors/src/set_instructions_visitors.rs
@@ -1,4 +1,4 @@
-use crate::{apply_struct_field_display, CombineTypesVisitor, KorokVisitor};
+use crate::{parse_field_display, CombineTypesVisitor, KorokVisitor};
 use codama_attributes::{
     AccountDirective, ArgumentDirective, Attributes, DefaultValueDirective, DiscriminatorDirective,
     DisplayDirective, EnumDiscriminatorDirective, OptionalAccountStrategyDirective,
@@ -10,7 +10,7 @@ use codama_nodes::{
     CamelCaseString, DefaultValueStrategy, EnumVariantTypeNode, FieldDiscriminatorNode,
     InstructionAccountNode, InstructionArgumentNode, InstructionDisplayNode, InstructionNode,
     NestedTypeNode, Node, NumberValueNode, OptionalAccountStrategy, ProgramNode,
-    StructFieldDisplayNode, StructFieldTypeNode, StructTypeNode, TypeNode,
+    StructFieldTypeNode, StructTypeNode, TypeNode,
 };
 use codama_syn_helpers::extensions::{ExprExtension, ToTokensExtension};
 
@@ -376,14 +376,4 @@ fn parse_enum_variant(
         korok.ast.ident
     );
     Err(korok.ast.error(message).into())
-}
-
-fn parse_field_display(field: &FieldKorok) -> Option<StructFieldDisplayNode> {
-    // Unnamed fields cannot carry StructFieldDisplayNode metadata during field traversal.
-    // Recover it here when an instruction tuple variant turns those fields into named arguments.
-    let mut display = None;
-    for directive in field.attributes.get_all(DisplayDirective::filter) {
-        apply_struct_field_display(&mut display, directive);
-    }
-    display
 }

--- a/codama-korok-visitors/tests/set_events_visitor/display_directive.rs
+++ b/codama-korok-visitors/tests/set_events_visitor/display_directive.rs
@@ -1,0 +1,97 @@
+use codama_errors::CodamaResult;
+use codama_korok_visitors::{
+    ApplyDisplayVisitor, IdentifyFieldTypesVisitor, KorokVisitable, SetEventsVisitor,
+};
+use codama_koroks::EnumKorok;
+use codama_nodes::{
+    AmountNumberDisplayNode, DisplaySkip, NumberDisplayNode, NumberFormat::U64, NumberTypeNode,
+    NumberValueNode, StringValueNode, StructFieldDisplayNode, StructFieldTypeNode,
+};
+
+fn event_fields(item: syn::Item) -> CodamaResult<Vec<StructFieldTypeNode>> {
+    let mut korok = EnumKorok::parse(&item)?;
+
+    korok.accept(&mut IdentifyFieldTypesVisitor::new())?;
+    korok.accept(&mut ApplyDisplayVisitor::new())?;
+    korok.accept(&mut SetEventsVisitor::new())?;
+
+    let Some(codama_nodes::Node::Program(program)) = korok.node else {
+        panic!("Expected a program node");
+    };
+    let codama_nodes::TypeNode::Struct(data) = &*program.events[0].data else {
+        panic!("Expected a struct type node");
+    };
+    Ok(data.fields.clone())
+}
+
+#[test]
+fn it_preserves_tuple_field_displays() -> CodamaResult<()> {
+    let fields = event_fields(syn::parse_quote! {
+        #[derive(CodamaEvents)]
+        enum Events {
+            Withdraw(
+                #[codama(name = "amount")]
+                #[codama(display(label = "First", skip = always))]
+                #[codama(display(label = "Amount", flatten, flatten_prefix = "Withdraw "))]
+                u64,
+            ),
+        }
+    })?;
+
+    assert_eq!(
+        fields[1].display,
+        Some(StructFieldDisplayNode {
+            label: Some("Amount".to_string()),
+            skip: Some(DisplaySkip::Always),
+            flatten: Some(true),
+            flatten_prefix: Some("Withdraw ".to_string()),
+        })
+    );
+    Ok(())
+}
+
+#[test]
+fn it_leaves_tuple_fields_without_displays_untouched() -> CodamaResult<()> {
+    let fields = event_fields(syn::parse_quote! {
+        #[derive(CodamaEvents)]
+        enum Events {
+            Withdraw(#[codama(name = "amount")] u64),
+        }
+    })?;
+
+    assert_eq!(fields[1].display, None);
+    Ok(())
+}
+
+#[test]
+fn it_preserves_both_halves_of_a_tuple_field_display() -> CodamaResult<()> {
+    let fields = event_fields(syn::parse_quote! {
+        #[derive(CodamaEvents)]
+        enum Events {
+            Withdraw(
+                #[codama(name = "amount")]
+                #[codama(display(label = "Amount", amount(decimals = 9, unit = "SOL")))]
+                u64,
+            ),
+        }
+    })?;
+
+    assert_eq!(
+        fields[1].display,
+        Some(StructFieldDisplayNode::new("Amount"))
+    );
+    assert_eq!(
+        *fields[1].r#type,
+        NumberTypeNode {
+            display: Box::new(Some(NumberDisplayNode::Amount(
+                AmountNumberDisplayNode::new(
+                    NumberValueNode::new(9u64),
+                    StringValueNode::new("SOL"),
+                ),
+            ))),
+            ..NumberTypeNode::le(U64)
+        }
+        .into()
+    );
+    Ok(())
+}

--- a/codama-korok-visitors/tests/set_events_visitor/mod.rs
+++ b/codama-korok-visitors/tests/set_events_visitor/mod.rs
@@ -1,3 +1,4 @@
+mod display_directive;
 mod from_codama_event;
 mod from_codama_events;
 mod program_directive;


### PR DESCRIPTION
Named-field event variants keep their `display`. Tuple variants drop it.

```rust
#[derive(CodamaEvents)]
enum Events {
    Withdraw(
        #[codama(name = "amount")]
        #[codama(display(label = "Amount", amount(decimals = 9, unit = "SOL")))]
        u64,
    ),
}
```

`label` is lost. The amount display survives, because it rides on the
`NumberTypeNode` rather than the struct field, so only half the attribute goes
missing. That is why it wasn't obvious.

#128 added `parse_field_display` to the instructions visitor for exactly this.
The events tuple branch still built a bare `StructFieldTypeNode::new`. This
calls it there too.

The helper moves next to the `apply_struct_field_display` it delegates to, so
both visitors share it instead of duplicating it. Happy to leave it where it
was as `pub(crate)` if you would rather keep this out of that file.

Tests in `tests/set_events_visitor/display_directive.rs`, mirroring
`it_preserves_tuple_argument_displays`.
